### PR TITLE
Fix the get_ticker crash

### DIFF
--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -1112,6 +1112,7 @@ market_ticker database_api_impl::get_ticker( const string& base, const string& q
       if ( trades.size() )
       {
          result.latest = trades[0].price;
+         result.percent_change = trades.size() > 0 ? ((result.latest / trades.back().price) - 1) * 100 : 0;
 
          for ( market_trade t: trades )
          {
@@ -1119,6 +1120,7 @@ market_ticker database_api_impl::get_ticker( const string& base, const string& q
             result.quote_volume += t.amount;
          }
 
+         /* TODO: fix get_trade_history to pull trades beyond 100 */
          while (trades.size() == 100)
          {
             trades = get_trade_history( base, quote, trades[99].date, fc::time_point_sec( now.sec_since_epoch() - day ), 100 );
@@ -1129,9 +1131,12 @@ market_ticker database_api_impl::get_ticker( const string& base, const string& q
                result.quote_volume += t.amount;
             }
          }
-
-         trades = get_trade_history( base, quote, trades.back().date, fc::time_point_sec(), 1 );
-         result.percent_change = trades.size() > 0 ? ( ( result.latest / trades.back().price ) - 1 ) * 100 : 0;
+          /*
+         if (!trades.empty()) {
+            trades = get_trade_history(base, quote, trades.back().date, fc::time_point_sec(), 1);
+            result.percent_change = trades.size() > 0 ? ((result.latest / trades.back().price) - 1) * 100 : 0;
+         }
+           */
       }
 
       auto orders = get_order_book( base, quote, 1 );
@@ -1178,7 +1183,7 @@ market_volume database_api_impl::get_24_volume( const string& base, const string
          result.base_volume += t.value;
          result.quote_volume += t.amount;
       }
-
+      /* TODO: fix get_trade_history to pull trades beyond 100 */
       while (trades.size() == 100)
       {
          trades = get_trade_history( base, quote, trades[99].date, fc::time_point_sec( now.sec_since_epoch() - bucket_size ), 100 );


### PR DESCRIPTION
The `get_ticker` api call was crashing the witness node.

The problem was not happening each time the function was called with different assets but the issue was present with the most active pairs like  BTS/CNY.

Client calling get_ticker:

```
curl --data '{"jsonrpc": "2.0", "params": ["database", "get_ticker", ["BTS", "CNY"]], "method": "call",
 "id": 10}' http://23.94.69.140:8090/rpc
```
Node:

```
47113ms th_a       database_api.cpp:571          get_full_accounts    ] subscribe to committee-account
Segmentation fault
```

The `get_ticker` depends fully on a call to `get_trade_history`. This function returns all the trades made for an asset in a date period and a limit of 100 results.

The `get_ticker` start by calling `get_trade_history` to get the trades made between the moment of the call(now) and now - 24 hours. 
get_ticker loops throw the results while it sum the volumes. The function `get_24_volume` use the same logic.

In a pair where there is no more than 100 trades the function just ends there and there is no crash.

In an active pair where more than 100 trades are made in the last 24 hours then the get_ticker(and also `get_24_volume`) makes a new call reducing the date range by using the last date of the first call as starting date and the now - 24 hours at the end. This should return a second block of 100(or less) trades.

The problem here is that function `get_trade_history` returns an empty set when called to get results that are beyond the last 100, here is pretty much what the get_ticker function will do at a given time.

1. get the trades between now and now - 24 hs:

```
> {"method": "call", "params": ["database", "get_trade_history", ["BTS", "CNY", "2017-03-23T20:29:15", "2017-03-22T20:29:15", 100]], "id": 7}
< {"id":7,"result":[{"date":"2017-03-23T20:19:33","price":"24.82976952351088329","amount":"14.03180000000000049","value":"348.40636000000000649"},{"date":"2017-0
3-23T20:18:39","price":"24.82976969204791473","amount":"20.19470000000000098","value":"501.42975000000001273"},{"date":"2017-03-23T20:18:39","price":"24.85825177
...
...
9999999999725","value":"1093.83166000000005624"},{"date":"2017-03-23T12:08:42","price":"24.57224441488762068","amount":"44.35900000000000176","value":"1090.00018
999999997504"},{"date":"2017-03-23T12:08:42","price":"24.57223813337315121","amount":"44.20380000000000109","value":"1086.18630000000007385"},{"date":"2017-03-23
T12:08:39","price":"24.57225609536110511","amount":"27.71780000000000044","value":"681.08888000000001739"}]}
```

2- get the last date, in this case: 2017-03-23T12:08:39

3- use the date to make an additional call to get_trade_history:

```
> {"method": "call", "params": ["database", "get_trade_history", ["BTS", "CNY", "2017-03-23T12:08:39", "2017-03-22T20:29:15", 100]], "id": 7}
< {"id":7,"result":[]}
> 
```

As can be seen, this returns an empty result, actually if a client want to get trades from an old date is not possible:

```
> {"method": "call", "params": ["database", "get_trade_history", ["BTS", "CNY", "2016-01-20T12:08:39", "2016-01-19T20:29:15", 100]], "id": 7}
< {"id":7,"result":[]}
> 
```

The crash is happening when the code tries to get the older trade to later make the calculation of the % change, this is the exact line that causes the crash:

`trades = get_trade_history(base, quote, trades.back().date, fc::time_point_sec(), 1);`

more specifically, the trades.back(). According to c++ documentation the back() function when called on an empty vector causes "undefined behavior", in bitshares case, a Segfault.

This pull request eliminate segfault by moving the percent_change to the top, as the second and further blocks of 100 trades are not retieved we can calculate everything just with the last 100 trades.

This is a temporal fix as i was not able yet to fully understand the market_history plugin, used by get_trade_history. Any help here will be appreciated.

Please note this is not the expected output, the expected output is tomake the ticker with all the trades made in the last 24 hours and not only with the last 100.

The logic of get_ticker is correct and should be reversed back after we can fix get_trade_history where the real problem is. the only modification that should be done to get_ticker is a safety check for the vector to be non empty before using back() over it. This is commented in the code at line 1134 to place back.

in regards to the ticker results, there are 2 fields that i think we could change:

lowest_ask
highest_bid

this can be just 24 hours high and 24 hours low or if we want to keep the ask and bid names it should be lowest_bid and  highest_ask i think.

any comment will be very appreciated, next job is to fix the market_history plugin to retrieve more than 100 results on its get_trade_history function.
