### PR TITLE
allow plugin to have descriptions

### DIFF
--- a/libraries/app/include/graphene/app/application.hpp
+++ b/libraries/app/include/graphene/app/application.hpp
@@ -56,7 +56,8 @@ namespace graphene { namespace app {
             auto plug = std::make_shared<PluginType>();
             plug->plugin_set_app(this);
 
-            boost::program_options::options_description plugin_cli_options("Options for plugin " + plug->plugin_name()), plugin_cfg_options;
+            boost::program_options::options_description plugin_cli_options(plug->plugin_name() + " plugin. " + plug->plugin_description() + "\nOptions"), plugin_cfg_options;
+            //boost::program_options::options_description plugin_cli_options("Options for plugin " + plug->plugin_name()), plugin_cfg_options;
             plug->plugin_set_program_options(plugin_cli_options, plugin_cfg_options);
             if( !plugin_cli_options.options().empty() )
                _cli_options.add(plugin_cli_options);

--- a/libraries/app/include/graphene/app/plugin.hpp
+++ b/libraries/app/include/graphene/app/plugin.hpp
@@ -35,6 +35,7 @@ class abstract_plugin
    public:
       virtual ~abstract_plugin(){}
       virtual std::string plugin_name()const = 0;
+      virtual std::string plugin_description()const = 0;
 
       /**
        * @brief Perform early startup routines and register plugin indexes, callbacks, etc.
@@ -100,6 +101,7 @@ class plugin : public abstract_plugin
       virtual ~plugin() override;
 
       virtual std::string plugin_name()const override;
+      virtual std::string plugin_description()const override;
       virtual void plugin_initialize( const boost::program_options::variables_map& options ) override;
       virtual void plugin_startup() override;
       virtual void plugin_shutdown() override;

--- a/libraries/app/plugin.cpp
+++ b/libraries/app/plugin.cpp
@@ -43,6 +43,11 @@ std::string plugin::plugin_name()const
    return "<unknown plugin>";
 }
 
+std::string plugin::plugin_description()const
+{
+   return "<no description>";
+}
+
 void plugin::plugin_initialize( const boost::program_options::variables_map& options )
 {
    return;

--- a/libraries/plugins/snapshot/include/graphene/snapshot/snapshot.hpp
+++ b/libraries/plugins/snapshot/include/graphene/snapshot/snapshot.hpp
@@ -35,6 +35,7 @@ class snapshot_plugin : public graphene::app::plugin {
       ~snapshot_plugin() {}
 
       std::string plugin_name()const override;
+      std::string plugin_description()const override;
 
       virtual void plugin_set_program_options(
          boost::program_options::options_description &command_line_options,

--- a/libraries/plugins/snapshot/snapshot.cpp
+++ b/libraries/plugins/snapshot/snapshot.cpp
@@ -54,6 +54,11 @@ std::string snapshot_plugin::plugin_name()const
    return "snapshot";
 }
 
+std::string snapshot_plugin::plugin_description()const
+{
+   return "Create snapshots at a specified time or block number.";
+}
+
 void snapshot_plugin::plugin_initialize(const boost::program_options::variables_map& options)
 { try {
    ilog("snapshot plugin: plugin_initialize() begin");


### PR DESCRIPTION
for demonstration purposes the snapshot plugin haves now a description, here is how it looks in the help:

```
$ ./programs/witness_node/witness_node --help
...
snapshot plugin. Create snapshots at a specified time or block number.
Options:
  --snapshot-at-block arg               Block number after which to do a 
                                        snapshot
  --snapshot-at-time arg                Block time (ISO format) after which to 
                                        do a snapshot
  --snapshot-to arg                     Pathname of JSON file where to store 
                                        the snapshot

```

plugins with no description haves the default:

```
...
market_history plugin. <no description>
Options:
...
```

If pull is accepted we can go adding to all plugins.