### PR TITLE
Expose get_relative_account_history to cli_wallet

### DIFF
--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -359,10 +359,10 @@ class wallet_api
        * @param name the name or id of the account
        * @param stop Sequence number of earliest operation.
        * @param limit the number of entries to return
-       * @param start the number where to start looping back throw the history
+       * @param start  the sequence number where to start looping back throw the history
        * @returns a list of \c operation_history_objects
        */
-      vector<operation_detail>  get_relative_account_history(string name, int stop, int limit, int start)const;
+     vector<operation_detail>  get_relative_account_history(string name, uint32_t stop, int limit, uint32_t start)const;
 
       vector<bucket_object>             get_market_history(string symbol, string symbol2, uint32_t bucket, fc::time_point_sec start, fc::time_point_sec end)const;
       vector<limit_order_object>        get_limit_orders(string a, string b, uint32_t limit)const;

--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -354,6 +354,15 @@ class wallet_api
        */
       vector<operation_detail>  get_account_history(string name, int limit)const;
 
+      /** Returns the relative operations on the named account from start number.
+       *
+       * @param name the name or id of the account
+       * @param stop Sequence number of earliest operation.
+       * @param limit the number of entries to return
+       * @param start the number where to start looping back throw the history
+       * @returns a list of \c operation_history_objects
+       */
+      vector<operation_detail>  get_relative_account_history(string name, int stop, int limit, int start)const;
 
       vector<bucket_object>             get_market_history(string symbol, string symbol2, uint32_t bucket, fc::time_point_sec start, fc::time_point_sec end)const;
       vector<limit_order_object>        get_limit_orders(string a, string b, uint32_t limit)const;
@@ -1651,6 +1660,7 @@ FC_API( graphene::wallet::wallet_api,
         (get_block)
         (get_account_count)
         (get_account_history)
+        (get_relative_account_history)
         (is_public_key_registered)
         (get_market_history)
         (get_global_properties)

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2088,6 +2088,23 @@ public:
 
          return ss.str();
       };
+      m["get_relative_account_history"] = [this](variant result, const fc::variants& a)
+      {
+         auto r = result.as<vector<operation_detail>>();
+         std::stringstream ss;
+
+         for( operation_detail& d : r )
+         {
+            operation_history_object& i = d.op;
+            auto b = _remote_db->get_block_header(i.block_num);
+            FC_ASSERT(b);
+            ss << b->timestamp.to_iso_string() << " ";
+            i.op.visit(operation_printer(ss, *this, i.result));
+            ss << " \n";
+         }
+
+         return ss.str();
+      };
 
       m["list_account_balances"] = [this](variant result, const fc::variants& a)
       {
@@ -2818,6 +2835,26 @@ vector<operation_detail> wallet_api::get_account_history(string name, int limit)
    return result;
 }
 
