### PR TITLE
Precalculate market ticker data

### DIFF
--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -111,7 +111,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       vector<collateral_bid_object>      get_collateral_bids(const asset_id_type asset, uint32_t limit, uint32_t start)const;
       void subscribe_to_market(std::function<void(const variant&)> callback, asset_id_type a, asset_id_type b);
       void unsubscribe_from_market(asset_id_type a, asset_id_type b);
-      market_ticker                      get_ticker( const string& base, const string& quote )const;
+      market_ticker                      get_ticker( const string& base, const string& quote, bool skip_order_book = false )const;
       market_volume                      get_24_volume( const string& base, const string& quote )const;
       order_book                         get_order_book( const string& base, const string& quote, unsigned limit = 50 )const;
       vector<market_trade>               get_trade_history( const string& base, const string& quote, fc::time_point_sec start, fc::time_point_sec stop, unsigned limit = 100 )const;
@@ -1154,7 +1154,7 @@ market_ticker database_api::get_ticker( const string& base, const string& quote 
     return my->get_ticker( base, quote );
 }
 
-market_ticker database_api_impl::get_ticker( const string& base, const string& quote )const
+market_ticker database_api_impl::get_ticker( const string& base, const string& quote, bool skip_order_book )const
 {
     const auto assets = lookup_asset_symbols( {base, quote} );
     FC_ASSERT( assets[0], "Invalid base asset symbol: ${s}", ("s",base) );
@@ -1178,11 +1178,6 @@ market_ticker database_api_impl::get_ticker( const string& base, const string& q
    auto quote_id = assets[1]->id;
    if( base_id > quote_id ) std::swap( base_id, quote_id );
 
-   history_key hkey;
-   hkey.base = base_id;
-   hkey.quote = quote_id;
-   hkey.sequence = std::numeric_limits<int64_t>::min();
-
    // TODO: move following duplicate code out
    // TODO: using pow is a bit inefficient here, optimization is possible
    auto asset_to_real = [&]( const asset& a, int p ) { return double(a.amount.value)/pow( 10, p ); };
@@ -1194,44 +1189,31 @@ market_ticker database_api_impl::get_ticker( const string& base, const string& q
          return asset_to_real( p.quote, assets[0]->precision ) / asset_to_real( p.base, assets[1]->precision );
    };
 
-   const auto& history_idx = _db.get_index_type<graphene::market_history::history_index>().indices().get<by_key>();
-   auto itr = history_idx.lower_bound( hkey );
-
-   bool is_latest = true;
-   price latest_price;
    fc::uint128 base_volume;
    fc::uint128 quote_volume;
-   while( itr != history_idx.end() && itr->key.base == base_id && itr->key.quote == quote_id )
+
+   const auto& ticker_idx = _db.get_index_type<graphene::market_history::market_ticker_index>().indices().get<by_market>();
+   auto itr = ticker_idx.find( std::make_tuple( base_id, quote_id ) );
+   if( itr != ticker_idx.end() )
    {
-      if( is_latest )
+      price latest_price = asset( itr->latest_base, itr->base ) / asset( itr->latest_quote, itr->quote );
+      result.latest = price_to_real( latest_price );
+      if( itr->last_day_base != 0 && itr->last_day_quote != 0 // has trade data before 24 hours
+            && ( itr->last_day_base != itr->latest_base || itr->last_day_quote != itr->latest_quote ) ) // price changed
       {
-         is_latest = false;
-         latest_price = itr->op.fill_price;
-         result.latest = price_to_real( latest_price );
+         price last_day_price = asset( itr->last_day_base, itr->base ) / asset( itr->last_day_quote, itr->quote );
+         result.percent_change = ( result.latest / price_to_real( last_day_price ) - 1 ) * 100;
       }
-
-      if( itr->time < yesterday )
+      if( assets[0]->id == itr->base )
       {
-         if( itr->op.fill_price != latest_price )
-            result.percent_change = ( result.latest / price_to_real( itr->op.fill_price ) - 1 ) * 100;
-         break;
+         base_volume = itr->base_volume;
+         quote_volume = itr->quote_volume;
       }
-
-      if( itr->op.is_maker )
+      else
       {
-         if( assets[0]->id == itr->op.receives.asset_id )
-         {
-            base_volume += itr->op.receives.amount.value;
-            quote_volume += itr->op.pays.amount.value;
-         }
-         else
-         {
-            base_volume += itr->op.pays.amount.value;
-            quote_volume += itr->op.receives.amount.value;
-         }
+         base_volume = itr->quote_volume;
+         quote_volume = itr->base_volume;
       }
-
-      ++itr;
    }
 
    auto uint128_to_double = []( const fc::uint128& n )
@@ -1242,9 +1224,12 @@ market_ticker database_api_impl::get_ticker( const string& base, const string& q
    result.base_volume = uint128_to_double( base_volume ) / pow( 10, assets[0]->precision );
    result.quote_volume = uint128_to_double( quote_volume ) / pow( 10, assets[1]->precision );
 
-   const auto orders = get_order_book( base, quote, 1 );
-   if( !orders.asks.empty() ) result.lowest_ask = orders.asks[0].price;
-   if( !orders.bids.empty() ) result.highest_bid = orders.bids[0].price;
+   if( !skip_order_book )
+   {
+      const auto orders = get_order_book( base, quote, 1 );
+      if( !orders.asks.empty() ) result.lowest_ask = orders.asks[0].price;
+      if( !orders.bids.empty() ) result.highest_bid = orders.bids[0].price;
+   }
 
    return result;
 }
@@ -1256,7 +1241,7 @@ market_volume database_api::get_24_volume( const string& base, const string& quo
 
 market_volume database_api_impl::get_24_volume( const string& base, const string& quote )const
 {
-    const auto& ticker = get_ticker( base, quote );
+    const auto& ticker = get_ticker( base, quote, true );
 
     market_volume result;
     result.time = ticker.time;

--- a/libraries/plugins/account_history/include/graphene/account_history/account_history_plugin.hpp
+++ b/libraries/plugins/account_history/include/graphene/account_history/account_history_plugin.hpp
@@ -47,13 +47,12 @@ namespace graphene { namespace account_history {
 // time.
 //
 #ifndef ACCOUNT_HISTORY_SPACE_ID
-#define ACCOUNT_HISTORY_SPACE_ID 5
+#define ACCOUNT_HISTORY_SPACE_ID 4
 #endif
 
 enum account_history_object_type
 {
-   key_account_object_type = 0,
-   bucket_object_type = 1 ///< used in market_history_plugin
+   key_account_object_type = 0
 };
 
 

--- a/libraries/plugins/market_history/include/graphene/market_history/market_history_plugin.hpp
+++ b/libraries/plugins/market_history/include/graphene/market_history/market_history_plugin.hpp
@@ -27,6 +27,7 @@
 #include <graphene/chain/database.hpp>
 
 #include <fc/thread/future.hpp>
+#include <fc/uint128.hpp>
 
 #include <boost/multi_index/composite_key.hpp>
 
@@ -43,9 +44,17 @@ using namespace chain;
 // various template automagic depends on them being known at compile
 // time.
 //
-#ifndef ACCOUNT_HISTORY_SPACE_ID
-#define ACCOUNT_HISTORY_SPACE_ID 5
+#ifndef MARKET_HISTORY_SPACE_ID
+#define MARKET_HISTORY_SPACE_ID 5
 #endif
+
+enum market_history_object_type
+{
+   order_history_object_type = 0,
+   bucket_object_type = 1,
+   market_ticker_object_type = 2,
+   market_ticker_meta_object_type = 3
+};
 
 struct bucket_key
 {
@@ -70,8 +79,8 @@ struct bucket_key
 
 struct bucket_object : public abstract_object<bucket_object>
 {
-   static const uint8_t space_id = ACCOUNT_HISTORY_SPACE_ID;
-   static const uint8_t type_id  = 1; // market_history_plugin type, referenced from account_history_plugin.hpp
+   static const uint8_t space_id = MARKET_HISTORY_SPACE_ID;
+   static const uint8_t type_id  = bucket_object_type;
 
    price high()const { return asset( high_base, key.base ) / asset( high_quote, key.quote ); }
    price low()const { return asset( low_base, key.base ) / asset( low_quote, key.quote ); }
@@ -103,9 +112,12 @@ struct history_key {
 };
 struct order_history_object : public abstract_object<order_history_object>
 {
-  history_key          key; 
-  fc::time_point_sec   time;
-  fill_order_operation op;
+   static const uint8_t space_id = MARKET_HISTORY_SPACE_ID;
+   static const uint8_t type_id  = order_history_object_type;
+
+   history_key          key;
+   fc::time_point_sec   time;
+   fill_order_operation op;
 };
 struct order_history_object_key_base_extractor
 {
@@ -121,6 +133,30 @@ struct order_history_object_key_sequence_extractor
 {
    typedef int64_t result_type;
    result_type operator()(const order_history_object& o)const { return o.key.sequence; }
+};
+
+struct market_ticker_object : public abstract_object<market_ticker_object>
+{
+   static const uint8_t space_id = MARKET_HISTORY_SPACE_ID;
+   static const uint8_t type_id  = market_ticker_object_type;
+
+   asset_id_type       base;
+   asset_id_type       quote;
+   share_type          last_day_base;
+   share_type          last_day_quote;
+   share_type          latest_base;
+   share_type          latest_quote;
+   fc::uint128         base_volume;
+   fc::uint128         quote_volume;
+};
+
+struct market_ticker_meta_object : public abstract_object<market_ticker_meta_object>
+{
+   static const uint8_t space_id = MARKET_HISTORY_SPACE_ID;
+   static const uint8_t type_id  = market_ticker_meta_object_type;
+
+   object_id_type      rolling_min_order_his_id;
+   bool                skip_min_order_his_id = false;
 };
 
 struct by_key;
@@ -157,9 +193,25 @@ typedef multi_index_container<
    >
 > order_history_multi_index_type;
 
+struct by_market;
+typedef multi_index_container<
+   market_ticker_object,
+   indexed_by<
+      ordered_unique< tag<by_id>, member< object, object_id_type, &object::id > >,
+      ordered_unique<
+         tag<by_market>,
+         composite_key<
+            market_ticker_object,
+            member<market_ticker_object, asset_id_type, &market_ticker_object::base>,
+            member<market_ticker_object, asset_id_type, &market_ticker_object::quote>
+         >
+      >
+   >
+> market_ticker_object_multi_index_type;
 
 typedef generic_index<bucket_object, bucket_object_multi_index_type> bucket_index;
 typedef generic_index<order_history_object, order_history_multi_index_type> history_index;
+typedef generic_index<market_ticker_object, market_ticker_object_multi_index_type> market_ticker_index;
 
 
 namespace detail
@@ -201,11 +253,17 @@ class market_history_plugin : public graphene::app::plugin
 FC_REFLECT( graphene::market_history::history_key, (base)(quote)(sequence) )
 FC_REFLECT_DERIVED( graphene::market_history::order_history_object, (graphene::db::object), (key)(time)(op) )
 FC_REFLECT( graphene::market_history::bucket_key, (base)(quote)(seconds)(open) )
-FC_REFLECT_DERIVED( graphene::market_history::bucket_object, (graphene::db::object), 
+FC_REFLECT_DERIVED( graphene::market_history::bucket_object, (graphene::db::object),
                     (key)
                     (high_base)(high_quote)
                     (low_base)(low_quote)
                     (open_base)(open_quote)
                     (close_base)(close_quote)
                     (base_volume)(quote_volume) )
-
+FC_REFLECT_DERIVED( graphene::market_history::market_ticker_object, (graphene::db::object),
+                    (base)(quote)
+                    (last_day_base)(last_day_quote)
+                    (latest_base)(latest_quote)
+                    (base_volume)(quote_volume) )
+FC_REFLECT_DERIVED( graphene::market_history::market_ticker_meta_object, (graphene::db::object),
+                    (rolling_min_order_his_id)(skip_min_order_his_id) )


### PR DESCRIPTION
PR for #509.

Benchmark:
* before change
```
$ time for n in {1..1000};do curl -d '{"id":1,"method":"call","params":["database","get_24_volume",["1.3.0","1.3.113"]]}' http://127.0.0.1:38380/ws >/dev/null 2>&1;done;echo

real    0m9.517s
user    0m3.020s
sys     0m1.408s
```
* after change:
```
$ time for n in {1..1000};do curl -d '{"id":1,"method":"call","params":["database","get_24_volume",["1.3.0","1.3.113"]]}' http://127.0.0.1:38480/ws >/dev/null 2>&1;done;echo

real    0m5.185s
user    0m2.852s
sys     0m1.404s
```

API query speed slightly increased.

By the way, it seems the overhead is quite high, even an empty query takes around 5 seconds to complete (1000 times). I'm not sure why.
```
$ time for n in {1..1000}; do curl -d '{}' http://127.0.0.1:38380/ws >/dev/null 2>&1;done
real    0m4.777s
user    0m2.968s
sys     0m1.300s
```