### PR TITLE
add get_transaction_id api call to node

### DIFF
--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -69,6 +69,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       map<uint32_t, optional<block_header>> get_block_header_batch(const vector<uint32_t> block_nums)const;
       optional<signed_block> get_block(uint32_t block_num)const;
       processed_transaction get_transaction( uint32_t block_num, uint32_t trx_in_block )const;
+      transaction_id_type get_transaction_id( uint32_t block_num, uint32_t trx_in_block )const;
 
       // Globals
       chain_property_object get_chain_properties()const;
@@ -417,6 +418,21 @@ processed_transaction database_api_impl::get_transaction(uint32_t block_num, uin
    FC_ASSERT( opt_block->transactions.size() > trx_num );
    return opt_block->transactions[trx_num];
 }
+
+transaction_id_type database_api::get_transaction_id(uint32_t block_num, uint32_t trx_num)const
+{
+    return my->get_transaction_id( block_num,  trx_num );
+}
+
+transaction_id_type database_api_impl::get_transaction_id(uint32_t block_num, uint32_t trx_num) const
+{
+    auto opt_block = _db.fetch_block_by_number(block_num);
+    FC_ASSERT( opt_block );
+    FC_ASSERT( opt_block->transactions.size() > trx_num );
+    auto trx = opt_block->transactions[trx_num];
+    return trx.id();
+}
+
 
 //////////////////////////////////////////////////////////////////////
 //                                                                  //

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -187,6 +187,11 @@ class database_api
        */
       optional<signed_transaction> get_recent_transaction_by_id( const transaction_id_type& id )const;
 
+      /**
+       * Get the transaction ID(hash) from block_num and tx position in block
+       */
+      transaction_id_type get_transaction_id( uint32_t block_num, uint32_t trx_in_block )const;
+
       /////////////
       // Globals //
       /////////////
@@ -624,6 +629,7 @@ FC_API(graphene::app::database_api,
    (get_block)
    (get_transaction)
    (get_recent_transaction_by_id)
+   (get_transaction_id)
 
    // Globals
    (get_chain_properties)


### PR DESCRIPTION
the pulls add a new api call to the node to get the transaction hash id with a given block and transaction position on it. i found that this was possible from inside the wallet while not possible using the node api.

call works ok, can be used as follows:

```
alfredo@alfredo-Inspiron-5559 ~/CLionProjects/get_transaction_id2 $ curl --data '{"jsonrpc": "2.0", "params": ["database", "get_transaction_id", [19421114, 0]], "method": "call", "id": 10}' http://localhost:8090/rpc --silent | jq
{
  "id": 10,
  "jsonrpc": "2.0",
  "result": "6f2d5064637391089127aa9feb36e2092347466c"
}
alfredo@alfredo-Inspiron-5559 ~/CLionProjects/get_transaction_id2 $ 
```

now, my initial intention was to add a second call as `get_transaction_from_id` with a transaction hash id as argument. this became harder than i was expecting as the `transaction_index` only have some of the last transactions, this is explained here:

https://github.com/bitshares/bitshares-core/blob/master/libraries/chain/db_block.cpp#L48-L52

and actual remove is done at: https://github.com/bitshares/bitshares-core/blob/master/libraries/chain/db_update.cpp#L165-L166

i also tried to get the simple `transaction_object` index but this one seems to be empty.

i will appreciate any ideas in regards on how to do it in an efficient way without looping throw all the blocks, getting the transactions and from there the hash and compare, this will be more than inefficient.