### PR TITLE
[docker] Create the symlink in the launch script, not the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,9 +49,6 @@ RUN chown bitshares:bitshares -R /var/lib/bitshares
 # Volume
 VOLUME ["/var/lib/bitshares", "/etc/bitshares"]
 
-# default settings
-RUN ln -f -s /etc/bitshares/config.ini /var/lib/bitshares
-
 # rpc service:
 EXPOSE 8090
 # p2p service:

--- a/docker/bitsharesentry.sh
+++ b/docker/bitsharesentry.sh
@@ -18,7 +18,7 @@ VERSION=`cat /etc/bitshares/version`
 
 ## Link the bitshares config file into home
 ## This link has been created in Dockerfile, already
-#ln -f -s /etc/bitshares/config.ini /var/lib/bitshares
+ln -f -s /etc/bitshares/config.ini /var/lib/bitshares
 
 ## get blockchain state from an S3 bucket
 # echo bitsharesd: beginning download and decompress of s3://$S3_BUCKET/blockchain-$VERSION-latest.tar.bz2


### PR DESCRIPTION
This fixes the issue that the container uses the default configuration as defined in the witness_node and not the default config as defined in the `docker/config.ini` file.

The basic difference is the removal of the logging and the exposure of 8090 as rpc port. That connection is exposed to docker only and needs to be configured separately to be available through public connection (e.g. `0.0.0.0`).

I hope no further changes will be needed since this is just the default behavior and everything else can be defined through `BITSHARESD_ARGS`