### PR TITLE
Improve startup time after crash

### DIFF
--- a/libraries/chain/db_block.cpp
+++ b/libraries/chain/db_block.cpp
@@ -423,7 +423,6 @@ void database::pop_block()
    GRAPHENE_ASSERT( head_block.valid(), pop_empty_chain, "there are no blocks to pop" );
 
    _fork_db.pop_block();
-   _block_id_to_block.remove( head_id );
    pop_undo();
 
    _popped_tx.insert( _popped_tx.begin(), head_block->transactions.begin(), head_block->transactions.end() );

--- a/libraries/chain/db_management.cpp
+++ b/libraries/chain/db_management.cpp
@@ -62,7 +62,7 @@ void database::reindex( fc::path data_dir )
    uint32_t flush_point = last_block_num - 10000;
    uint32_t undo_point = last_block_num - 50;
 
-   ilog( "Replaying blocks..." );
+   ilog( "Replaying blocks, starting at ${next}...", ("next",head_block_num() + 1) );
    if( head_block_num() >= undo_point )
       _fork_db.start_block( *fetch_block_by_number( head_block_num() ) );
    else

--- a/libraries/chain/db_management.cpp
+++ b/libraries/chain/db_management.cpp
@@ -46,27 +46,35 @@ database::~database()
    clear_pending();
 }
 
