### PR TITLE
Require voted entity exists (issue #143)

### DIFF
--- a/libraries/chain/account_evaluator.cpp
+++ b/libraries/chain/account_evaluator.cpp
@@ -90,7 +90,7 @@ void verify_account_votes( const database& db, const account_options& options )
          }
       }
    }
-   if ( db.head_block_time() >= HARDFORK_143_2_TIME ) {
+   if ( db.head_block_time() >= HARDFORK_CORE_143_TIME ) {
       const auto& approve_worker_idx = db.get_index_type<worker_index>().indices().get<by_vote_for>();
       const auto& committee_idx = db.get_index_type<committee_member_index>().indices().get<by_vote_id>();
       const auto& witness_idx = db.get_index_type<witness_index>().indices().get<by_vote_id>();

--- a/libraries/chain/account_evaluator.cpp
+++ b/libraries/chain/account_evaluator.cpp
@@ -90,33 +90,26 @@ void verify_account_votes( const database& db, const account_options& options )
          }
       }
    }
-   if (true /* db.head_block_time() >= HARDFORK_NEXT_TIME*/ ) {
-      int voted_committee_count = 0;
-      int voted_witness_count = 0;
+   if ( db.head_block_time() >= HARDFORK_143_2_TIME ) {
       const auto& approve_worker_idx = db.get_index_type<worker_index>().indices().get<by_vote_for>();
       const auto& committee_idx = db.get_index_type<committee_member_index>().indices().get<by_vote_id>();
       const auto& witness_idx = db.get_index_type<witness_index>().indices().get<by_vote_id>();
       for ( auto id : options.votes ) {
-         switch ( id ) {
-            case vote_id_type::worker:
-               FC_ASSERT( approve_worker_idx.find( id ) != approve_worker_idx.end() );
-               break;
+         switch ( id.type() ) {
             case vote_id_type::committee:
-               voted_committee_count++;
                FC_ASSERT( committee_idx.find(id) != committee_idx.end() );
                break;
             case vote_id_type::witness:
-               voted_witness_count++;
                FC_ASSERT( witness_idx.find(id) != witness_idx.end());
                break;
+            case vote_id_type::worker:
+               FC_ASSERT( approve_worker_idx.find( id ) != approve_worker_idx.end() );
+               break;
             default:
-               FC_THROW( "Invalid Vote Type" );
+               FC_THROW( "Invalid Vote Type: ${id}", ("id", id) );
                break;
          }
       }
-      FC_ASSERT( options.num_committee <= voted_committee_count );
-      FC_ASSERT( options.num_witness <= voted_witness_count );
-      //TODO: check all options.votes.id are unique to prevent duplucate votes
    }
 }
 

--- a/libraries/chain/hardfork.d/143-2.hf
+++ b/libraries/chain/hardfork.d/143-2.hf
@@ -1,4 +1,0 @@
-// #143 Require voted entities to exist
-#ifndef HARDFORK_143_2_TIME
-#define HARDFORK_143_2_TIME (fc::time_point_sec( 1503878400 ))
-#endif

--- a/libraries/chain/hardfork.d/143-2.hf
+++ b/libraries/chain/hardfork.d/143-2.hf
@@ -1,0 +1,4 @@
+// #143 Require voted entities to exist
+#ifndef HARDFORK_143_2_TIME
+#define HARDFORK_143_2_TIME (fc::time_point_sec( 1503878400 ))
+#endif

--- a/libraries/chain/hardfork.d/core-143.hf
+++ b/libraries/chain/hardfork.d/core-143.hf
@@ -1,0 +1,4 @@
+// #143 Require voted entities to exist
+#ifndef HARDFORK_CORE_143_TIME
+#define HARDFORK_CORE_143_TIME (fc::time_point_sec( 1503878400 ))
+#endif

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -442,7 +442,7 @@ BOOST_AUTO_TEST_CASE( prediction_market )
 BOOST_AUTO_TEST_CASE( create_account_test )
 {
    try {
-      generate_blocks( HARDFORK_143_2_TIME );
+      generate_blocks( HARDFORK_CORE_143_TIME );
       set_expiration( db, trx );
       trx.operations.push_back(make_account());
       account_create_operation op = trx.operations.back().get<account_create_operation>();


### PR DESCRIPTION
This PR is work in progress, compilable but have not yet been tested.
I think this simple validation may prevent voting for non-existent entity. (#143)
~~And also we should check that all votes are unique.~~(`account_options.votes` is a `flat_set` so uniqueness check is unnecessary. )
May I go on with this plan?