### PR TITLE
Prevent bid_collateral from executing through proposal before hardfork

### DIFF
--- a/libraries/chain/include/graphene/chain/asset_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/asset_evaluator.hpp
@@ -160,6 +160,10 @@ namespace graphene { namespace chain {
             template<typename T>
             void operator()( const T& v )const {}
 
+            void operator()( const graphene::chain::bid_collateral_operation& v )const {
+               FC_ASSERT( false, "Not allowed until hardfork" );
+            }
+
             void operator()( const graphene::chain::asset_create_operation& v )const {
                FC_ASSERT( v.fee.asset_id == asset_id_type(), "Can only pay fee in BTS since block #21040000" );
             }


### PR DESCRIPTION
This fix prevents an issue pointed out by @abitmore:
An upgraded witness could include a proposal with a bid_collateral_operation into the blockchain, which would cause block misses for nodes that haven't upgraded yet. After a majority of witnesses have upgraded, such an event would exclude all older nodes from the network.