### PR TITLE
adding update_all_auth to cli wallet

### DIFF
--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -1518,6 +1518,24 @@ class wallet_api
       fc::signal<void(bool)> lock_changed;
       std::shared_ptr<detail::wallet_api_impl> my;
       void encrypt_keys();
+
+
+      /** Update account authorities
+       *
+       * @param account_name The account to be updated.
+       * @param auth_owner_accounts Array of owner accounts and weights to be added or deleted(if weight = 0 then delete account from owner auth).
+       * @param auth_owner_keys Array of owner keys and weights to be added or deleted(if weight = 0 then delete key from owner auth).
+       * @param auth_active_accounts Array of active accounts and weights to be added or deleted(if weight = 0 then delete account from active auth).
+       * @param auth_active_keys Array of active keys and weights to be added or deleted(if weight = 0 then delete key from active auth).
+       * @param owner_threshold Owner threshold number.
+       * @param active_threshold Active threshold number.
+       * @param broadcast true if you wish to broadcast the transaction
+       * @return the signed version of the transaction
+       */
+      signed_transaction update_all_auth( string account_name, map<string, weight_type> auth_owner_accounts, map<public_key_type, weight_type> auth_owner_keys, map<string, weight_type> auth_active_accounts, map<public_key_type, weight_type> auth_active_keys, uint32_t owner_threshold, uint32_t active_threshold, bool broadcast );
+
+
+
 };
 
 } }
@@ -1691,4 +1709,5 @@ FC_API( graphene::wallet::wallet_api,
         (blind_history)
         (receive_blind_transfer)
         (get_order_book)
+        (update_all_auth)
       )

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -4324,6 +4324,89 @@ vesting_balance_object_with_info::vesting_balance_object_with_info( const vestin
    allowed_withdraw_time = now;
 }
 
+signed_transaction wallet_api::update_all_auth( string account_name, map<string, weight_type> auth_owner_accounts, map<public_key_type, weight_type> auth_owner_keys, map<string, weight_type> auth_active_accounts, map<public_key_type, weight_type> auth_active_keys, uint32_t owner_threshold, uint32_t active_threshold, bool broadcast )
+{
+   FC_ASSERT( !is_locked() );
+
+   auto account = get_account(account_name);
+   FC_ASSERT( account_name == account.name, "Account name doesn't match?" );
+
+
+   authority new_auth_owner;
+   authority new_auth_active;
+
+   new_auth_owner = account.owner;
+   new_auth_active = account.active;
+
+   // update the owner accounts
+   if(auth_owner_accounts.size() > 0) {
+      for (const auto &a_o_a : auth_owner_accounts) {
+         auto auth_acc = get_account(a_o_a.first);
+
+         if (a_o_a.second == 0) {
+            new_auth_owner.account_auths.erase(auth_acc.id);
+         } else {
+            new_auth_owner.add_authority(auth_acc.id, a_o_a.second);
+         }
+      }
+   }
+   // update the owner keys
+   if(auth_owner_keys.size() > 0) {
+      for (const auto &a_o_k : auth_owner_keys) {
+
+         if (a_o_k.second == 0) {
+            new_auth_owner.key_auths.erase(a_o_k.first);
+         } else {
+            new_auth_owner.add_authority(a_o_k.first, a_o_k.second);
+         }
+      }
+   }
+   // update the active accounts
+   if(auth_active_accounts.size() > 0) {
+      for (const auto &a_a_a : auth_active_accounts) {
+         auto auth_acc = get_account(a_a_a.first);
+
+         if (a_a_a.second == 0) {
+            new_auth_active.account_auths.erase(auth_acc.id);
+         } else {
+            new_auth_active.add_authority(auth_acc.id, a_a_a.second);
+         }
+      }
+   }
+   // update the active keys
+   if(auth_active_keys.size() > 0) {
+      for (const auto &a_a_k : auth_active_keys) {
+
+         if (a_a_k.second == 0) {
+            new_auth_active.key_auths.erase(a_a_k.first);
+         } else {
+            new_auth_active.add_authority(a_a_k.first, a_a_k.second);
+         }
+      }
+   }
+
+   // update the 2 theresholds
+   new_auth_owner.weight_threshold = owner_threshold;
+   new_auth_active.weight_threshold = active_threshold;
+
+   account_update_operation op;
+   op.account = account.id;
+
+   op.owner = new_auth_owner;
+   op.active = new_auth_active;
+
+   signed_transaction tx;
+   tx.operations.push_back(op);
+   auto current_fees = my->_remote_db->get_global_properties().parameters.current_fees;
+   my->set_operation_fees( tx, current_fees );
+   //fc::ecc::private_key owner_private_key = my->get_private_key_for_account(account);
+   //tx.sign( owner_private_key, my->_chain_id );
+   tx.validate();
+
+   return my->sign_transaction( tx, broadcast );
+}
+
+
 } } // graphene::wallet
 
 void fc::to_variant(const account_multi_index_type& accts, fc::variant& vo)


