### PR TITLE
Auto login on every ws/rpc connection using HTTP Authorization header if present

### DIFF
--- a/libraries/app/include/graphene/app/api.hpp
+++ b/libraries/app/include/graphene/app/api.hpp
@@ -286,9 +286,9 @@ namespace graphene { namespace app {
          /// @brief Retrieve the debug API (if available)
          fc::api<graphene::debug_witness::debug_api> debug()const;
 
-      private:
          /// @brief Called to enable an API, not reflected.
          void enable_api( const string& api_name );
+      private:
 
          application& _app;
          optional< fc::api<database_api> > _database_api;


### PR DESCRIPTION
This PR will allow to: 

**Use the name of the APIs when calling.**

`curl --data '{"jsonrpc": "2.0", "params": ["history", "get_account_history", ["1.2.31489", "1.11.0", 10, "1.11.0"]], "method": "call", "id": 10}' http://testgraphene:8090/rpc`

**Specify the credentials using standard HTTP Headers** (if the API is restricted)

`curl -u bytemaster:supersecret --data '{"jsonrpc": "2.0", "params": ["history", "get_account_history", ["1.2.31489", "1.11.0", 10, "1.11.0"]], "method": "call", "id": 10}' http://testgraphene:8090/rpc`

**Prevent unnecessary round trips (login, query API number, call function) when using WS**
`wscat -c ws://bytemaster:supersecret@testgraphene:8090`  

Needs the following FC library PRs to work

**Add access to HTTP request headers in websocket_connection**
https://github.com/bitshares/bitshares-fc/pull/1

**Replace the call to get_api_by_name**
https://github.com/bitshares/bitshares-fc/pull/2

It also preserve:
 * Same default api access permissions 
 * Possibility to use numbers to specify the API
 * Default API numbers (database = 0, login = 1)
 * Old ws mechanics => connect / login / query api number / call  
 