### PR TITLE
Add a test that reproduce something-for-nothing fill bug

### DIFF
--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -96,6 +96,8 @@ database_fixture::database_fixture()
    // app.initialize();
    ahplugin->plugin_set_app(&app);
    ahplugin->plugin_initialize(options);
+
+   options.insert(std::make_pair("bucket-size", boost::program_options::variable_value(string("[15]"),false)));
    mhplugin->plugin_set_app(&app);
    mhplugin->plugin_initialize(options);
 
@@ -1054,6 +1056,24 @@ vector< operation_history_object > database_fixture::get_operation_history( acco
       if(node->next == account_transaction_history_id_type())
          break;
       node = db.find(node->next);
+   }
+   return result;
+}
+
+vector< graphene::market_history::order_history_object > database_fixture::get_market_order_history( asset_id_type a, asset_id_type b )const
+{
+   const auto& history_idx = db.get_index_type<graphene::market_history::history_index>().indices().get<graphene::market_history::by_key>();
+   graphene::market_history::history_key hkey;
+   if( a > b ) std::swap(a,b);
+   hkey.base = a;
+   hkey.quote = b;
+   hkey.sequence = std::numeric_limits<int64_t>::min();
+   auto itr = history_idx.lower_bound( hkey );
+   vector<graphene::market_history::order_history_object> result;
+   while( itr != history_idx.end())
+   {
+       result.push_back( *itr );
+       ++itr;
    }
    return result;
 }

--- a/tests/common/database_fixture.hpp
+++ b/tests/common/database_fixture.hpp
@@ -29,6 +29,7 @@
 #include <fc/smart_ref_impl.hpp>
 
 #include <graphene/chain/operation_history_object.hpp>
+#include <graphene/market_history/market_history_plugin.hpp>
 
 #include <iostream>
 
@@ -281,6 +282,7 @@ struct database_fixture {
    int64_t get_balance( account_id_type account, asset_id_type a )const;
    int64_t get_balance( const account_object& account, const asset_object& a )const;
    vector< operation_history_object > get_operation_history( account_id_type account_id )const;
+   vector< graphene::market_history::order_history_object > get_market_order_history( asset_id_type a, asset_id_type b )const;
 };
 
 namespace test {

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -1197,7 +1197,6 @@ BOOST_AUTO_TEST_CASE( witness_feeds )
 /**
  *  Create an order such that when the trade executes at the
  *  requested price the resulting payout to one party is 0
- *
  */
 BOOST_AUTO_TEST_CASE( trade_amount_equals_zero )
 {
@@ -1230,12 +1229,14 @@ BOOST_AUTO_TEST_CASE( trade_amount_equals_zero )
       generate_block();
       fc::usleep(fc::milliseconds(1000));
 
+       //TODO: This will fail because of something-for-nothing bug(#345)
+       // Must be fixed with a hardfork
       auto result = get_market_order_history(core.id, test.id);
-      BOOST_CHECK_EQUAL(result.size(), 4);
-      BOOST_CHECK(result[0].op.pays == core.amount(0));
-      BOOST_CHECK(result[0].op.receives == test.amount(1));
-      BOOST_CHECK(result[1].op.pays == test.amount(1));
-      BOOST_CHECK(result[1].op.receives == core.amount(0));
+      BOOST_CHECK_EQUAL(result.size(), 2);
+      BOOST_CHECK(result[0].op.pays == core.amount(1));
+      BOOST_CHECK(result[0].op.receives == test.amount(2));
+      BOOST_CHECK(result[1].op.pays == test.amount(2));
+      BOOST_CHECK(result[1].op.receives == core.amount(1));
    } catch( const fc::exception& e) {
       edump((e.to_detail_string()));
       throw;


### PR DESCRIPTION
Added a test that reproduces something-for-nothing fill bug #184 after hardfork555.

To put it briefly, following process reproduces the bug.
```
create_sell_order(core_seller, core.amount(1), test.amount(2));
create_sell_order(core_seller, core.amount(1), test.amount(2));
create_sell_order(core_buyer, test.amount(3), core.amount(1));
```

It's because `maybe_cull_small_order()` logic is deferred for a taker order.  Even when  `amount_for_receive()` become 0 for the taker, the order might be matched with other orders in case `amount_for_sale()` isn't 0.
 (https://github.com/bitshares/bitshares-core/blob/master/libraries/chain/db_market.cpp#L182-L203 )



As discussed in related issues, this should be fixed carefully.