### PR TITLE
get_account_history fix

### DIFF
--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -316,10 +316,10 @@ namespace graphene { namespace app {
              node = nullptr;
           else node = &node->next(db);
        }
-       if( stop.instance.value == 0 && result.size() < limit && account_transaction_history_id_type()(db).account == account)
+       if( stop.instance.value == 0 && result.size() < limit)
        {
           node = db.find(account_transaction_history_id_type());
-          if( node )
+          if( node && account_transaction_history_id_type()(db).account == account)
              result.push_back( node->operation_id(db) );
        }
        return result;

--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -316,7 +316,7 @@ namespace graphene { namespace app {
              node = nullptr;
           else node = &node->next(db);
        }
-       if( stop.instance.value == 0 && result.size() < limit )
+       if( stop.instance.value == 0 && result.size() < limit && account_transaction_history_id_type()(db).account == account)
        {
           node = db.find(account_transaction_history_id_type());
           if( node )

--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -316,7 +316,7 @@ namespace graphene { namespace app {
              node = nullptr;
           else node = &node->next(db);
        }
-       if( stop.instance.value == 0 && result.size() < limit)
+       if( stop.instance.value == 0 && result.size() < limit )
        {
           node = db.find(account_transaction_history_id_type());
           if( node && account_transaction_history_id_type()(db).account == account)

--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -319,7 +319,7 @@ namespace graphene { namespace app {
        if( stop.instance.value == 0 && result.size() < limit )
        {
           node = db.find(account_transaction_history_id_type());
-          if( node && account_transaction_history_id_type()(db).account == account)
+          if( node && node->account == account)
              result.push_back( node->operation_id(db) );
        }
        return result;


### PR DESCRIPTION
@pmconrad found a failing unit test at `./chain_test -t history_api_tests/get_account_history` . problem was introduced to api call `get_account_history` in this commit https://github.com/bitshares/bitshares-core/commit/339ac39c22393dad36b8f63b11e5d1dbee31c93a where 1.11.0 operation was added to the results without checking if operation was made by the requested account. 
this patch will fix the issue and now the operation_history tests will pass.