### PR TITLE
market_history plugin fix

### DIFF
--- a/libraries/plugins/market_history/market_history_plugin.cpp
+++ b/libraries/plugins/market_history/market_history_plugin.cpp
@@ -110,7 +110,7 @@ struct operation_process_fill_order
 
       hkey.sequence += 200;
       itr = history_idx.lower_bound( hkey );
-
+      /*
       while( itr != history_idx.end() )
       {
          if( itr->key.base == hkey.base && itr->key.quote == hkey.quote )
@@ -120,6 +120,7 @@ struct operation_process_fill_order
          }
          else break;
       }
+      */
 
 
       auto max_history = _plugin.max_history();


### PR DESCRIPTION
fix get_trade_history and calls that use it(get_ticker, get_24_volume).

my research into this plugin started after a segfault caused in the get_ticker function fixed in this commit by @vikramrajkumar https://github.com/bitshares/bitshares-core/commit/12be59db79e3bf714757dd0a1eadb2d9b9e9c7b9.

discussed in other places like: https://github.com/bitshares/bitshares-core/pull/250

the segfault issue was fixed but the problem persisted in the get_trade_history function.

the problem itself is described in this comment with samples:

https://github.com/bitshares/bitshares-core/pull/250#issuecomment-289172622 

the get_trade_history was unable to get trades over an old period of time, can't get actually more than 100 trades in history for any asset pair.

this is wrong and should be fixed as the idea of the get_trade_history is to get trades of any period of time. The 100 limitation is fine in the public functions but the index itself should have all the history not only the last 100 trades made.

this had direct implications in the get_ticker function, as more than 100 trades were done in the last 24 hours of any asset the function was not able to get data beyond that limit as the index was empty.

the cause of the empty index was in the market_history_plugin.cpp code, hardcoded(not sure why, if someone can have an idea please share) to delete any trades older than 200(hardcoded 200 because orders get tracked twice in the index, for both sides of the trade).

This pull request removes that limitation from the market_history_plugin and allow the public functions to work propertly, here are a few examples on what can be done now:

get trades from a past period of time, not possible before:

```
root@alfredo:~# curl --data '{"jsonrpc": "2.0", "params": ["database", "get_trade_history", ["BTS", "CNY", "2017-03-23T20:29:15", "2017-03-22T20:29:15", 1]], "metho
d": "call", "id": 10}' http://23.94.69.140:8090/rpc | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   302  100   146  100   156  30925  33043 --:--:-- --:--:-- --:--:-- 39000
{
  "id": 10,
  "result": [
    {
      "date": "2017-03-23T20:19:33",
      "price": "24.82976952351088329",
      "amount": "14.03180000000000049",
      "value": "348.40636000000000649"
    }
  ]
}
root@alfredo:~# 
```
the get ticker function is now also fully working:

```
root@alfredo:~# curl --data '{"jsonrpc": "2.0", "params": ["database", "get_ticker", ["BTS", "CNY"]], "method": "call", "id": 10}' http://23.94.69.140:8090/rpc |
 jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   375  100   275  100   100   215k  80192 --:--:-- --:--:-- --:--:--  268k
{
  "id": 10,
  "result": {
    "base": "BTS",
    "quote": "CNY",
    "latest": "17.21717441705435547",
    "lowest_ask": "17.25327889739532949",
    "highest_bid": "17.19076369562665363",
    "percent_change": "2.51794071792583729",
    "base_volume": "1817366.53631001571193337",
    "quote_volume": "105595.43159999996714760"
  }
}
root@alfredo:~# 
```
One thing i will like @svk31 to check is that at the same time i am getting 2.51 % change i see a different number in openledger:

![svk](https://cloud.githubusercontent.com/assets/21685097/24821660/47c75d96-1bc6-11e7-96fb-5c436eff59b0.png)

please check if possible, thx.

hope this helps to make better trading applications, i think it will :)