### PR TITLE
Partial fix for issue 303

### DIFF
--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -1080,7 +1080,10 @@ void application::shutdown()
    if( my->_p2p_network )
       my->_p2p_network->close();
    if( my->_chain_db )
+   {
       my->_chain_db->close();
+      my->_chain_db = nullptr;
+   }
 }
 
 void application::initialize_plugins( const boost::program_options::variables_map& options )

--- a/libraries/chain/db_management.cpp
+++ b/libraries/chain/db_management.cpp
@@ -150,6 +150,7 @@ void database::close(bool rewind)
       {
          uint32_t cutoff = get_dynamic_global_properties().last_irreversible_block_num;
 
+         ilog( "Rewinding from ${head} to ${cutoff}", ("head",head_block_num())("cutoff",cutoff) );
          while( head_block_num() > cutoff )
          {
          //   elog("pop");

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -124,9 +124,6 @@ database_fixture::~database_fixture()
       verify_account_history_plugin_index();
       BOOST_CHECK( db.get_node_properties().skip_flags == database::skip_nothing );
    }
-
-   if( data_dir )
-      db.close();
    return;
 } FC_CAPTURE_AND_RETHROW() }
 


### PR DESCRIPTION
This PR gets rid of the "no blocks to pop" message in witness_node and some unit tests.

IMO a better fix would be to define a clear distinction between "open" and "closed" states in the database, and handle state transitions within the database code. Feel free to reject this PR if you agree. :-)