### PR TITLE
added list of assets created by account to get_full_accounts api function

### DIFF
--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -600,6 +600,15 @@ std::map<std::string, full_account> database_api_impl::get_full_accounts( const 
                     [&acnt] (const call_order_object& call) {
                        acnt.call_orders.emplace_back(call);
                     });
+					
+      // get assets issued by user
+      auto asset_range = _db.get_index_type<asset_index>().indices().get<by_issuer>().equal_range(account->id);
+      std::for_each(asset_range.first, asset_range.second,
+                    [&acnt] (const asset_object& asset) {
+                       acnt.assets.emplace_back(asset.id);
+                    });
+	  
+	  
       results[account_name_or_id] = acnt;
    }
    return results;

--- a/libraries/app/include/graphene/app/full_account.hpp
+++ b/libraries/app/include/graphene/app/full_account.hpp
@@ -44,6 +44,7 @@ namespace graphene { namespace app {
       vector<limit_order_object>       limit_orders;
       vector<call_order_object>        call_orders;
       vector<proposal_object>          proposals;
+      vector<asset_id_type>            assets;   
    };
 
 } }
@@ -61,4 +62,5 @@ FC_REFLECT( graphene::app::full_account,
             (limit_orders)
             (call_orders)
             (proposals) 
+            (assets)
           )

--- a/libraries/chain/include/graphene/chain/asset_object.hpp
+++ b/libraries/chain/include/graphene/chain/asset_object.hpp
@@ -232,11 +232,13 @@ namespace graphene { namespace chain {
 
    struct by_symbol;
    struct by_type;
+   struct by_issuer;
    typedef multi_index_container<
       asset_object,
       indexed_by<
          ordered_unique< tag<by_id>, member< object, object_id_type, &object::id > >,
          ordered_unique< tag<by_symbol>, member<asset_object, string, &asset_object::symbol> >,
+         ordered_non_unique< tag<by_issuer>, member<asset_object, account_id_type, &asset_object::issuer > >,
          ordered_unique< tag<by_type>,
             composite_key< asset_object,
                 const_mem_fun<asset_object, bool, &asset_object::is_market_issued>,


### PR DESCRIPTION
sample output:

note assets output, shows created assets by account 1.2.0.
![image](https://cloud.githubusercontent.com/assets/21685097/22569077/f6486024-e974-11e6-9d06-c67dd5391188.png)

an account that has not created any asset:
![image](https://cloud.githubusercontent.com/assets/21685097/22569144/27833b8c-e975-11e6-966e-f6c1a59219c4.png)

