### PR TITLE
History relations API calls.

### DIFF
--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -69,6 +69,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       optional<signed_block> get_block(uint32_t block_num)const;
       processed_transaction get_transaction( uint32_t block_num, uint32_t trx_in_block )const;
       operation_history_id_type get_operation_history_id(uint32_t block_num, uint32_t trx_in_block, uint32_t op_in_trx)const;
+      account_transaction_history_id_type get_account_transaction_history_id(operation_history_id_type operation_id)const;
 
       // Globals
       chain_property_object get_chain_properties()const;
@@ -424,6 +425,25 @@ operation_history_id_type database_api_impl::get_operation_history_id(uint32_t b
    {
       if(op.block_num == block_num and op.trx_in_block == trx_in_block and op.op_in_trx == op_in_trx) {
          return op.id;
+         break;
+      }
+   }
+}
+account_transaction_history_id_type database_api::get_account_transaction_history_id(operation_history_id_type operation_id)const
+{
+   return my->get_account_transaction_history_id( operation_id );
+}
+
+account_transaction_history_id_type database_api_impl::get_account_transaction_history_id(operation_history_id_type operation_id)const
+{
+   const auto& ath_idx = _db.get_index_type<account_transaction_history_index>();
+   const auto& ath_by_seq_idx = ath_idx.indices().get<by_seq>();
+
+   for( const account_transaction_history_object& ath : ath_by_seq_idx )
+   {
+      if(ath.operation_id == operation_id) {
+         return ath.id;
+         break;
       }
    }
 }

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -68,6 +68,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       map<uint32_t, optional<block_header>> get_block_header_batch(const vector<uint32_t> block_nums)const;
       optional<signed_block> get_block(uint32_t block_num)const;
       processed_transaction get_transaction( uint32_t block_num, uint32_t trx_in_block )const;
+      operation_history_id_type get_operation_history_id(uint32_t block_num, uint32_t trx_in_block, uint32_t op_in_trx)const;
 
       // Globals
       chain_property_object get_chain_properties()const;
@@ -409,6 +410,24 @@ processed_transaction database_api_impl::get_transaction(uint32_t block_num, uin
    FC_ASSERT( opt_block->transactions.size() > trx_num );
    return opt_block->transactions[trx_num];
 }
+
+operation_history_id_type database_api::get_operation_history_id(uint32_t block_num, uint32_t trx_in_block, uint32_t op_in_trx)const
+{
+   return my->get_operation_history_id( block_num, trx_in_block, op_in_trx );
+}
+
+operation_history_id_type database_api_impl::get_operation_history_id(uint32_t block_num, uint32_t trx_in_block, uint32_t op_in_trx)const
+{
+   const simple_index<operation_history_object>& op_index = _db.get_index_type<simple_index<operation_history_object>>();
+
+   for( const operation_history_object& op : op_index )
+   {
+      if(op.block_num == block_num and op.trx_in_block == trx_in_block and op.op_in_trx == op_in_trx) {
+         return op.id;
+      }
+   }
+}
+
 
 //////////////////////////////////////////////////////////////////////
 //                                                                  //

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -190,6 +190,10 @@ class database_api
       */
       operation_history_id_type get_operation_history_id(uint32_t block_num, uint32_t trx_in_block, uint32_t op_in_trx)const;
 
+      /**
+      * Given a operation_history_id, get the account_transaction_history_id
+      */
+      account_transaction_history_id_type get_account_transaction_history_id(operation_history_id_type operation_id)const;
 
       /////////////
       // Globals //
@@ -607,6 +611,7 @@ FC_API(graphene::app::database_api,
    (get_transaction)
    (get_recent_transaction_by_id)
    (get_operation_history_id)
+   (get_account_transaction_history_id)
 
    // Globals
    (get_chain_properties)

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -185,6 +185,12 @@ class database_api
        */
       optional<signed_transaction> get_recent_transaction_by_id( const transaction_id_type& id )const;
 
+      /**
+      * Given a block, transaction in block position and operation position in transaction, get the operation_history_id
+      */
+      operation_history_id_type get_operation_history_id(uint32_t block_num, uint32_t trx_in_block, uint32_t op_in_trx)const;
+
+
       /////////////
       // Globals //
       /////////////
@@ -600,6 +606,7 @@ FC_API(graphene::app::database_api,
    (get_block)
    (get_transaction)
    (get_recent_transaction_by_id)
+   (get_operation_history_id)
 
    // Globals
    (get_chain_properties)


### PR DESCRIPTION
While developing the block explorer i found out that i had no way to relate operations from blocks to get the corresponding account_transaction_history and  operation_history objects by using API calls.

By getting a block number a client can get all the transactions and operations inside this block but was not possible to get the "2.9.X" and "1.11.X" objects from it.

At the same time this can be used to solve https://github.com/bitshares/bitshares-core/issues/243

`get_operation_history_id` takes `block_num`, `trx_in_block` and `op_in_trx` and returns an id of "1.11.X" form.

`get_account_transaction_history_id` takes a "1.11.X" id as argument and returns a "2.9.X" id.

Some samples:

```
root@alfredo:~/bitshares-munich/explorer/node/2/bitshares-core# wscat -c localhost:8090
connected (press CTRL+C to quit)
> {"id":1, "method":"call", "params":[0,"get_operation_history_id",[7300006, 0,0]]}
< {"id":1,"jsonrpc":"2.0","result":"1.11.615741080"}
> {"id":1, "method":"call", "params":[0,"get_account_transaction_history_id",["1.11.615741080"]]}
< {"id":1,"jsonrpc":"2.0","result":"2.9.77098776"}
> {"id":1, "method":"call", "params":[0,"get_operation_history_id",[7980000, 0,0]]}
< {"id":1,"jsonrpc":"2.0","result":"1.11.4124357"}
> {"id":1, "method":"call", "params":[0,"get_operation_history_id",[7980000, 2,0]]}
< {"id":1,"jsonrpc":"2.0","result":"1.11.4124359"}
> {"id":1, "method":"call", "params":[0,"get_account_transaction_history_id",["1.11.4124359"]]}
< {"id":1,"jsonrpc":"2.0","result":"2.9.4227687"}
```




