### PR TITLE
add version command to node

### DIFF
--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -58,6 +58,8 @@
 
 #include <boost/range/adaptor/reversed.hpp>
 
+#include <graphene/utilities/git_revision.hpp>
+
 namespace graphene { namespace app {
 using net::item_hash_t;
 using net::item_id;
@@ -943,6 +945,7 @@ void application::set_program_options(boost::program_options::options_descriptio
          ("resync-blockchain", "Delete all blocks and re-sync with network from scratch")
          ("force-validate", "Force validation of all transactions")
          ("genesis-timestamp", bpo::value<uint32_t>(), "Replace timestamp from genesis.json with current time plus this many seconds (experts only!)")
+         ("version", "Display version information")
          ;
    command_line_options.add(_cli_options);
    configuration_file_options.add(_cfg_options);
@@ -952,6 +955,14 @@ void application::initialize(const fc::path& data_dir, const boost::program_opti
 {
    my->_data_dir = data_dir;
    my->_options = &options;
+
+   if( options.count("version") )
+   {
+      std::cout << "Version: " << graphene::utilities::git_revision_description << "\n";
+      std::cout << "SHA: " << graphene::utilities::git_revision_sha << "\n";
+      std::cout << "Timestamp: " << fc::get_approximate_relative_time_string(fc::time_point_sec(graphene::utilities::git_revision_unix_timestamp)) << "\n";
+      std::exit(EXIT_SUCCESS);
+   }
 
    if( options.count("create-genesis-json") )
    {

--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -945,7 +945,7 @@ void application::set_program_options(boost::program_options::options_descriptio
          ("resync-blockchain", "Delete all blocks and re-sync with network from scratch")
          ("force-validate", "Force validation of all transactions")
          ("genesis-timestamp", bpo::value<uint32_t>(), "Replace timestamp from genesis.json with current time plus this many seconds (experts only!)")
-         ("version", "Display version information")
+         ("version,v", "Display version information")
          ;
    command_line_options.add(_cli_options);
    configuration_file_options.add(_cfg_options);

--- a/programs/cli_wallet/main.cpp
+++ b/programs/cli_wallet/main.cpp
@@ -50,6 +50,8 @@
 #include <fc/log/logger.hpp>
 #include <fc/log/logger_config.hpp>
 
+#include <graphene/utilities/git_revision.hpp>
+
 #ifdef WIN32
 # include <signal.h>
 #else
@@ -79,7 +81,9 @@ int main( int argc, char** argv )
          ("rpc-http-endpoint,H", bpo::value<string>()->implicit_value("127.0.0.1:8093"), "Endpoint for wallet HTTP RPC to listen on")
          ("daemon,d", "Run the wallet in daemon mode" )
          ("wallet-file,w", bpo::value<string>()->implicit_value("wallet.json"), "wallet to load")
-         ("chain-id", bpo::value<string>(), "chain ID to connect to");
+         ("chain-id", bpo::value<string>(), "chain ID to connect to")
+         ("version,v", "Display version information");
+
 
       bpo::variables_map options;
 
@@ -88,6 +92,13 @@ int main( int argc, char** argv )
       if( options.count("help") )
       {
          std::cout << opts << "\n";
+         return 0;
+      }
+      if( options.count("version") )
+      {
+         std::cout << "Version: " << graphene::utilities::git_revision_description << "\n";
+         std::cout << "SHA: " << graphene::utilities::git_revision_sha << "\n";
+         std::cout << "Timestamp: " << fc::get_approximate_relative_time_string(fc::time_point_sec(graphene::utilities::git_revision_unix_timestamp)) << "\n";
          return 0;
       }
 


### PR DESCRIPTION
https://github.com/bitshares/bitshares-core/issues/521

The pull add a `version` argument to the `witness_node executable`. Output will be like this:

```
$ ./programs/witness_node/witness_node --version
Version: 2.0.171025-minor-fix-1-98-gee06ec1
SHA: ee06ec19935a34cb52789245b8d29918f8fbae83
Timestamp: 10 hours ago
$ 
```

It was made with the utilities already in the core. I didnt added it to the `cli_wallet` because it haves an `about` command already displaying the info:

```
new >>> about
about
{
  "client_version": "2.0.171025-minor-fix-1-98-gee06ec1",
  "graphene_revision": "ee06ec19935a34cb52789245b8d29918f8fbae83",
  "graphene_revision_age": "10 hours ago",
  "fc_revision": "7cd9f1c7a43684c79dd5b4a7cebd23154b902877",
  "fc_revision_age": "27 days ago",
  "compile_date": "compiled on Dec 11 2017 at 16:23:22",
  "boost_version": "1.57",
  "openssl_version": "OpenSSL 1.0.2g  1 Mar 2016",
  "build": "linux 64-bit"
}
new >>> 
```

open to suggestions.