### PR TITLE
blind_transfer and receive_from_blind transactions are never signed

### DIFF
--- a/libraries/chain/protocol/transaction.cpp
+++ b/libraries/chain/protocol/transaction.cpp
@@ -340,6 +340,13 @@ set<public_key_type> signed_transaction::get_required_signatures(
 
    set<public_key_type> result;
 
+   // force "other" pubkeys in:
+   for( const auto &auth : other )
+   {
+      for( const auto &pk : auth.get_keys() )
+         result.insert( pk );
+   }
+
    for( auto& provided_sig : s.provided_signatures )
       if( available_keys.find( provided_sig.first ) != available_keys.end() )
          result.insert( provided_sig.first );


### PR DESCRIPTION
If we follow the [StealthTransfers][1] guide, neither `blind_transfer`, neither `transfer_from_blind` calls work.

```
>>> blind_transfer alice bobby 500 BTS true
Assert Exception: missing other authority. Missing Authority
```

The assert is triggered from the https://github.com/bitshares/bitshares-core/blob/develop/libraries/chain/protocol/transaction.cpp#L274, on the witness side.

On the cli_wallet side, [sign_transaction][2] is not actually doing it's job, as:
```cpp
signed_transaction sign_transaction(signed_transaction tx, bool broadcast = false)
   {
      set<public_key_type> pks = _remote_db->get_potential_signatures( tx );
//!
//already too late, get_potential_signatures has called get_required_signatures with
//empty allowed_keys set by itself, so the "other" required keys never show up.
//!
      flat_set<public_key_type> owned_keys;
      owned_keys.reserve( pks.size() );
      std::copy_if( pks.begin(), pks.end(), std::inserter(owned_keys, owned_keys.end()),
                    [this](const public_key_type& pk){ return _keys.find(pk) != _keys.end(); } );
      set<public_key_type> approving_key_set = _remote_db->get_required_signatures( tx, owned_keys );
```

The provided patch fixes the issues for the `blind_transfer` and `transfer_from_blind` paths. I have no idea if it breaks some other transaction types. As far as I can tell, it shouldn't, as the first call *should* get as much keys as possible, to filter that list down against owned/available keys. So, in theory, this is a very safe patch, but please review my logic + I haven't tested each and every transaction type to see the repercussions.

 [1]: https://github.com/bitshares/bitshares-core/wiki/StealthTransfers
 [2]: https://github.com/bitshares/bitshares-core/blob/6d6f5dd66589ae09730f3dddecccb0adaddeb033/libraries/wallet/wallet.cpp#L1818