### PR TITLE
Minor stuff fixed during testnet release

### DIFF
--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -385,9 +385,6 @@ namespace detail {
          }
          _chain_db->add_checkpoints( loaded_checkpoints );
 
-         bool replay = false;
-         std::string replay_reason = "reason not provided";
-
          if( _options->count("replay-blockchain") )
             _chain_db->wipe( _data_dir / "blockchain", false );
 

--- a/libraries/chain/account_evaluator.cpp
+++ b/libraries/chain/account_evaluator.cpp
@@ -325,14 +325,14 @@ void_result account_update_evaluator::do_apply( const account_update_operation& 
       sa_after = a.has_special_authority();
    });
 
-   if( sa_before & (!sa_after) )
+   if( sa_before && (!sa_after) )
    {
       const auto& sa_idx = d.get_index_type< special_authority_index >().indices().get<by_account>();
       auto sa_it = sa_idx.find( o.account );
       assert( sa_it != sa_idx.end() );
       d.remove( *sa_it );
    }
-   else if( (!sa_before) & sa_after )
+   else if( (!sa_before) && sa_after )
    {
       d.create< special_authority_object >( [&]( special_authority_object& sa )
       {

--- a/libraries/net/message_oriented_connection.cpp
+++ b/libraries/net/message_oriented_connection.cpp
@@ -180,8 +180,8 @@ namespace graphene { namespace net {
             _delegate->on_message(_self, m);
           }
           /// Dedicated catches needed to distinguish from general fc::exception
-          catch ( const fc::canceled_exception& e ) { throw e; }
-          catch ( const fc::eof_exception& e ) { throw e; }
+          catch ( const fc::canceled_exception& e ) { throw; }
+          catch ( const fc::eof_exception& e ) { throw; }
           catch ( const fc::exception& e)
           {
             /// Here loop should be continued so exception should be just caught locally.

--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -2356,7 +2356,6 @@ namespace graphene { namespace net { namespace detail {
     {
       VERIFY_CORRECT_THREAD();
       item_hash_t reference_point = peer->last_block_delegate_has_seen;
-      uint32_t reference_point_block_num = _delegate->get_block_number(peer->last_block_delegate_has_seen);
 
       // when we call _delegate->get_blockchain_synopsis(), we may yield and there's a
       // chance this peer's state will change before we get control back.  Save off
@@ -3344,7 +3343,7 @@ namespace graphene { namespace net { namespace detail {
           bool new_transaction_discovered = false;
           for (const item_hash_t& transaction_message_hash : contained_transaction_message_ids)
           {
-            size_t items_erased = _items_to_fetch.get<item_id_index>().erase(item_id(trx_message_type, transaction_message_hash));
+            /*size_t items_erased =*/ _items_to_fetch.get<item_id_index>().erase(item_id(trx_message_type, transaction_message_hash));
             // there are two ways we could behave here: we could either act as if we received
             // the transaction outside the block and offer it to our peers, or we could just
             // forget about it (we would still advertise this block to our peers so they should

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2776,7 +2776,7 @@ vector<operation_detail> wallet_api::get_account_history(string name, int limit)
          auto memo = o.op.visit(detail::operation_printer(ss, *my, o.result));
          result.push_back( operation_detail{ memo, ss.str(), o } );
       }
-      if( current.size() < std::min(100,limit) )
+      if( int(current.size()) < std::min(100,limit) )
          break;
       limit -= current.size();
    }

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2431,7 +2431,7 @@ public:
          "to access the network API on the witness_node you are\n"
          "connecting to.  Please follow the instructions in README.md to set up an apiaccess file.\n"
          "\n";
-         throw(e);
+         throw;
       }
    }
 

--- a/tests/tests/block_tests.cpp
+++ b/tests/tests/block_tests.cpp
@@ -722,7 +722,7 @@ BOOST_FIXTURE_TEST_CASE( limit_order_expiration, database_fixture )
    //Get a sane head block time
    generate_block();
 
-   auto* test = &create_bitasset("TEST");
+   auto* test = &create_bitasset("MIATEST");
    auto* core = &asset_id_type()(db);
    auto* nathan = &create_account("nathan");
    auto* committee = &account_id_type()(db);
@@ -751,7 +751,7 @@ BOOST_FIXTURE_TEST_CASE( limit_order_expiration, database_fixture )
    auto id = limit_itr->id;
 
    generate_blocks(op.expiration, false);
-   test = &get_asset("TEST");
+   test = &get_asset("MIATEST");
    core = &asset_id_type()(db);
    nathan = &get_account("nathan");
    committee = &account_id_type()(db);

--- a/tests/tests/block_tests.cpp
+++ b/tests/tests/block_tests.cpp
@@ -49,7 +49,7 @@ genesis_state_type make_genesis() {
 
    auto init_account_priv_key = fc::ecc::private_key::regenerate(fc::sha256::hash(string("null_key")));
    genesis_state.initial_active_witnesses = 10;
-   for( int i = 0; i < genesis_state.initial_active_witnesses; ++i )
+   for( unsigned int i = 0; i < genesis_state.initial_active_witnesses; ++i )
    {
       auto name = "init"+fc::to_string(i);
       genesis_state.initial_accounts.emplace_back(name,

--- a/tests/tests/block_tests.cpp
+++ b/tests/tests/block_tests.cpp
@@ -1068,7 +1068,8 @@ BOOST_FIXTURE_TEST_CASE( transaction_invalidated_in_cache, database_fixture )
       while( db2.head_block_num() < db.head_block_num() )
       {
          optional< signed_block > b = db.fetch_block_by_number( db2.head_block_num()+1 );
-         db2.push_block(*b, database::skip_witness_signature);
+         db2.push_block(*b, database::skip_witness_signature
+                           |database::skip_authority_check );
       }
       BOOST_CHECK( db2.get( alice_id ).name == "alice" );
       BOOST_CHECK( db2.get( bob_id ).name == "bob" );

--- a/tests/tests/confidential_tests.cpp
+++ b/tests/tests/confidential_tests.cpp
@@ -64,7 +64,6 @@ BOOST_AUTO_TEST_CASE( confidential_test )
 
    auto InB1  = fc::sha256::hash("InB1");
    auto InB2  = fc::sha256::hash("InB2");
-   auto OutB  = fc::sha256::hash("InB2");
    auto nonce1 = fc::sha256::hash("nonce");
    auto nonce2 = fc::sha256::hash("nonce2");
 

--- a/tests/tests/database_tests.cpp
+++ b/tests/tests/database_tests.cpp
@@ -66,6 +66,7 @@ BOOST_AUTO_TEST_CASE( flat_index_test )
 {
    ACTORS((sam));
    const auto& bitusd = create_bitasset("USDBIT", sam.id);
+   const asset_id_type bitusd_id = bitusd.id;
    update_feed_producers(bitusd, {sam.id});
    price_feed current_feed;
    current_feed.settlement_price = bitusd.amount(100) / asset(100);
@@ -88,7 +89,7 @@ BOOST_AUTO_TEST_CASE( flat_index_test )
    const auto& dynamic_global_props = db.get<dynamic_global_property_object>(dynamic_global_property_id_type());
    generate_blocks(dynamic_global_props.next_maintenance_time, true);
 
-   FC_ASSERT( !(*bitusd.bitasset_data_id)(db).current_feed.settlement_price.is_null() );
+   FC_ASSERT( !(*bitusd_id(db).bitasset_data_id)(db).current_feed.settlement_price.is_null() );
 }
 
 BOOST_AUTO_TEST_CASE( merge_test )

--- a/tests/tests/database_tests.cpp
+++ b/tests/tests/database_tests.cpp
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE( merge_test )
    try {
       database db;
       auto ses = db._undo_db.start_undo_session();
-      const auto& bal_obj1 = db.create<account_balance_object>( [&]( account_balance_object& obj ){
+      db.create<account_balance_object>( [&]( account_balance_object& obj ){
           obj.balance = 42;
       });
       ses.merge();

--- a/tests/tests/history_api_tests.cpp
+++ b/tests/tests/history_api_tests.cpp
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(get_account_history) {
    } catch (fc::exception &e) {
       edump((e.to_detail_string()));
       throw;
-   } FC_LOG_AND_RETHROW()
+   }
 }
 
 BOOST_AUTO_TEST_CASE(get_account_history_operations) {
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(get_account_history_operations) {
    } catch (fc::exception &e) {
       edump((e.to_detail_string()));
       throw;
-   } FC_LOG_AND_RETHROW()
+   }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -320,6 +320,8 @@ BOOST_AUTO_TEST_CASE( create_account_test )
       REQUIRE_THROW_WITH_VALUE(op, options.voting_account, account_id_type(999999999));
 
       // Not allow voting for non-exist entities.
+      auto save_num_committee = op.options.num_committee;
+      auto save_num_witness = op.options.num_witness;
       op.options.num_committee = 1;
       op.options.num_witness = 0;
       REQUIRE_THROW_WITH_VALUE(op, options.votes, boost::assign::list_of<vote_id_type>(vote_id_type("0:1")).convert_to_container<flat_set<vote_id_type>>());
@@ -328,7 +330,8 @@ BOOST_AUTO_TEST_CASE( create_account_test )
       REQUIRE_THROW_WITH_VALUE(op, options.votes, boost::assign::list_of<vote_id_type>(vote_id_type("1:19")).convert_to_container<flat_set<vote_id_type>>());
       op.options.num_witness = 0;
       REQUIRE_THROW_WITH_VALUE(op, options.votes, boost::assign::list_of<vote_id_type>(vote_id_type("2:19")).convert_to_container<flat_set<vote_id_type>>());
-      op.options.num_committee = 4;
+      op.options.num_committee = save_num_committee;
+      op.options.num_witness = save_num_witness;
 
       auto auth_bak = op.owner;
       op.owner.add_authority(account_id_type(9999999999), 10);
@@ -1077,7 +1080,9 @@ BOOST_AUTO_TEST_CASE( trade_amount_equals_zero )
       set_expiration( db, trx );
 
       const asset_object& test = get_asset( "TEST" );
+      const asset_id_type test_id = test.id;
       const asset_object& core = get_asset( GRAPHENE_SYMBOL );
+      const asset_id_type core_id = core.id;
       const account_object& core_seller = create_account( "shorter1" );
       const account_object& core_buyer = get_account("nathan");
 
@@ -1102,7 +1107,7 @@ BOOST_AUTO_TEST_CASE( trade_amount_equals_zero )
 
        //TODO: This will fail because of something-for-nothing bug(#345)
        // Must be fixed with a hardfork
-      auto result = get_market_order_history(core.id, test.id);
+      auto result = get_market_order_history(core_id, test_id);
       BOOST_CHECK_EQUAL(result.size(), 2);
       BOOST_CHECK(result[0].op.pays == core.amount(1));
       BOOST_CHECK(result[0].op.receives == test.amount(2));

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -45,6 +45,8 @@
 using namespace graphene::chain;
 using namespace graphene::chain::test;
 
+#define UIA_TEST_SYMBOL "UIATEST"
+
 BOOST_FIXTURE_TEST_SUITE( operation_tests, database_fixture )
 
 BOOST_AUTO_TEST_CASE( feed_limit_logic_test )
@@ -88,6 +90,7 @@ BOOST_AUTO_TEST_CASE( call_order_update_test )
       update_feed_producers( bitusd, {sam.id} );
 
       price_feed current_feed; current_feed.settlement_price = bitusd.amount( 100 ) / core.amount(100);
+      current_feed.maintenance_collateral_ratio = 1750; // need to set this explicitly, testnet has a different default
       publish_feed( bitusd, sam, current_feed );
 
       FC_ASSERT( bitusd.bitasset_data(db).current_feed.settlement_price == current_feed.settlement_price );
@@ -181,6 +184,8 @@ BOOST_AUTO_TEST_CASE( margin_call_limit_test )
 
       price_feed current_feed;
       current_feed.settlement_price = bitusd.amount( 100 ) / core.amount(100);
+      current_feed.maintenance_collateral_ratio = 1750; // need to set this explicitly, testnet has a different default
+      current_feed.maximum_short_squeeze_ratio  = 1500; // need to set this explicitly, testnet has a different default
 
       // starting out with price 1:1
       publish_feed( bitusd, feedproducer, current_feed );
@@ -564,7 +569,7 @@ BOOST_AUTO_TEST_CASE( create_uia )
       asset_create_operation creator;
       creator.issuer = account_id_type();
       creator.fee = asset();
-      creator.symbol = "TEST";
+      creator.symbol = UIA_TEST_SYMBOL;
       creator.common_options.max_supply = 100000000;
       creator.precision = 2;
       creator.common_options.market_fee_percent = GRAPHENE_MAX_MARKET_FEE_PERCENT/100; /*1%*/
@@ -575,7 +580,7 @@ BOOST_AUTO_TEST_CASE( create_uia )
       PUSH_TX( db, trx, ~0 );
 
       const asset_object& test_asset = test_asset_id(db);
-      BOOST_CHECK(test_asset.symbol == "TEST");
+      BOOST_CHECK(test_asset.symbol == UIA_TEST_SYMBOL);
       BOOST_CHECK(asset(1, test_asset_id) * test_asset.options.core_exchange_rate == asset(2));
       BOOST_CHECK((test_asset.options.flags & white_list) == 0);
       BOOST_CHECK(test_asset.options.max_supply == 100000000);
@@ -613,7 +618,7 @@ BOOST_AUTO_TEST_CASE( update_uia )
    using namespace graphene;
    try {
       INVOKE(create_uia);
-      const auto& test = get_asset("TEST");
+      const auto& test = get_asset(UIA_TEST_SYMBOL);
       const auto& nathan = create_account("nathan");
 
       asset_update_operation op;
@@ -690,7 +695,7 @@ BOOST_AUTO_TEST_CASE( issue_uia )
       INVOKE(create_uia);
       INVOKE(create_account_test);
 
-      const asset_object& test_asset = *db.get_index_type<asset_index>().indices().get<by_symbol>().find("TEST");
+      const asset_object& test_asset = *db.get_index_type<asset_index>().indices().get<by_symbol>().find(UIA_TEST_SYMBOL);
       const account_object& nathan_account = *db.get_index_type<account_index>().indices().get<by_name>().find("nathan");
 
       asset_issue_operation op;
@@ -729,7 +734,7 @@ BOOST_AUTO_TEST_CASE( transfer_uia )
    try {
       INVOKE(issue_uia);
 
-      const asset_object& uia = *db.get_index_type<asset_index>().indices().get<by_symbol>().find("TEST");
+      const asset_object& uia = *db.get_index_type<asset_index>().indices().get<by_symbol>().find(UIA_TEST_SYMBOL);
       const account_object& nathan = *db.get_index_type<account_index>().indices().get<by_name>().find("nathan");
       const account_object& committee = account_id_type()(db);
 
@@ -757,7 +762,7 @@ BOOST_AUTO_TEST_CASE( transfer_uia )
 BOOST_AUTO_TEST_CASE( create_buy_uia_multiple_match_new )
 { try {
    INVOKE( issue_uia );
-   const asset_object&   core_asset     = get_asset( "TEST" );
+   const asset_object&   core_asset     = get_asset( UIA_TEST_SYMBOL );
    const asset_object&   test_asset     = get_asset( GRAPHENE_SYMBOL );
    const account_object& nathan_account = get_account( "nathan" );
    const account_object& buyer_account  = create_account( "buyer" );
@@ -797,7 +802,7 @@ BOOST_AUTO_TEST_CASE( create_buy_uia_multiple_match_new )
 BOOST_AUTO_TEST_CASE( create_buy_exact_match_uia )
 { try {
    INVOKE( issue_uia );
-   const asset_object&   test_asset     = get_asset( "TEST" );
+   const asset_object&   test_asset     = get_asset( UIA_TEST_SYMBOL );
    const asset_object&   core_asset     = get_asset( GRAPHENE_SYMBOL );
    const account_object& nathan_account = get_account( "nathan" );
    const account_object& buyer_account  = create_account( "buyer" );
@@ -838,7 +843,7 @@ BOOST_AUTO_TEST_CASE( create_buy_exact_match_uia )
 BOOST_AUTO_TEST_CASE( create_buy_uia_multiple_match_new_reverse )
 { try {
    INVOKE( issue_uia );
-   const asset_object&   test_asset     = get_asset( "TEST" );
+   const asset_object&   test_asset     = get_asset( UIA_TEST_SYMBOL );
    const asset_object&   core_asset     = get_asset( GRAPHENE_SYMBOL );
    const account_object& nathan_account = get_account( "nathan" );
    const account_object& buyer_account  = create_account( "buyer" );
@@ -878,7 +883,7 @@ BOOST_AUTO_TEST_CASE( create_buy_uia_multiple_match_new_reverse )
 BOOST_AUTO_TEST_CASE( create_buy_uia_multiple_match_new_reverse_fract )
 { try {
    INVOKE( issue_uia );
-   const asset_object&   test_asset     = get_asset( "TEST" );
+   const asset_object&   test_asset     = get_asset( UIA_TEST_SYMBOL );
    const asset_object&   core_asset     = get_asset( GRAPHENE_SYMBOL );
    const account_object& nathan_account = get_account( "nathan" );
    const account_object& buyer_account  = create_account( "buyer" );
@@ -926,7 +931,7 @@ BOOST_AUTO_TEST_CASE( uia_fees )
 
       enable_fees();
 
-      const asset_object& test_asset = get_asset("TEST");
+      const asset_object& test_asset = get_asset(UIA_TEST_SYMBOL);
       const asset_dynamic_data_object& asset_dynamic = test_asset.dynamic_asset_data_id(db);
       const account_object& nathan_account = get_account("nathan");
       const account_object& committee_account = account_id_type()(db);
@@ -989,7 +994,7 @@ BOOST_AUTO_TEST_CASE( uia_fees )
 BOOST_AUTO_TEST_CASE( cancel_limit_order_test )
 { try {
    INVOKE( issue_uia );
-   const asset_object&   test_asset     = get_asset( "TEST" );
+   const asset_object&   test_asset     = get_asset( UIA_TEST_SYMBOL );
    const account_object& buyer_account  = create_account( "buyer" );
 
    transfer( committee_account(db), buyer_account, asset( 10000 ) );
@@ -1079,7 +1084,7 @@ BOOST_AUTO_TEST_CASE( trade_amount_equals_zero )
       generate_blocks( HARDFORK_555_TIME );
       set_expiration( db, trx );
 
-      const asset_object& test = get_asset( "TEST" );
+      const asset_object& test = get_asset( UIA_TEST_SYMBOL );
       const asset_id_type test_id = test.id;
       const asset_object& core = get_asset( GRAPHENE_SYMBOL );
       const asset_id_type core_id = core.id;
@@ -1128,7 +1133,7 @@ BOOST_AUTO_TEST_CASE( limit_order_fill_or_kill )
 { try {
    INVOKE(issue_uia);
    const account_object& nathan = get_account("nathan");
-   const asset_object& test = get_asset("TEST");
+   const asset_object& test = get_asset(UIA_TEST_SYMBOL);
    const asset_object& core = asset_id_type()(db);
 
    limit_order_create_operation op;
@@ -1280,7 +1285,7 @@ BOOST_AUTO_TEST_CASE( reserve_asset_test )
    {
       ACTORS((alice)(bob)(sam)(judge));
       const auto& basset = create_bitasset("USDBIT", judge_id);
-      const auto& uasset = create_user_issued_asset("TEST");
+      const auto& uasset = create_user_issued_asset(UIA_TEST_SYMBOL);
       const auto& passet = create_prediction_market("PMARK", judge_id);
       const auto& casset = asset_id_type()(db);
 
@@ -1325,6 +1330,7 @@ BOOST_AUTO_TEST_CASE( reserve_asset_test )
       update_feed_producers( basset, {sam.id} );
       price_feed current_feed;
       current_feed.settlement_price = basset.amount( 2 ) / casset.amount(100);
+      current_feed.maintenance_collateral_ratio = 1750; // need to set this explicitly, testnet has a different default
       publish_feed( basset, sam, current_feed );
       borrow( alice_id, basset.amount( init_balance ), casset.amount( 100*init_balance ) );
       BOOST_CHECK_EQUAL( get_balance( alice, basset ), init_balance );
@@ -1443,7 +1449,7 @@ BOOST_AUTO_TEST_CASE( vesting_balance_create_test )
    INVOKE( create_uia );
 
    const asset_object& core = asset_id_type()(db);
-   const asset_object& test_asset = get_asset("TEST");
+   const asset_object& test_asset = get_asset(UIA_TEST_SYMBOL);
 
    vesting_balance_create_operation op;
    op.fee = core.amount( 0 );
@@ -1494,7 +1500,7 @@ BOOST_AUTO_TEST_CASE( vesting_balance_withdraw_test )
    generate_block();
 
    const asset_object& core = asset_id_type()(db);
-   const asset_object& test_asset = get_asset( "TEST" );
+   const asset_object& test_asset = get_asset( UIA_TEST_SYMBOL );
 
    vesting_balance_withdraw_operation op;
    op.fee = core.amount( 0 );

--- a/tests/tests/swan_tests.cpp
+++ b/tests/tests/swan_tests.cpp
@@ -96,6 +96,7 @@ struct swan_fixture : database_fixture {
 
     void set_feed(share_type usd, share_type core) {
         price_feed feed;
+        feed.maintenance_collateral_ratio = 1750; // need to set this explicitly, testnet has a different default
         feed.settlement_price = swan().amount(usd) / back().amount(core);
         publish_feed(swan(), feedproducer(), feed);
     }


### PR DESCRIPTION
Mostly compiler warnings / issues detected by static code analysis.
Had to adapt some unit tests because testnet uses different defaults (MCR/MSSR, core symbol name). All tests in chain_test should work now on both develop and testnet (except for the known something-for-nothing bug).