### PR TITLE
[Testnet] New defaults for max- and partial-ops

### DIFF
--- a/libraries/plugins/account_history/account_history_plugin.cpp
+++ b/libraries/plugins/account_history/account_history_plugin.cpp
@@ -262,8 +262,8 @@ void account_history_plugin::plugin_set_program_options(
 {
    cli.add_options()
          ("track-account", boost::program_options::value<std::vector<std::string>>()->composing()->multitoken(), "Account ID to track history for (may specify multiple times)")
-         ("partial-operations", boost::program_options::value<bool>(), "Keep only those operations in memory that are related to account history tracking")
-         ("max-ops-per-account", boost::program_options::value<uint32_t>(), "Maximum number of operations per account will be kept in memory")
+         ("partial-operations", boost::program_options::value<bool>()->default_value(true), "Keep only those operations in memory that are related to account history tracking (defaults to true)")
+         ("max-ops-per-account", boost::program_options::value<uint32_t>()->default_value(1000), "Maximum number of operations per account will be kept in memory (defaults to 1000)")
          ;
    cfg.add(cli);
 }


### PR DESCRIPTION
The reasoning here is that maintainers and operators don't need to
customize the configuration fiel in order to have the BitShares backend
running in low memory mode. The number 1000 should be sufficient for
most operations (even exchanges) to include all needed operations in the
exchanges' account.