-void database::reindex(fc::path data_dir, const genesis_state_type& initial_allocation)
+void database::reindex( fc::path data_dir )
 { try {
-   ilog( "reindexing blockchain" );
-   wipe(data_dir, false);
-   open(data_dir, [&initial_allocation]{return initial_allocation;});
-
-   auto start = fc::time_point::now();
    auto last_block = _block_id_to_block.last();
    if( !last_block ) {
       elog( "!no last block" );
       edump((last_block));
       return;
    }
+   if( last_block->block_num() <= head_block_num()) return;
 
+   ilog( "reindexing blockchain" );
+   auto start = fc::time_point::now();
    const auto last_block_num = last_block->block_num();
+   uint32_t flush_point = last_block_num - 10000;
+   uint32_t undo_point = last_block_num - 50;
 
    ilog( "Replaying blocks..." );
    _undo_db.disable();
-   for( uint32_t i = 1; i <= last_block_num; ++i )
+   for( uint32_t i = head_block_num() + 1; i <= last_block_num; ++i )
    {
       if( i % 10000 == 0 ) std::cerr << "   " << double(i*100)/last_block_num << "%   "<<i << " of " <<last_block_num<<"   \n";
+      if( i == flush_point )
+      {
+         ilog( "Writing database to disk at block ${i}", ("i",i) );
+         flush();
+         ilog( "Done" );
+      }
+      if( i == undo_point )
+         _undo_db.enable();
       fc::optional< signed_block > block = _block_id_to_block.fetch_by_number(i);
       if( !block.valid() )
       {
@@ -110,10 +118,29 @@ void database::wipe(const fc::path& data_dir, bool include_blocks)
 
 void database::open(
    const fc::path& data_dir,
-   std::function<genesis_state_type()> genesis_loader)
+   std::function<genesis_state_type()> genesis_loader,
+   const std::string& db_version)
 {
    try
    {
+      bool wipe_object_db = false;
+      if( !fc::exists( data_dir / "db_version" ) )
+         wipe_object_db = true;
+      else
+      {
+         std::string version_string;
+         fc::read_file_contents( data_dir / "db_version", version_string );
+         wipe_object_db = ( version_string != db_version );
+      }
+      if( wipe_object_db ) {
+          ilog("Wiping object_database due to missing or wrong version");
+          object_database::wipe( data_dir );
+          std::ofstream version_file( (data_dir / "db_version").generic_string().c_str(),
+                                      std::ios::out | std::ios::binary | std::ios::trunc );
+          version_file.write( db_version.c_str(), db_version.size() );
+          version_file.close();
+      }
+
       object_database::open(data_dir);
 
       _block_id_to_block.open(data_dir / "database" / "block_num_to_block");
@@ -121,17 +148,13 @@ void database::open(
       if( !find(global_property_id_type()) )
          init_genesis(genesis_loader());
 
-      fc::optional<signed_block> last_block = _block_id_to_block.last();
+      fc::optional<block_id_type> last_block = _block_id_to_block.last_id();
       if( last_block.valid() )
       {
-         _fork_db.start_block( *last_block );
-         idump((last_block->id())(last_block->block_num()));
-         idump((head_block_id())(head_block_num()));
-         if( last_block->id() != head_block_id() )
-         {
-              FC_ASSERT( head_block_num() == 0, "last block ID does not match current chain state",
-                         ("last_block->id", last_block->id())("head_block_num",head_block_num()) );
-         }
+         FC_ASSERT( *last_block >= head_block_id(),
+                    "last block ID does not match current chain state",
+                    ("last_block->id", last_block)("head_block_id",head_block_num()) );
+         reindex( data_dir );
       }
    }
    FC_CAPTURE_LOG_AND_RETHROW( (data_dir) )
@@ -152,17 +175,9 @@ void database::close(bool rewind)
 
          while( head_block_num() > cutoff )
          {
-         //   elog("pop");
             block_id_type popped_block_id = head_block_id();
             pop_block();
             _fork_db.remove(popped_block_id); // doesn't throw on missing
-            try
-            {
-               _block_id_to_block.remove(popped_block_id);
-            }
-            catch (const fc::key_not_found_exception&)
-            {
-            }
          }
       }
       catch ( const fc::exception& e )

--- a/libraries/chain/db_management.cpp
+++ b/libraries/chain/db_management.cpp
@@ -59,12 +59,15 @@ void database::reindex( fc::path data_dir )
    ilog( "reindexing blockchain" );
    auto start = fc::time_point::now();
    const auto last_block_num = last_block->block_num();
-   uint32_t flush_point = last_block_num - 10000;
-   uint32_t undo_point = last_block_num - 50;
+   uint32_t flush_point = last_block_num < 10000 ? 0 : last_block_num - 10000;
+   uint32_t undo_point = last_block_num < 50 ? 0 : last_block_num - 50;
 
    ilog( "Replaying blocks, starting at ${next}...", ("next",head_block_num() + 1) );
    if( head_block_num() >= undo_point )
-      _fork_db.start_block( *fetch_block_by_number( head_block_num() ) );
+   {
+      if( head_block_num() > 0 )
+         _fork_db.start_block( *fetch_block_by_number( head_block_num() ) );
+   }
    else
       _undo_db.disable();
    for( uint32_t i = head_block_num() + 1; i <= last_block_num; ++i )

--- a/libraries/chain/include/graphene/chain/block_database.hpp
+++ b/libraries/chain/include/graphene/chain/block_database.hpp
@@ -47,6 +47,7 @@ namespace graphene { namespace chain {
          optional<block_id_type> last_id()const;
       private:
          optional<index_entry> last_index_entry()const;
+         fc::path _index_filename;
          mutable std::fstream _blocks;
          mutable std::fstream _block_num_to_pos;
    };

--- a/libraries/chain/include/graphene/chain/block_database.hpp
+++ b/libraries/chain/include/graphene/chain/block_database.hpp
@@ -26,6 +26,8 @@
 #include <graphene/chain/protocol/block.hpp>
 
 namespace graphene { namespace chain {
+   class index_entry;
+
    class block_database 
    {
       public:
@@ -44,6 +46,7 @@ namespace graphene { namespace chain {
          optional<signed_block> last()const;
          optional<block_id_type> last_id()const;
       private:
+         optional<index_entry> last_index_entry()const;
          mutable std::fstream _blocks;
          mutable std::fstream _block_num_to_pos;
    };

--- a/libraries/chain/include/graphene/chain/database.hpp
+++ b/libraries/chain/include/graphene/chain/database.hpp
@@ -89,10 +89,12 @@ namespace graphene { namespace chain {
           *
           * @param data_dir Path to open or create database in
           * @param genesis_loader A callable object which returns the genesis state to initialize new databases on
+          * @param db_version a version string that changes when the internal database format and/or logic is modified
           */
           void open(
              const fc::path& data_dir,
-             std::function<genesis_state_type()> genesis_loader );
+             std::function<genesis_state_type()> genesis_loader,
+             const std::string& db_version );
 
          /**
           * @brief Rebuild object graph from block history and open detabase
@@ -100,7 +102,7 @@ namespace graphene { namespace chain {
           * This method may be called after or instead of @ref database::open, and will rebuild the object graph by
           * replaying blockchain history. When this method exits successfully, the database will be open.
           */
-         void reindex(fc::path data_dir, const genesis_state_type& initial_allocation = genesis_state_type());
+         void reindex(fc::path data_dir);
 
          /**
           * @brief wipe Delete database from disk, and potentially the raw chain as well.

--- a/libraries/db/object_database.cpp
+++ b/libraries/db/object_database.cpp
@@ -93,7 +93,7 @@ void object_database::wipe(const fc::path& data_dir)
 
 void object_database::open(const fc::path& data_dir)
 { try {
-   if( fc::exists( _data_dir / "object_database" / "lock" ) )
+   if( fc::exists( data_dir / "object_database" / "lock" ) )
    {
        wlog("Ignoring locked object_database");
        return;

--- a/libraries/db/object_database.cpp
+++ b/libraries/db/object_database.cpp
@@ -71,16 +71,20 @@ index& object_database::get_mutable_index(uint8_t space_id, uint8_t type_id)
 void object_database::flush()
 {
 //   ilog("Save object_database in ${d}", ("d", _data_dir));
-   fc::create_directories( _data_dir / "object_database" / "lock" );
+   fc::create_directories( _data_dir / "object_database.tmp" / "lock" );
    for( uint32_t space = 0; space < _index.size(); ++space )
    {
-      fc::create_directories( _data_dir / "object_database" / fc::to_string(space) );
+      fc::create_directories( _data_dir / "object_database.tmp" / fc::to_string(space) );
       const auto types = _index[space].size();
       for( uint32_t type = 0; type  <  types; ++type )
          if( _index[space][type] )
-            _index[space][type]->save( _data_dir / "object_database" / fc::to_string(space)/fc::to_string(type) );
+            _index[space][type]->save( _data_dir / "object_database.tmp" / fc::to_string(space)/fc::to_string(type) );
    }
-   fc::remove_all( _data_dir / "object_database" / "lock" );
+   fc::remove_all( _data_dir / "object_database.tmp" / "lock" );
+   if( fc::exists( _data_dir / "object_database" ) )
+      fc::rename( _data_dir / "object_database", _data_dir / "object_database.old" );
+   fc::rename( _data_dir / "object_database.tmp", _data_dir / "object_database" );
+   fc::remove_all( _data_dir / "object_database.old" );
 }
 
 void object_database::wipe(const fc::path& data_dir)

--- a/libraries/db/object_database.cpp
+++ b/libraries/db/object_database.cpp
@@ -71,6 +71,7 @@ index& object_database::get_mutable_index(uint8_t space_id, uint8_t type_id)
 void object_database::flush()
 {
 //   ilog("Save object_database in ${d}", ("d", _data_dir));
+   fc::create_directories( _data_dir / "object_database" / "lock" );
    for( uint32_t space = 0; space < _index.size(); ++space )
    {
       fc::create_directories( _data_dir / "object_database" / fc::to_string(space) );
@@ -79,6 +80,7 @@ void object_database::flush()
          if( _index[space][type] )
             _index[space][type]->save( _data_dir / "object_database" / fc::to_string(space)/fc::to_string(type) );
    }
+   fc::remove_all( _data_dir / "object_database" / "lock" );
 }
 
 void object_database::wipe(const fc::path& data_dir)
@@ -91,6 +93,11 @@ void object_database::wipe(const fc::path& data_dir)
 
 void object_database::open(const fc::path& data_dir)
 { try {
+   if( fc::exists( _data_dir / "object_database" / "lock" ) )
+   {
+       wlog("Ignoring locked object_database");
+       return;
+   }
    ilog("Opening object database from ${d} ...", ("d", data_dir));
    _data_dir = data_dir;
    for( uint32_t space = 0; space < _index.size(); ++space )

--- a/libraries/db/object_database.cpp
+++ b/libraries/db/object_database.cpp
@@ -93,13 +93,13 @@ void object_database::wipe(const fc::path& data_dir)
 
 void object_database::open(const fc::path& data_dir)
 { try {
-   if( fc::exists( data_dir / "object_database" / "lock" ) )
+   _data_dir = data_dir;
+   if( fc::exists( _data_dir / "object_database" / "lock" ) )
    {
        wlog("Ignoring locked object_database");
        return;
    }
    ilog("Opening object database from ${d} ...", ("d", data_dir));
-   _data_dir = data_dir;
    for( uint32_t space = 0; space < _index.size(); ++space )
       for( uint32_t type = 0; type  < _index[space].size(); ++type )
          if( _index[space][type] )

--- a/libraries/db/undo_database.cpp
+++ b/libraries/db/undo_database.cpp
@@ -118,8 +118,6 @@ void undo_database::undo()
       _db.insert( std::move(*item.second) );
 
    _stack.pop_back();
-   if( _stack.empty() )
-      _stack.emplace_back();
    enable();
    --_active_sessions;
 } FC_CAPTURE_AND_RETHROW() }
@@ -127,6 +125,12 @@ void undo_database::undo()
 void undo_database::merge()
 {
    FC_ASSERT( _active_sessions > 0 );
+   if( _active_sessions == 1 && _stack.size() == 1 )
+   {
+      _stack.pop_back();
+      --_active_sessions;
+      return;
+   }
    FC_ASSERT( _stack.size() >=2 );
    auto& state = _stack.back();
    auto& prev_state = _stack[_stack.size()-2];

--- a/tests/benchmarks/genesis_allocation.cpp
+++ b/tests/benchmarks/genesis_allocation.cpp
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE( genesis_and_persistence_bench )
 
       {
          database db;
-         db.open(data_dir.path(), [&]{return genesis_state;});
+         db.open(data_dir.path(), [&]{return genesis_state;}, "test");
 
          for( int i = 11; i < account_count + 11; ++i)
             BOOST_CHECK(db.get_balance(account_id_type(i), asset_id_type()).amount == GRAPHENE_MAX_SHARE_SUPPLY / account_count);
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE( genesis_and_persistence_bench )
          database db;
 
          fc::time_point start_time = fc::time_point::now();
-         db.open(data_dir.path(), [&]{return genesis_state;});
+         db.open(data_dir.path(), [&]{return genesis_state;}, "test");
          ilog("Opened database in ${t} milliseconds.", ("t", (fc::time_point::now() - start_time).count() / 1000));
 
          for( int i = 11; i < account_count + 11; ++i)
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE( genesis_and_persistence_bench )
 
          auto start_time = fc::time_point::now();
          wlog( "about to start reindex..." );
-         db.reindex(data_dir.path(), genesis_state);
+         db.open(data_dir.path(), [&]{return genesis_state;}, "force_wipe");
          ilog("Replayed database in ${t} milliseconds.", ("t", (fc::time_point::now() - start_time).count() / 1000));
 
          for( int i = 0; i < blocks_to_produce; ++i )

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -303,7 +303,7 @@ void database_fixture::open_database()
 {
    if( !data_dir ) {
       data_dir = fc::temp_directory( graphene::utilities::temp_directory_path() );
-      db.open(data_dir->path(), [this]{return genesis_state;});
+      db.open(data_dir->path(), [this]{return genesis_state;}, "test");
    }
 }
 

--- a/tests/generate_empty_blocks/main.cpp
+++ b/tests/generate_empty_blocks/main.cpp
@@ -124,7 +124,7 @@ int main( int argc, char** argv )
 
       database db;
       fc::path db_path = data_dir / "db";
-      db.open(db_path, [&]() { return genesis; } );
+      db.open(db_path, [&]() { return genesis; }, "TEST" );
 
       uint32_t slot = 1;
       uint32_t missed = 0;

--- a/tests/tests/block_tests.cpp
+++ b/tests/tests/block_tests.cpp
@@ -135,6 +135,7 @@ BOOST_AUTO_TEST_CASE( generate_empty_blocks )
       // TODO:  Don't generate this here
       auto init_account_priv_key = fc::ecc::private_key::regenerate(fc::sha256::hash(string("null_key")) );
       signed_block cutoff_block;
+      uint32_t last_block;
       {
          database db;
          db.open(data_dir.path(), make_genesis, "TEST" );
@@ -154,6 +155,7 @@ BOOST_AUTO_TEST_CASE( generate_empty_blocks )
             if( cutoff_height >= 200 )
             {
                cutoff_block = *(db.fetch_block_by_number( cutoff_height ));
+               last_block = db.head_block_num();
                break;
             }
          }
@@ -162,7 +164,9 @@ BOOST_AUTO_TEST_CASE( generate_empty_blocks )
       {
          database db;
          db.open(data_dir.path(), []{return genesis_state_type();}, "TEST");
-         BOOST_CHECK_EQUAL( db.head_block_num(), cutoff_block.block_num() );
+         BOOST_CHECK_EQUAL( db.head_block_num(), last_block );
+         while( db.head_block_num() > cutoff_block.block_num() )
+            db.pop_block();
          b = cutoff_block;
          for( uint32_t i = 0; i < 200; ++i )
          {

--- a/tests/tests/block_tests.cpp
+++ b/tests/tests/block_tests.cpp
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE( generate_empty_blocks )
       signed_block cutoff_block;
       {
          database db;
-         db.open(data_dir.path(), make_genesis );
+         db.open(data_dir.path(), make_genesis, "TEST" );
          b = db.generate_block(db.get_slot_time(1), db.get_scheduled_witness(1), init_account_priv_key, database::skip_nothing);
 
          // TODO:  Change this test when we correct #406
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE( generate_empty_blocks )
       }
       {
          database db;
-         db.open(data_dir.path(), []{return genesis_state_type();});
+         db.open(data_dir.path(), []{return genesis_state_type();}, "TEST");
          BOOST_CHECK_EQUAL( db.head_block_num(), cutoff_block.block_num() );
          b = cutoff_block;
          for( uint32_t i = 0; i < 200; ++i )
@@ -186,7 +186,7 @@ BOOST_AUTO_TEST_CASE( undo_block )
       fc::temp_directory data_dir( graphene::utilities::temp_directory_path() );
       {
          database db;
-         db.open(data_dir.path(), make_genesis);
+         db.open(data_dir.path(), make_genesis, "TEST");
          fc::time_point_sec now( GRAPHENE_TESTING_GENESIS_TIMESTAMP );
          std::vector< time_point_sec > time_stack;
 
@@ -235,9 +235,9 @@ BOOST_AUTO_TEST_CASE( fork_blocks )
       fc::temp_directory data_dir2( graphene::utilities::temp_directory_path() );
 
       database db1;
-      db1.open(data_dir1.path(), make_genesis);
+      db1.open(data_dir1.path(), make_genesis, "TEST");
       database db2;
-      db2.open(data_dir2.path(), make_genesis);
+      db2.open(data_dir2.path(), make_genesis, "TEST");
       BOOST_CHECK( db1.get_chain_id() == db2.get_chain_id() );
 
       auto init_account_priv_key  = fc::ecc::private_key::regenerate(fc::sha256::hash(string("null_key")) );
@@ -380,7 +380,7 @@ BOOST_AUTO_TEST_CASE( undo_pending )
       fc::temp_directory data_dir( graphene::utilities::temp_directory_path() );
       {
          database db;
-         db.open(data_dir.path(), make_genesis);
+         db.open(data_dir.path(), make_genesis, "TEST");
 
          auto init_account_priv_key = fc::ecc::private_key::regenerate(fc::sha256::hash(string("null_key")) );
          public_key_type init_account_pub_key  = init_account_priv_key.get_public_key();
@@ -445,8 +445,8 @@ BOOST_AUTO_TEST_CASE( switch_forks_undo_create )
                          dir2( graphene::utilities::temp_directory_path() );
       database db1,
                db2;
-      db1.open(dir1.path(), make_genesis);
-      db2.open(dir2.path(), make_genesis);
+      db1.open(dir1.path(), make_genesis, "TEST");
+      db2.open(dir2.path(), make_genesis, "TEST");
       BOOST_CHECK( db1.get_chain_id() == db2.get_chain_id() );
 
       auto init_account_priv_key  = fc::ecc::private_key::regenerate(fc::sha256::hash(string("null_key")) );
@@ -504,8 +504,8 @@ BOOST_AUTO_TEST_CASE( duplicate_transactions )
                          dir2( graphene::utilities::temp_directory_path() );
       database db1,
                db2;
-      db1.open(dir1.path(), make_genesis);
-      db2.open(dir2.path(), make_genesis);
+      db1.open(dir1.path(), make_genesis, "TEST");
+      db2.open(dir2.path(), make_genesis, "TEST");
       BOOST_CHECK( db1.get_chain_id() == db2.get_chain_id() );
 
       auto skip_sigs = database::skip_transaction_signatures | database::skip_authority_check;
@@ -554,7 +554,7 @@ BOOST_AUTO_TEST_CASE( tapos )
    try {
       fc::temp_directory dir1( graphene::utilities::temp_directory_path() );
       database db1;
-      db1.open(dir1.path(), make_genesis);
+      db1.open(dir1.path(), make_genesis, "TEST");
 
       const account_object& init1 = *db1.get_index_type<account_index>().indices().get<by_name>().find("init1");
 
@@ -1058,7 +1058,7 @@ BOOST_FIXTURE_TEST_CASE( transaction_invalidated_in_cache, database_fixture )
       fc::temp_directory data_dir2( graphene::utilities::temp_directory_path() );
 
       database db2;
-      db2.open(data_dir2.path(), make_genesis);
+      db2.open(data_dir2.path(), make_genesis, "TEST");
       BOOST_CHECK( db.get_chain_id() == db2.get_chain_id() );
 
       while( db2.head_block_num() < db.head_block_num() )
@@ -1218,7 +1218,7 @@ BOOST_AUTO_TEST_CASE( genesis_reserve_ids )
          genesis_state.initial_assets.push_back( usd );
 
          return genesis_state;
-      } );
+      }, "TEST" );
 
       const auto& acct_idx = db.get_index_type<account_index>().indices().get<by_name>();
       auto acct_itr = acct_idx.find("init0");

--- a/tests/tests/database_tests.cpp
+++ b/tests/tests/database_tests.cpp
@@ -91,4 +91,23 @@ BOOST_AUTO_TEST_CASE( flat_index_test )
    FC_ASSERT( !(*bitusd.bitasset_data_id)(db).current_feed.settlement_price.is_null() );
 }
 
+BOOST_AUTO_TEST_CASE( merge_test )
+{
+   try {
+      database db;
+      auto ses = db._undo_db.start_undo_session();
+      const auto& bal_obj1 = db.create<account_balance_object>( [&]( account_balance_object& obj ){
+          obj.balance = 42;
+      });
+      ses.merge();
+
+      auto balance = db.get_balance( account_id_type(), asset_id_type() );
+      BOOST_CHECK_EQUAL( 42, balance.amount.value );
+   } catch ( const fc::exception& e )
+   {
+      edump( (e.to_detail_string()) );
+      throw;
+   }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/tests/operation_tests2.cpp
+++ b/tests/tests/operation_tests2.cpp
@@ -1068,7 +1068,7 @@ BOOST_AUTO_TEST_CASE( balance_object_test )
    auto _sign = [&]( signed_transaction& tx, const private_key_type& key )
    {  tx.sign( key, db.get_chain_id() );   };
 
-   db.open(td.path(), [this]{return genesis_state;});
+   db.open(td.path(), [this]{return genesis_state;}, "TEST");
    const balance_object& balance = balance_id_type()(db);
    BOOST_CHECK_EQUAL(balance.balance.amount.value, 1);
    BOOST_CHECK_EQUAL(balance_id_type(1)(db).balance.amount.value, 1);


### PR DESCRIPTION
Tl;dr: if during startup we have a (possibly old) object_database available, we should use it.

We have up to two on-disk representations of the blockchain state: the block log and the object_database. The object database can be reconstructed from the block log, this is what a "replay" does. A replay takes a long time, and this time is constantly growing. This PR is an attempt to mitigate that.

During startup, the application checks the availability and state of the on-disk representation. The old code applies some rather restrictive logic (object_database.head_block == block_log.last_block) to determine if the state from the object_database can be used. This prevents creating and using snapshots of the object_database.

The logic implemented by this PR is more natural, IMO:
1. If we have an object_database, we should use it. Only if object_database.head_block > block_log.last_block we have an inconsistency (we cannot reconstruct that object_database from that block_log). In that case, treat the object_database as if it were absent.
2. If we don't have an object_database, use genesis.
3. From where we are now (genesis or object_database.head), replay all additional blocks from the block_log.
4. If during step 3 we come across block_log.last - 10000 (an arbitrary number about 8 hours in the past), flush the object_database to disk, and continue. This snapshot will be available in the next restart, if the node crashes or does otherwise not exit cleanly.
5. During step 3, at 50 blocks before block_log.last (another arbitrary number, about twice the number of active witnesses), switch from apply()ing blocks to push()ing blocks. This will populate the fork_database and enable switching to a different fork, if our block_log ends in a fork.

This change will greatly improve startup time for nodes, which will be particularly important ~~if~~when we experience another blockchain halt, like a couple of weeks ago.