### PR TITLE
get_history_by_date

### DIFF
--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cryptonomex, Inc., and contributors.
+ * Copyright (c) 2017 Cryptonomex, Inc., and contributors.
  *
  * The MIT License
  *
@@ -393,6 +393,60 @@ namespace graphene { namespace app {
           while ( itr != itr_stop && result.size() < limit );
        }
        return result;
+    }
+
+    vector<operation_history_object> history_api::get_account_history_by_date( account_id_type account,
+                                                                               fc::time_point_sec time_start,
+                                                                               fc::time_point_sec time_end,
+                                                                               unsigned limit )const
+    {
+       FC_ASSERT( _app.chain_database() );
+       const auto& db = *_app.chain_database();
+       FC_ASSERT(limit <= 100);
+       FC_ASSERT(time_end > time_start);
+       FC_ASSERT(time_end < db.head_block_time());
+       vector<operation_history_object> results;
+
+       const auto& hist_idx = db.get_index_type<account_transaction_history_index>();
+       const auto& by_seq_idx = hist_idx.indices().get<by_seq>();
+
+       auto itr_upper = by_seq_idx.upper_bound(account);
+       --itr_upper;
+
+       int32_t l = 0;
+       int32_t r = itr_upper->sequence;
+       if(itr_upper->account != account) return {};
+       uint32_t start_seq;
+       int32_t m = 0;
+       while (l <= r)
+       {
+          m = l + (r-l)/2;
+          auto itr_position = by_seq_idx.lower_bound(boost::make_tuple(account, m));
+          auto block_time = db.fetch_block_by_number(itr_position->operation_id(db).block_num)->timestamp;
+          if (block_time == time_start)
+             break;
+
+          if (block_time < time_start)
+             l = m + 1;
+          else
+             r = m - 1;
+       }
+       start_seq = m;
+
+       auto itr = by_seq_idx.lower_bound(boost::make_tuple(account, start_seq));
+       while(itr != by_seq_idx.end() && results.size() < limit && db.fetch_block_by_number(itr->operation_id(db).block_num)->timestamp < time_end)
+       {
+          if(db.fetch_block_by_number(itr->operation_id(db).block_num)->timestamp < time_start) {
+             ++itr;
+             continue;
+          }
+          if(itr->account != account)
+             break;
+
+          results.push_back( itr->operation_id(db) );
+          ++itr;
+       }
+       return results;
     }
 
     flat_set<uint32_t> history_api::get_market_history_buckets()const

--- a/libraries/app/include/graphene/app/api.hpp
+++ b/libraries/app/include/graphene/app/api.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cryptonomex, Inc., and contributors.
+ * Copyright (c) 2017 Cryptonomex, Inc., and contributors.
  *
  * The MIT License
  *