### PR DESCRIPTION
The pull request add a new function to the cli wallet to work with authorities. I had been working on this since a while and the first approach was to copy the steem functionality and the authority functions  of that cli wallet. Today @abitmore and I were discussing this on telegram and found the steem model was not going to suit very well for bitshares as they change authorities one by one and in bitshares, the account_update operation haves a fee.

So here is the function and i hope it is not too complicated. 

```
      /** Update account authorities
       *
       * @param account_name The account to be updated.
       * @param auth_owner_accounts Array of owner accounts and weights to be added or deleted(if weight = 0 then delete account from owner auth).
       * @param auth_owner_keys Array of owner keys and weights to be added or deleted(if weight = 0 then delete key from owner auth).
       * @param auth_active_accounts Array of active accounts and weights to be added or deleted(if weight = 0 then delete account from active auth).
       * @param auth_active_keys Array of active keys and weights to be added or deleted(if weight = 0 then delete key from active auth).
       * @param owner_threshold Owner threshold number.
       * @param active_threshold Active threshold number.
       * @param broadcast true if you wish to broadcast the transaction
       * @return the signed version of the transaction
       */
      signed_transaction update_all_auth( string account_name, map<string, weight_type> auth_owner_accounts, map<public_key_type, weight_type> auth_owner_keys, map<string, weight_type> auth_active_accounts, map<public_key_type, weight_type> auth_active_keys, uint32_t owner_threshold, uint32_t active_threshold, bool broadcast );
```

A few use cases:

`update_all_auth oxarbitrage3 [] [] [["oxarbitrage.a699", 1],["oxarbitrage2", 1]] [] 1 1 true`

Will add 2 accounts to the active authority.

`update_all_auth oxarbitrage3 [] [] [["oxarbitrage.a699", 0],["oxarbitrage2", 0]] [] 1 1 true`

Will delete the last 2 added. Weights of 0 removes the authority.

From the 4 arrays, if any of them is empty as [] then the function will keep what it is already there, so:

 `update_all_auth oxarbitrage3 [] [] [] [] 2 1 true`

Will just update the owner_threshold to 2.

`update_all_auth oxarbitrage3 [["PUB KEY 1", 1],["PUB_KEY2", 1]] [] [] [] 1 1 true`

Will add 2 new pub keys as owner. Remove them by:

`update_all_auth oxarbitrage3 [["PUB KEY 1", 0],["PUB_KEY2", 0]] [] [] [] 1 1 true`

Please use it at your own risk, this authority changes can fully block your account until a hard fork. I recommend create new account, transfer some balances and test with that and don't even try it with any important account if you don't know exactly what you are doing.

PD: Bitshares also accept addresses to be added to owner and active authorities but this as commented by @Taconator seems to be something related with legacy accounts. We left them out of the function to make the list of arguments shorter.
