### PR TITLE
Proposed fix for Issue #196: create_account_with_brain_key doesn't save owner key

### DIFF
--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -212,6 +212,15 @@ class database_api
 
       vector<vector<account_id_type>> get_key_references( vector<public_key_type> key )const;
 
+     /**
+      * Determine whether a textual representation of a public key
+      * (in Base-58 format) is *currently* linked
+      * to any *registered* (i.e. non-stealth) account on the blockchain
+      * @param public_key Public key
+      * @return Whether a public key is known
+      */
+     bool is_public_key_registered(string public_key) const;
+
       //////////////
       // Accounts //
       //////////////
@@ -592,6 +601,7 @@ FC_API(graphene::app::database_api,
 
    // Keys
    (get_key_references)
+   (is_public_key_registered)
 
    // Accounts
    (get_accounts)

--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -256,6 +256,26 @@ namespace detail {
 class wallet_api_impl;
 }
 
+/***
+ * A utility class for performing various state-less actions that are related to wallets
+ */
+class utility {
+   public:
+      /**
+       * Derive any number of *possible* owner keys from a given brain key.
+       *
+       * NOTE: These keys may or may not match with the owner keys of any account.
+       * This function is merely intended to assist with account or key recovery.
+       *
+       * @see suggest_brain_key()
+       *
+       * @param brain_key    Brain key
+       * @param number_of_desired_keys  Number of desired keys
+       * @return A list of keys that are deterministically derived from the brainkey
+       */
+      static vector<brain_key_info> derive_owner_keys_from_brain_key(string brain_key, int number_of_desired_keys = 1);
+};
+
 struct operation_detail {
    string                   memo;
    string                   description;
@@ -575,6 +595,29 @@ class wallet_api
        * @returns a suggested brain_key
        */
       brain_key_info suggest_brain_key()const;
+
+     /**
+      * Derive any number of *possible* owner keys from a given brain key.
+      *
+      * NOTE: These keys may or may not match with the owner keys of any account.
+      * This function is merely intended to assist with account or key recovery.
+      *
+      * @see suggest_brain_key()
+      *
+      * @param brain_key    Brain key
+      * @param numberOfDesiredKeys  Number of desired keys
+      * @return A list of keys that are deterministically derived from the brainkey
+      */
+     vector<brain_key_info> derive_owner_keys_from_brain_key(string brain_key, int number_of_desired_keys = 1) const;
+
+     /**
+      * Determine whether a textual representation of a public key
+      * (in Base-58 format) is *currently* linked
+      * to any *registered* (i.e. non-stealth) account on the blockchain
+      * @param public_key Public key
+      * @return Whether a public key is known
+      */
+     bool is_public_key_registered(string public_key) const;
 
       /** Converts a signed_transaction in JSON form to its binary representation.
        *
@@ -1565,6 +1608,7 @@ FC_API( graphene::wallet::wallet_api,
         (import_account_keys)
         (import_balance)
         (suggest_brain_key)
+        (derive_owner_keys_from_brain_key)
         (register_account)
         (upgrade_account)
         (create_account_with_brain_key)
@@ -1609,6 +1653,7 @@ FC_API( graphene::wallet::wallet_api,
         (get_block)
         (get_account_count)
         (get_account_history)
+        (is_public_key_registered)
         (get_market_history)
         (get_global_properties)
         (get_dynamic_global_properties)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 file(GLOB UNIT_TESTS "tests/*.cpp")
 add_executable( chain_test ${UNIT_TESTS} ${COMMON_SOURCES} )
-target_link_libraries( chain_test graphene_chain graphene_app graphene_account_history graphene_egenesis_none fc ${PLATFORM_SPECIFIC_LIBS} )
+target_link_libraries( chain_test graphene_chain graphene_app graphene_account_history graphene_egenesis_none fc graphene_wallet ${PLATFORM_SPECIFIC_LIBS} )
 if(MSVC)
   set_source_files_properties( tests/serialization_tests.cpp PROPERTIES COMPILE_FLAGS "/bigobj" )
 endif(MSVC)

--- a/tests/tests/database_api_tests.cpp
+++ b/tests/tests/database_api_tests.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2017 Cryptonomex, Inc., and contributors.
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <boost/test/unit_test.hpp>
+
+#include <graphene/app/database_api.hpp>
+
+#include "../common/database_fixture.hpp"
+
+using namespace graphene::chain;
+using namespace graphene::chain::test;
+
+BOOST_FIXTURE_TEST_SUITE(database_api_tests, database_fixture)
+
+  BOOST_AUTO_TEST_CASE(is_registered) {
+      try {
+          /***
+           * Arrange
+           */
+          auto nathan_private_key = generate_private_key("nathan");
+          public_key_type nathan_public = nathan_private_key.get_public_key();
+
+          auto dan_private_key = generate_private_key("dan");
+          public_key_type dan_public = dan_private_key.get_public_key();
+
+          auto unregistered_private_key = generate_private_key("unregistered");
+          public_key_type unregistered_public = unregistered_private_key.get_public_key();
+
+
+          /***
+           * Act
+           */
+          create_account("dan", dan_private_key.get_public_key()).id;
+          create_account("nathan", nathan_private_key.get_public_key()).id;
+          // Unregistered key will not be registered with any account
+
+
+          /***
+           * Assert
+           */
+          graphene::app::database_api db_api(db);
+
+          BOOST_CHECK(db_api.is_public_key_registered((string) nathan_public));
+          BOOST_CHECK(db_api.is_public_key_registered((string) dan_public));
+          BOOST_CHECK(!db_api.is_public_key_registered((string) unregistered_public));
+
+      } FC_LOG_AND_RETHROW()
+  }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/tests/wallet_tests.cpp
+++ b/tests/tests/wallet_tests.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2017 Cryptonomex, Inc., and contributors.
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <boost/test/unit_test.hpp>
+
+#include <graphene/app/database_api.hpp>
+#include <graphene/wallet/wallet.hpp>
+
+#include <iostream>
+
+#include "../common/database_fixture.hpp"
+
+using namespace graphene::chain;
+using namespace graphene::chain::test;
+using namespace graphene::wallet;
+
+BOOST_FIXTURE_TEST_SUITE(wallet_tests, database_fixture)
+
+  /***
+   * Check the basic behavior of deriving potential owner keys from a brain key
+   */
+  BOOST_AUTO_TEST_CASE(derive_owner_keys_from_brain_key) {
+      try {
+          /***
+           * Act
+           */
+          int nbr_keys_desired = 3;
+          vector<brain_key_info> derived_keys = graphene::wallet::utility::derive_owner_keys_from_brain_key("SOME WORDS GO HERE", nbr_keys_desired);
+
+
+          /***
+           * Assert: Check the number of derived keys
+           */
+          BOOST_CHECK_EQUAL(nbr_keys_desired, derived_keys.size());
+
+          /***
+           * Assert: Check that each derived key is unique
+           */
+          set<string> set_derived_public_keys;
+          for (auto info : derived_keys) {
+              string description = (string) info.pub_key;
+              set_derived_public_keys.emplace(description);
+          }
+          BOOST_CHECK_EQUAL(nbr_keys_desired, set_derived_public_keys.size());
+
+          /***
+           * Assert: Check whether every public key begins with the expected prefix
+           */
+          string expected_prefix = GRAPHENE_ADDRESS_PREFIX;
+          for (auto info : derived_keys) {
+              string description = (string) info.pub_key;
+              BOOST_CHECK_EQUAL(0, description.find(expected_prefix));
+          }
+
+      } FC_LOG_AND_RETHROW()
+  }
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Behavior

