### PR TITLE
Fixed error when account_history_object with id 0 doesnt exist

### DIFF
--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -316,8 +316,12 @@ namespace graphene { namespace app {
              node = nullptr;
           else node = &node->next(db);
        }
-       if( stop.instance.value == 0 && account_transaction_history_id_type()(db).account == account && result.size() < limit )
-          result.push_back( account_transaction_history_id_type()(db).operation_id(db) );
+       if( stop.instance.value == 0 && result.size() < limit )
+       {
+          node = db.find(account_transaction_history_id_type());
+          if( node )
+             result.push_back( node->operation_id(db) );
+       }
        return result;
     }
 


### PR DESCRIPTION
If history-per-size is set it can happen that object 2.9.0 is pruned from the database. In that case an assertion fails when get_account_history is called with stop = 1.11.0.