### PR TITLE
Add new API (block_api)

### DIFF
--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -79,6 +79,10 @@ namespace graphene { namespace app {
        {
           _database_api = std::make_shared< database_api >( std::ref( *_app.chain_database() ) );
        }
+       else if( api_name == "block_api" )
+       {
+          _block_api = std::make_shared< block_api >( std::ref( *_app.chain_database() ) );
+       }
        else if( api_name == "network_broadcast_api" )
        {
           _network_broadcast_api = std::make_shared< network_broadcast_api >( std::ref( _app ) );
@@ -102,6 +106,20 @@ namespace graphene { namespace app {
              _debug_api = std::make_shared< graphene::debug_witness::debug_api >( std::ref(_app) );
        }
        return;
+    }
+
+    // block_api
+    block_api::block_api(graphene::chain::database& db) : _db(db) { }
+    block_api::~block_api() { }
+
+    vector<optional<signed_block>> block_api::get_blocks(uint32_t block_num_from, uint32_t block_num_to)const
+    {
+       FC_ASSERT( block_num_to >= block_num_from );
+       vector<optional<signed_block>> res;
+       for(uint32_t block_num=block_num_from; block_num<=block_num_to; block_num++) {
+          res.push_back(_db.fetch_block_by_number(block_num));
+       }
+       return res;
     }
 
     network_broadcast_api::network_broadcast_api(application& a):_app(a)
@@ -191,6 +209,12 @@ namespace graphene { namespace app {
     {
        FC_ASSERT(_network_broadcast_api);
        return *_network_broadcast_api;
+    }
+
+    fc::api<block_api> login_api::block()const
+    {
+       FC_ASSERT(_block_api);
+       return *_block_api;
     }
 
     fc::api<network_node_api> login_api::network_node()const

--- a/libraries/app/include/graphene/app/api.hpp
+++ b/libraries/app/include/graphene/app/api.hpp
@@ -119,6 +119,22 @@ namespace graphene { namespace app {
    };
 
    /**
+    * @brief Block api
+    */
+   class block_api
+   {
+   public:
+      block_api(graphene::chain::database& db);
+      ~block_api();
+
+      vector<optional<signed_block>> get_blocks(uint32_t block_num_from, uint32_t block_num_to)const;
+
+   private:
+      graphene::chain::database& _db;
+   };
+
+
+   /**
     * @brief The network_broadcast_api class allows broadcasting of transactions.
     */
    class network_broadcast_api : public std::enable_shared_from_this<network_broadcast_api>
@@ -273,6 +289,8 @@ namespace graphene { namespace app {
           * has sucessfully authenticated.
           */
          bool login(const string& user, const string& password);
+         /// @brief Retrieve the network block API
+         fc::api<block_api> block()const;
          /// @brief Retrieve the network broadcast API
          fc::api<network_broadcast_api> network_broadcast()const;
          /// @brief Retrieve the database API
@@ -291,6 +309,7 @@ namespace graphene { namespace app {
          void enable_api( const string& api_name );
 
          application& _app;
+         optional< fc::api<block_api> > _block_api;
          optional< fc::api<database_api> > _database_api;
          optional< fc::api<network_broadcast_api> > _network_broadcast_api;
          optional< fc::api<network_node_api> > _network_node_api;
@@ -316,6 +335,9 @@ FC_API(graphene::app::history_api,
        (get_fill_order_history)
        (get_market_history)
        (get_market_history_buckets)
+     )
+FC_API(graphene::app::block_api,
+       (get_blocks)
      )
 FC_API(graphene::app::network_broadcast_api,
        (broadcast_transaction)
@@ -343,6 +365,7 @@ FC_API(graphene::app::crypto_api,
      )
 FC_API(graphene::app::login_api,
        (login)
+       (block)
        (network_broadcast)
        (database)
        (history)


### PR DESCRIPTION
Add new API (block_api) to retrive blocks in bulk.

This is useful when synchronizing with an external DB to speed up the process instead of multiple calling database::get_block 