This proposed fix addresses Issue #196 

> Issue #196 : create_account_with_brain_key doesn't save owner key
> 
> After creating an account with create_account_with_brain_key, owner key of new account hasn't been listed in the result of dump_private_keys command."


# Confirmation of Behavior

This observation is correct in that dump_private_keys is not listing the owner key of the new account.  There is no bug in dump_private_keys.  Rather, the owner key is not saved in the wallet as a result of create_account_with_brain_key.  This appears to be intentional because of a comment in the code in # create_account_with_private_key() that says "we do not insert owner_privkey here because it is intended to only be used for key recovery".  The owner key is temporarily created in order to create the active and memo keys (which are persisted to the wallet), but the owner key is then discarded.


# Proposed Resolution

Therefore, if this default behavior is to be maintained as being reasonable, and since there is a desire and sometimes a need to have the owner key, then the solution proposed here involves the creation of a function called derive_owner_keys_from_brain_key() which generates any number of deterministically determined keys from the brain key any one of which might be the current owner key for a particular account.

The derived owner keys may or may not be the owner key/authority for a particular account.  For example, the owner key might have originally been the first derived owner key but was later changed to, perhaps, the second derived key, or perhaps to some other key that is not derivable from the brain key.

Furthermore, to assist with determining whether a key is *currently* associated with any registered account, a supplementary function has also been proposed that is called is_public_key_registered().  This is intended to be used merely as a quick check to see whether a public key is currently "registered".

# Use Cases
## Use Case A
A CLI user is attempting to "load" an owner key into his wallet and still has the brain key.  The user might proceed as follows.

A.1. Run get_account() in order to view the current owner_key for an account
`get_account account-name-here`

A.2. Run derive_owner_keys_from_brain_key() with an brain key and the number of owner keys that can be derived from it
`derive_owner_keys_from_brain_key "brain key here" 5`

The output will include five key-WIF tuples.

A.3. If one of the public keys matches the owner key from Step A.1, then the user can import this key with the import_key() function and use the WIF for the key that matches.

`import_key "account-name-here" WIF...GOES...HERE`


## Use Case B

A user or some code needs to determine whether a particular key is currently associated with any account.  This can be necessary when, for example, creating a new account or (a proposed feature) claiming an existing account or (a proposed feature) creating an key based on something other than a standard brain key. (Caution: this approach could also be used to brute force hack into an existing account.)  In that situation,

B.1 Some logic or code is used create a potential new key (possibly with a new key generation mechanism), and a check must be made to ensure that it is not currently associated with any registered account (to avoid obvious clashes and unintentionally sharing keys).

B.2 A check can be made to see whether the key is currently associated with a registered account on the blockchain by running the is_public_key_registered() function

`is_public_key_registered CORE...PUBLIC_KEY_HERE`

which will return true or false.


# Applicability of Proposed Resolution to Other Issues

This functionality will also be helpful for addressing various other issues such as:

(a) Issue #197 : Account_update_operation requires both owner authorities and active authorities when owner presents

> When specified owner in account_update_operation, witness_node asks for both owner authorities and active authorities for signing the transaction. Worse case is when active authorities contain multiple keys but not all keys are in the wallet, even if the transaction is signed with owner key, sometimes it will still be rejected by witness_node. IMO active authorities is not needed in this case.
> 
> We need a clear specification about owner/active authorities, not just concepts like https://bitshares.org/technology/dynamic-account-permissions/.
> @abitmore 

(b) One function that is currently within the CLI wallet call (e.g. create_account_with_brain_key()) calls for checking the blockchain for publickeys that might already exist (see "scan blockchain for accounts that exist with same brain key").  This new functionality would enable the existing code to make use of this proposed code for that check.  (See "Use Case B" above.)

(c) Useful for a new feature to "claim an account with a given brain key" such that an account could be rebuilt in the CLI with solely a brain key (and assuming that the account's current keys can all be derived from the brain key).