+vector<operation_detail> wallet_api::get_relative_account_history(string name, int stop, int limit, int start)const
+{
+   vector<operation_detail> result;
+   auto account_id = get_account(name).get_id();
+
+   while( limit > 0 )
+   {
+      vector<operation_history_object> current = my->_remote_hist->get_relative_account_history(account_id, stop, std::min(100,limit), start);
+      for( auto& o : current ) {
+         std::stringstream ss;
+         auto memo = o.op.visit(detail::operation_printer(ss, *my, o.result));
+         result.push_back( operation_detail{ memo, ss.str(), o } );
+      }
+      if( current.size() < std::min(100,limit) )
+         break;
+      limit -= current.size();
+   }
+
+   return result;
+}
 
 vector<bucket_object> wallet_api::get_market_history( string symbol1, string symbol2, uint32_t bucket , fc::time_point_sec start, fc::time_point_sec end )const
 {

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2837,6 +2837,9 @@ vector<operation_detail> wallet_api::get_account_history(string name, int limit)
 
 vector<operation_detail> wallet_api::get_relative_account_history(string name, uint32_t stop, int limit, uint32_t start)const
 {
+   
+   FC_ASSERT( start > 0 || limit <= 100 );
+   
    vector<operation_detail> result;
    auto account_id = get_account(name).get_id();
 

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2837,6 +2837,8 @@ vector<operation_detail> wallet_api::get_account_history(string name, int limit)
 
 vector<operation_detail> wallet_api::get_relative_account_history(string name, uint32_t stop, int limit, uint32_t start)const
 {
+   FC_ASSERT( start > 0 || limit <= 100 );
+   
    vector<operation_detail> result;
    auto account_id = get_account(name).get_id();
 

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2835,24 +2835,26 @@ vector<operation_detail> wallet_api::get_account_history(string name, int limit)
    return result;
 }
 
-vector<operation_detail> wallet_api::get_relative_account_history(string name, int stop, int limit, int start)const
+vector<operation_detail> wallet_api::get_relative_account_history(string name, uint32_t stop, int limit, uint32_t start)const
 {
    vector<operation_detail> result;
    auto account_id = get_account(name).get_id();
 
    while( limit > 0 )
    {
-      vector<operation_history_object> current = my->_remote_hist->get_relative_account_history(account_id, stop, std::min(100,limit), start);
-      for( auto& o : current ) {
-         std::stringstream ss;
-         auto memo = o.op.visit(detail::operation_printer(ss, *my, o.result));
-         result.push_back( operation_detail{ memo, ss.str(), o } );
+      if(stop >= 0 and start >= 0) {
+         vector <operation_history_object> current = my->_remote_hist->get_relative_account_history(account_id, stop, std::min<uint32_t>(100, limit), start);
+         for (auto &o : current) {
+            std::stringstream ss;
+            auto memo = o.op.visit(detail::operation_printer(ss, *my, o.result));
+            result.push_back(operation_detail{memo, ss.str(), o});
+         }
+         if (current.size() < std::min<uint32_t>(100, limit))
+            break;
+         limit -= current.size();
+         start -= 100;
       }
-      if( current.size() < std::min(100,limit) )
-         break;
-      limit -= current.size();
    }
-
    return result;
 }
 

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2837,25 +2837,22 @@ vector<operation_detail> wallet_api::get_account_history(string name, int limit)
 
 vector<operation_detail> wallet_api::get_relative_account_history(string name, uint32_t stop, int limit, uint32_t start)const
 {
-   FC_ASSERT( start > 0 || limit <= 100 );
-   
    vector<operation_detail> result;
    auto account_id = get_account(name).get_id();
 
    while( limit > 0 )
    {
-      if(stop >= 0 and start >= 0) {
-         vector <operation_history_object> current = my->_remote_hist->get_relative_account_history(account_id, stop, std::min<uint32_t>(100, limit), start);
-         for (auto &o : current) {
-            std::stringstream ss;
-            auto memo = o.op.visit(detail::operation_printer(ss, *my, o.result));
-            result.push_back(operation_detail{memo, ss.str(), o});
-         }
-         if (current.size() < std::min<uint32_t>(100, limit))
-            break;
-         limit -= current.size();
-         start -= 100;
+      vector <operation_history_object> current = my->_remote_hist->get_relative_account_history(account_id, stop, std::min<uint32_t>(100, limit), start);
+      for (auto &o : current) {
+         std::stringstream ss;
+         auto memo = o.op.visit(detail::operation_printer(ss, *my, o.result));
+         result.push_back(operation_detail{memo, ss.str(), o});
       }
+      if (current.size() < std::min<uint32_t>(100, limit))
+         break;
+      limit -= current.size();
+      start -= 100;
+      if( start == 0 ) break;
    }
    return result;
 }


### PR DESCRIPTION
for issue https://github.com/bitshares/bitshares-core/issues/92 and issue https://github.com/bitshares/bitshares-core/issues/276.

The current get_relative_account_history in api.cpp and this new call in wallet.cpp are a bit tricky to use, here are some samples that may help the new users.

We have the `get_account_history` call that display the basic info of the last X operations of an account, lets get the last 10 from one account:

```
unlocked >>> get_account_history oxarbitrage3 10     
get_account_history oxarbitrage3 10
2017-05-03T13:46:33 Transfer 5 BTS from oxarbitrage3 to oxarbitrage.a699   (Fee: 2.64174 BTS) 
2017-05-03T13:46:09 Update Account 'oxarbitrage3'   (Fee: 0.14676 BTS) 
2017-05-03T13:45:15 Update Account 'oxarbitrage3'   (Fee: 0.14676 BTS) 
2017-05-03T13:44:24 Update Account 'oxarbitrage3'   (Fee: 0.14676 BTS) 
2017-05-03T13:44:06 Transfer 10 BTS from oxarbitrage.a699 to oxarbitrage3   (Fee: 2.64174 BTS) 
2017-05-03T13:40:39 Update Account 'oxarbitrage3'   (Fee: 0.14676 BTS) 
2017-05-03T13:39:48 Update Account 'oxarbitrage3'   (Fee: 0.14676 BTS) 
2017-05-03T13:37:36 Transfer 5 BTS from oxarbitrage3 to oxarbitrage.a699   (Fee: 2.64174 BTS) 
2017-05-03T13:18:21 Update Account 'oxarbitrage3'   (Fee: 0.14676 BTS) 
2017-05-03T13:13:12 Update Account 'oxarbitrage3'   (Fee: 0.14676 BTS) 
```

The same can be done now with `get_relative_account_history` with values of 0 in start and stop parameters and using 10 as the limit:


```
unlocked >>> get_relative_account_history oxarbitrage3 0 10 0  
get_relative_account_history oxarbitrage3 0 10 0
2017-05-03T13:46:33 Transfer 5 BTS from oxarbitrage3 to oxarbitrage.a699   (Fee: 2.64174 BTS) 
2017-05-03T13:46:09 Update Account 'oxarbitrage3'   (Fee: 0.14676 BTS) 
2017-05-03T13:45:15 Update Account 'oxarbitrage3'   (Fee: 0.14676 BTS) 
2017-05-03T13:44:24 Update Account 'oxarbitrage3'   (Fee: 0.14676 BTS) 
2017-05-03T13:44:06 Transfer 10 BTS from oxarbitrage.a699 to oxarbitrage3   (Fee: 2.64174 BTS) 
2017-05-03T13:40:39 Update Account 'oxarbitrage3'   (Fee: 0.14676 BTS) 
2017-05-03T13:39:48 Update Account 'oxarbitrage3'   (Fee: 0.14676 BTS) 
2017-05-03T13:37:36 Transfer 5 BTS from oxarbitrage3 to oxarbitrage.a699   (Fee: 2.64174 BTS) 
2017-05-03T13:18:21 Update Account 'oxarbitrage3'   (Fee: 0.14676 BTS) 
2017-05-03T13:13:12 Update Account 'oxarbitrage3'   (Fee: 0.14676 BTS) 
```
In order to get different "blocks" of operations we need to start playing with the last parameter, parameter start.

common sense will tell us to do something like:

`get_relative_account_history oxarbitrage3 0 2 2`

to get 2 operations starting at number 2 from top, i was expecting to get this:

```
2017-05-03T13:45:15 Update Account 'oxarbitrage3'   (Fee: 0.14676 BTS) 
2017-05-03T13:44:24 Update Account 'oxarbitrage3'   (Fee: 0.14676 BTS) 
```

But when doing it i got 1 operations from the first ones made. The problem here is that parameter start is a sequence number relative to the account last operation.

first thing a client need to do is to get the statistic object id as:

```
unlocked >>> get_account oxarbitrage3
get_account oxarbitrage3
{
  "id": "1.2.167006",
  "membership_expiration_date": "1970-01-01T00:00:00",
  "registrar": "1.2.96393",
  "referrer": "1.2.96393",
  "lifetime_referrer": "1.2.96393",
  "network_fee_percentage": 2000,
  "lifetime_referrer_fee_percentage": 3000,
  "referrer_rewards_percentage": 0,
  "name": "oxarbitrage3",
  "owner": {
    "weight_threshold": 1,
    "account_auths": [],
    "key_auths": [[
        "BTS75uzxS57o2Hey9eJHZ3zXBW9dGDjujPJzcxGaZZqnEUjNmbMct",
        1
      ]
    ],
    "address_auths": []
  },
  "active": {
    "weight_threshold": 1,
    "account_auths": [],
    "key_auths": [[
        "BTS7UEwDk19nbwasN4p95jF15TfEzV61rqoF58BquFgoVt5rt9jxk",
        1
      ],[
        "BTS75uzxS57o2Hey9eJHZ3zXBW9dGDjujPJzcxGaZZqnEUjNmbMct",
        1
      ]
    ],
    "address_auths": []
  },
  "options": {
    "memo_key": "BTS7UEwDk19nbwasN4p95jF15TfEzV61rqoF58BquFgoVt5rt9jxk",
    "voting_account": "1.2.5",
    "num_witness": 0,
    "num_committee": 0,
    "votes": [],
    "extensions": []
  },
  "statistics": "2.6.167006",
  "whitelisting_accounts": [],
  "blacklisting_accounts": [],
  "whitelisted_accounts": [],
  "blacklisted_accounts": [],
  "owner_special_authority": [
    0,{}
  ],
  "active_special_authority": [
    0,{}
  ],
  "top_n_control_flags": 0
}
unlocked >>> get_object 2.6.167006
get_object 2.6.167006
[{
    "id": "2.6.167006",
    "owner": "1.2.167006",
    "most_recent_op": "2.9.15497698",
    "total_ops": 24,
    "total_core_in_orders": 0,
    "lifetime_fees_paid": 807192,
    "pending_fees": 0,
    "pending_vested_fees": 0
  }
]
unlocked >>>
```

Statistics object id for this user is **2.6.167006** This number is created at account creation and it will never change for this user. Every account haves a unique statistics id object.

Inside the object:

```
unlocked >>> get_object 2.6.167006
get_object 2.6.167006
[{
    "id": "2.6.167006",
    "owner": "1.2.167006",
    "most_recent_op": "2.9.15497698",
    "total_ops": 24,
    "total_core_in_orders": 0,
    "lifetime_fees_paid": 807192,
    "pending_fees": 0,
    "pending_vested_fees": 0
  }
]
unlocked >>>
```
**total_ops =  24**

This is the sequence number we need to work with the new(cli wallet) and the old(api.cpp) get_relative_account_history, the 2 works in the same way.

With this in mind we now do this to get the last operation(same result can be obtained with `get_relative_account_history oxarbitrage3 0 1 0`).

```
unlocked >>> get_relative_account_history oxarbitrage3 0 1 24
get_relative_account_history oxarbitrage3 0 1 24
2017-05-03T13:46:33 Transfer 5 BTS from oxarbitrage3 to oxarbitrage.a699   (Fee: 2.64174 BTS) 
```


And from there we get what we want as:

```
unlocked >>> get_relative_account_history oxarbitrage3 0 1 23
get_relative_account_history oxarbitrage3 0 1 23
2017-05-03T13:46:09 Update Account 'oxarbitrage3'   (Fee: 0.14676 BTS) 

unlocked >>> get_relative_account_history oxarbitrage3 0 2 22
get_relative_account_history oxarbitrage3 0 2 22
2017-05-03T13:45:15 Update Account 'oxarbitrage3'   (Fee: 0.14676 BTS) 
2017-05-03T13:44:24 Update Account 'oxarbitrage3'   (Fee: 0.14676 BTS) 

unlocked >>> 
```
And so on.

Hope this helps.
