### PR TITLE
Market history plugin improvements

### DIFF
--- a/libraries/plugins/market_history/include/graphene/market_history/market_history_plugin.hpp
+++ b/libraries/plugins/market_history/include/graphene/market_history/market_history_plugin.hpp
@@ -28,6 +28,8 @@
 
 #include <fc/thread/future.hpp>
 
+#include <boost/multi_index/composite_key.hpp>
+
 namespace graphene { namespace market_history {
 using namespace chain;
 
@@ -105,6 +107,21 @@ struct order_history_object : public abstract_object<order_history_object>
   fc::time_point_sec   time;
   fill_order_operation op;
 };
+struct order_history_object_key_base_extractor
+{
+   typedef asset_id_type result_type;
+   result_type operator()(const order_history_object& o)const { return o.key.base; }
+};
+struct order_history_object_key_quote_extractor
+{
+   typedef asset_id_type result_type;
+   result_type operator()(const order_history_object& o)const { return o.key.quote; }
+};
+struct order_history_object_key_sequence_extractor
+{
+   typedef int64_t result_type;
+   result_type operator()(const order_history_object& o)const { return o.key.sequence; }
+};
 
 struct by_key;
 typedef multi_index_container<
@@ -115,11 +132,28 @@ typedef multi_index_container<
    >
 > bucket_object_multi_index_type;
 
+struct by_market_time;
 typedef multi_index_container<
    order_history_object,
    indexed_by<
       hashed_unique< tag<by_id>, member< object, object_id_type, &object::id > >,
-      ordered_unique< tag<by_key>, member< order_history_object, history_key, &order_history_object::key > >
+      ordered_unique< tag<by_key>, member< order_history_object, history_key, &order_history_object::key > >,
+      ordered_unique<
+         tag<by_market_time>,
+         composite_key<
+            order_history_object,
+            order_history_object_key_base_extractor,
+            order_history_object_key_quote_extractor,
+            member<order_history_object, time_point_sec, &order_history_object::time>,
+            order_history_object_key_sequence_extractor
+         >,
+         composite_key_compare<
+            std::less< asset_id_type >,
+            std::less< asset_id_type >,
+            std::greater< time_point_sec >,
+            std::less< int64_t >
+         >
+      >
    >
 > order_history_multi_index_type;
 
@@ -154,6 +188,8 @@ class market_history_plugin : public graphene::app::plugin
 
       uint32_t                    max_history()const;
       const flat_set<uint32_t>&   tracked_buckets()const;
+      uint32_t                    max_order_his_records_per_market()const;
+      uint32_t                    max_order_his_seconds_per_market()const;
 
    private:
       friend class detail::market_history_plugin_impl;

--- a/libraries/plugins/market_history/include/graphene/market_history/market_history_plugin.hpp
+++ b/libraries/plugins/market_history/include/graphene/market_history/market_history_plugin.hpp
@@ -127,7 +127,7 @@ struct by_key;
 typedef multi_index_container<
    bucket_object,
    indexed_by<
-      hashed_unique< tag<by_id>, member< object, object_id_type, &object::id > >,
+      ordered_unique< tag<by_id>, member< object, object_id_type, &object::id > >,
       ordered_unique< tag<by_key>, member< bucket_object, bucket_key, &bucket_object::key > >
    >
 > bucket_object_multi_index_type;
@@ -136,7 +136,7 @@ struct by_market_time;
 typedef multi_index_container<
    order_history_object,
    indexed_by<
-      hashed_unique< tag<by_id>, member< object, object_id_type, &object::id > >,
+      ordered_unique< tag<by_id>, member< object, object_id_type, &object::id > >,
       ordered_unique< tag<by_key>, member< order_history_object, history_key, &order_history_object::key > >,
       ordered_unique<
          tag<by_market_time>,

--- a/libraries/plugins/market_history/market_history_plugin.cpp
+++ b/libraries/plugins/market_history/market_history_plugin.cpp
@@ -188,8 +188,16 @@ struct operation_process_fill_order
           { // update existing bucket
              //wlog( "    before updating bucket ${b}", ("b",*itr) );
              db.modify( *itr, [&]( bucket_object& b ){
-                  b.base_volume += trade_price.base.amount;
-                  b.quote_volume += trade_price.quote.amount;
+                  try {
+                     b.base_volume += trade_price.base.amount;
+                  } catch( fc::overflow_exception ) {
+                     b.base_volume = std::numeric_limits<int64_t>::max();
+                  }
+                  try {
+                     b.quote_volume += trade_price.quote.amount;
+                  } catch( fc::overflow_exception ) {
+                     b.quote_volume = std::numeric_limits<int64_t>::max();
+                  }
                   b.close_base = fill_price.base.amount;
                   b.close_quote = fill_price.quote.amount;
                   if( b.high() < fill_price )


### PR DESCRIPTION
PR for #472, #467, #454.

Introduces two new options to market_history_plugin:
* `max-order-his-records-per-market`:
  Will only store this amount of matched orders for each market in order
  history for querying, or those meet the other option, which has more data.
  (default: 1000)
* `max-order-his-seconds-per-market`:
  Will only store matched orders in last X seconds for each market in order
  history for querying, or those meet the other option, which has more data.
  (default: 259200 (3 days))

With these default settings, running current BitShares main net, RAM usage is
`VIRT=4389536, RES=3.287g`.

In comparison to earlier results mentioned in https://github.com/bitshares/bitshares-core/issues/472#issuecomment-343781768 (`VIRT = 5982640`, `RES = 4.805g`), the new changes made in this PR saved another `1.6GB` of RAM, so in total saved more than `2GB` of RAM.

With the new `by_market_time` index, #458 will be able to be addressed.