@@ -137,6 +137,19 @@ namespace graphene { namespace app {
                                                                         uint32_t stop = 0,
                                                                         unsigned limit = 100,
                                                                         uint32_t start = 0) const;
+
+         /**
+          * @breif Get operations from an account using a timerange
+          * @param account The account whose history should be queried
+          * @param time_start Time to start
+          * @param time_start Time to end
+          * @param limit Maximum number of operations to retrieve (must not exceed 100)
+          * @return A list of filtered operations performed by account, ordered from most oldest to recent
+         */
+         vector<operation_history_object> get_account_history_by_date( account_id_type account,
+                                                                       fc::time_point_sec time_start,
+                                                                       fc::time_point_sec time_end,
+                                                                       unsigned limit ) const;
 
          vector<order_history_object> get_fill_order_history( asset_id_type a, asset_id_type b, uint32_t limit )const;
          vector<bucket_object> get_market_history( asset_id_type a, asset_id_type b, uint32_t bucket_seconds,
@@ -390,6 +403,7 @@ FC_API(graphene::app::history_api,
        (get_account_history)
        (get_account_history_operations)
        (get_relative_account_history)
+       (get_account_history_by_date)
        (get_fill_order_history)
        (get_market_history)
        (get_market_history_buckets)


### PR DESCRIPTION
**Background:**

Some background is needed to understand better how do we reach here.

The code on this pull is a result of working on a filter by date account history api function for issue https://github.com/bitshares/bitshares-core/issues/358

The first attempt was to add the date into the account transaction history object(atho). This is discussed and implemented here https://github.com/bitshares/bitshares-core/pull/379
, problem is the solution increase ram usage significantly so i moved to a new option suggested by @pc(check last comments of above pull). It was very hard and tricky to make a global member function inside the account transaction history index that can pull the date of the block at the moment of the history is added and store it but only in the index, this reduces ram but decrease performance in replay. This is a solution that actually works but don't convince me fully.

Problem is that to make the time index we need to call fetch block every time new history is added in the entire system. To reduce computation we found out we could remove the block fetching on the global function and just make the index `by_block` instead of `by_time`. related code can be found at https://github.com/oxarbitrage/bitshares-core/tree/develop_358

The challenge there is that api calls will input time and index is by block. There is  no way to simple relate the blocks and the time as the production chain was stuck at moments, blocks are missing at any time, etc. In a theoretical chain producing blocks every 3 seconds since genesis this will be easy but it is not our case.
 
As we need precision, @pc suggested me to make a binary search inside the `by_block` index to get the closest blocks to the date arguments of the api call. 
After a successful attempt of introducing a binary search algo adapted for our needs i realized the `by_block` index actually haves the same order as the already there `by_seq` index. Making the binary search in the by_seq index makes sense now as the most effective way to do it.

**The solution**

Proposed code if accepted is a generic way to solve issues like https://github.com/bitshares/bitshares-core/issues/61 , https://github.com/bitshares/bitshares-core/issues/243 and some others where different data is already in the blockchain but hard and inefficient to relate in an api call. Solution does not need to add any new index, data to object or anything like that, everything is just done in the `api.cpp` and `api.hpp`. This was explored before but performance sucks as a traversal search inside the account will have to be made. The key is the binary search.
Can probably be made with less lines but please note built in binary searches were not possible for our case so i had to make my own. Still, i could be missing special cases or other issues. There could be a faster algo than the binary search for sequenced indexes however i was not able to find any that can suit.

Binary search loop is made in by_seq index to find start date inside the account. Then a normal loop is made with this start until the end date. 

Inside the loop `lower_bound` is used, this is also a binary search in the index however the introduced function `get_account_history_by_date` seems to be fast and precise in all the cases tested.

In a synchronized chain, in and account with 850 operations like http://bitshares-explorer.io/#/accounts/xeroc the function loop will need 9-10 iterations to actually find any date inside. I don't have resources to test in a full node and with accounts with millions of ops but definitely this will be a lot faster than linear searching or anything else.

```
alfredo@alfredo-Inspiron-5559 ~/CLionProjects/issue358_5 $ curl --data '{"jsonrpc": "2.0", "params": ["history", "get_account_history_by_date", ["1.2.282", "2015-12-26T00:00:06", "2015-12-26T23:00:00", 100]], "method": "call", "id": 10}' http://localhost:8090/rpc --silent | jq
{
  "id": 10,
  "jsonrpc": "2.0",
  "result": [
    {
      "id": "1.11.732691",
      "op": [
        0,
        {
          "fee": {
            "amount": 3273437,
            "asset_id": "1.3.0"
          },
          "from": "1.2.97259",
          "to": "1.2.282",
          "amount": {
            "amount": 3,
            "asset_id": "1.3.569"
          },
          "memo": {
            "from": "BTS5UJBnRKcaysHN8iXCDUr5zkjN8U393EVbK5PfjgU8P3sjSYmXv",
            "to": "BTS5TPTziKkLexhVKsQKtSpo4bAv5RnB8oXcG4sMHEwCcTf3r7dqE",
            "nonce": "10810090194978835734",
            "message": "3a03b41636f4f8741a15ef501f3f9d0fe5a956f0d70fbd25d7dc8d8a73fa8629ee063370263534e202fe113f8c64b2e92f012e953316a386b14299613c8e33bd"
          },
          "extensions": []
        }
      ],
      "result": [
        0,
        {}
      ],
      "block_num": 2101074,
      "trx_in_block": 5,
      "op_in_trx": 0,
      "virtual_op": 43295
    }
  ]
}
alfredo@alfredo-Inspiron-5559 ~/CLionProjects/issue358_5 $ 
```

**notes:** 
- it does not deal with more than 100 ops in the same block but i dont think we should here but actually rethink the limits.
- filter by op can be done client side once he haves all the ops in interval.
- filter by asset was discarded from this call as it is too specific, only works against a few ops.