### PR TITLE
Proposal: expose sign/read memo API to wallet

### DIFF
--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -786,6 +786,22 @@ class wallet_api
       transaction_id_type get_transaction_id( const signed_transaction& trx )const { return trx.id(); }
 
 
+      /** Sign a memo message.
+       *
+       * @param from the name or id of signing account; or a public key.
+       * @param to the name or id of receiving account; or a public key.
+       * @param memo text to sign.
+       */
+      memo_data sign_memo(string from, string to, string memo);
+
+      /** Read a memo.
+       *
+       * @param memo JSON-enconded memo.
+       * @returns string with decrypted message..
+       */
+      string read_memo(const memo_data& memo);
+
+
       /** These methods are used for stealth transfers */
       ///@{
       /**
@@ -1718,6 +1734,8 @@ FC_API( graphene::wallet::wallet_api,
         (flood_network)
         (network_add_nodes)
         (network_get_connected_peers)
+        (sign_memo)
+        (read_memo)
         (set_key_label)
         (get_key_label)
         (get_public_key)


### PR DESCRIPTION
Rationale: when you're constructing a transaction manually, via the construction builder, you might need to add a memo to an operation. At this point, the memo should already be encrypted with a private key. So without a stand-alone API to generate/sign such memo, you, as a cli_wallet user, can not actually do this.

This PR adds 2 new wallet API methods: `sign_memo` and `read_memo`. 

`sign_memo` takes 2 account names/ids (or literal public keys) and a text message and returns a `memo_data` struct (in JSON), which is suitable for inclusion into operation templates.
```
unlocked >>> sign_memo alice bob hey
{
  "from": "BTS....",
  "to": "BTS...",
  "nonce": "4108...",
  "message": "421e..."
}
```

`read_memo` takes such JSON struct, decrypts it, and returns the plain-text message.

```
unlocked >>> read_memo {"from": "BTS....", "to": "BTS...", "nonce": "4108...", "message": "421e..." }
"hey"
```

Bonus rationale: with such an API, alice and bob can exchange messages off-chain, in a fairly secure manner. Also, "Proof-of-account ownership" tests could be done easily, and some websites might want to integrate this as 2FA. Also, bitcoin-core has similar API (signmessage/verifymessage), so people might expect to have access to their memo keys in a similar manner.