### PR TITLE
Asset claim pool operation

### DIFF
--- a/libraries/app/impacted.cpp
+++ b/libraries/app/impacted.cpp
@@ -43,6 +43,7 @@ struct get_impacted_account_visitor
    }
 
    void operator()( const asset_claim_fees_operation& op ){}
+   void operator()( const asset_claim_pool_operation& op ){}
    void operator()( const limit_order_create_operation& op ) {}
    void operator()( const limit_order_cancel_operation& op )
    {

--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -620,7 +620,7 @@ void_result asset_claim_pool_evaluator::do_evaluate( const asset_claim_pool_oper
 { try {
     FC_ASSERT( db().head_block_time() >= HARDFORK_CORE_188_TIME,
          "This operation is only available after Hardfork #188!" );
-    FC_ASSERT( o.asset_id(db()).issuer == o.issuer, "Asset fee pool withdrawal may only be claimed by the issuer" );
+    FC_ASSERT( o.asset_id(db()).issuer == o.issuer, "Asset fee pool may only be claimed by the issuer" );
 
     return void_result();
 } FC_CAPTURE_AND_RETHROW( (o) ) }

--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -633,7 +633,7 @@ void_result asset_claim_pool_evaluator::do_apply( const asset_claim_pool_operati
     const asset_dynamic_data_object& addo = a.dynamic_asset_data_id(d);
     FC_ASSERT( o.amount_to_claim.amount <= addo.fee_pool, "Attempt to claim more fees than is available", ("addo",addo) );
 
-    d.modify( addo, [&]( asset_dynamic_data_object& _addo  ) {
+    d.modify( addo, [&o]( asset_dynamic_data_object& _addo  ) {
         _addo.fee_pool -= o.amount_to_claim.amount;
     });
 

--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -592,7 +592,7 @@ void_result asset_publish_feeds_evaluator::do_apply(const asset_publish_feed_ope
 
 void_result asset_claim_fees_evaluator::do_evaluate( const asset_claim_fees_operation& o )
 { try {
-   FC_ASSERT( db().head_block_time() > HARDFORK_CORE_188_TIME );
+   FC_ASSERT( db().head_block_time() > HARDFORK_413_TIME );
    FC_ASSERT( o.amount_to_claim.asset_id(db()).issuer == o.issuer, "Asset fees may only be claimed by the issuer" );
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (o) ) }

--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -614,28 +614,28 @@ void_result asset_claim_fees_evaluator::do_apply( const asset_claim_fees_operati
 
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (o) ) }
-    
+
 
 void_result asset_claim_pool_evaluator::do_evaluate( const asset_claim_pool_operation& o )
 { try {
     FC_ASSERT( db().head_block_time() > HARDFORK_413_TIME );
     FC_ASSERT( o.asset_id(db()).issuer == o.issuer, "Asset fee pool withdrawal may only be claimed by the issuer" );
-    
+
     return void_result();
 } FC_CAPTURE_AND_RETHROW( (o) ) }
 
 void_result asset_claim_pool_evaluator::do_apply( const asset_claim_pool_operation& o )
 { try {
     database& d = db();
-    
+
     const asset_object& a = o.asset_id(d);
     const asset_dynamic_data_object& addo = a.dynamic_asset_data_id(d);
     FC_ASSERT( o.amount_to_claim.amount <= addo.fee_pool, "Attempt to claim more fees than is available", ("addo",addo) );
-    
+
     d.modify( addo, [&]( asset_dynamic_data_object& _addo  ) {
         _addo.fee_pool -= o.amount_to_claim.amount;
     });
-    
+
     d.adjust_balance( o.issuer, o.amount_to_claim );
 
     return void_result();

--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -618,7 +618,8 @@ void_result asset_claim_fees_evaluator::do_apply( const asset_claim_fees_operati
 
 void_result asset_claim_pool_evaluator::do_evaluate( const asset_claim_pool_operation& o )
 { try {
-    FC_ASSERT( db().head_block_time() > HARDFORK_CORE_188_TIME );
+    FC_ASSERT( db().head_block_time() >= HARDFORK_CORE_188_TIME,
+         "This operation is only available after Hardfork #188!" );
     FC_ASSERT( o.asset_id(db()).issuer == o.issuer, "Asset fee pool withdrawal may only be claimed by the issuer" );
 
     return void_result();

--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -614,6 +614,32 @@ void_result asset_claim_fees_evaluator::do_apply( const asset_claim_fees_operati
 
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (o) ) }
+    
+
+void_result asset_claim_pool_evaluator::do_evaluate( const asset_claim_pool_operation& o )
+{ try {
+    FC_ASSERT( db().head_block_time() > HARDFORK_413_TIME );
+    FC_ASSERT( o.asset_id(db()).issuer == o.issuer, "Asset fee pool withdrawal may only be claimed by the issuer" );
+    
+    return void_result();
+} FC_CAPTURE_AND_RETHROW( (o) ) }
+
+void_result asset_claim_pool_evaluator::do_apply( const asset_claim_pool_operation& o )
+{ try {
+    database& d = db();
+    
+    const asset_object& a = o.asset_id(d);
+    const asset_dynamic_data_object& addo = a.dynamic_asset_data_id(d);
+    FC_ASSERT( o.amount_to_claim.amount <= addo.fee_pool, "Attempt to claim more fees than is available", ("addo",addo) );
+    
+    d.modify( addo, [&]( asset_dynamic_data_object& _addo  ) {
+        _addo.fee_pool -= o.amount_to_claim.amount;
+    });
+    
+    d.adjust_balance( o.issuer, o.amount_to_claim );
+
+    return void_result();
+} FC_CAPTURE_AND_RETHROW( (o) ) }
 
 
 } } // graphene::chain

--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -592,7 +592,7 @@ void_result asset_publish_feeds_evaluator::do_apply(const asset_publish_feed_ope
 
 void_result asset_claim_fees_evaluator::do_evaluate( const asset_claim_fees_operation& o )
 { try {
-   FC_ASSERT( db().head_block_time() > HARDFORK_413_TIME );
+   FC_ASSERT( db().head_block_time() > HARDFORK_CORE_188_TIME );
    FC_ASSERT( o.amount_to_claim.asset_id(db()).issuer == o.issuer, "Asset fees may only be claimed by the issuer" );
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (o) ) }
@@ -618,7 +618,7 @@ void_result asset_claim_fees_evaluator::do_apply( const asset_claim_fees_operati
 
 void_result asset_claim_pool_evaluator::do_evaluate( const asset_claim_pool_operation& o )
 { try {
-    FC_ASSERT( db().head_block_time() > HARDFORK_413_TIME );
+    FC_ASSERT( db().head_block_time() > HARDFORK_CORE_188_TIME );
     FC_ASSERT( o.asset_id(db()).issuer == o.issuer, "Asset fee pool withdrawal may only be claimed by the issuer" );
 
     return void_result();

--- a/libraries/chain/db_init.cpp
+++ b/libraries/chain/db_init.cpp
@@ -172,6 +172,7 @@ void database::initialize_evaluators()
    register_evaluator<transfer_from_blind_evaluator>();
    register_evaluator<blind_transfer_evaluator>();
    register_evaluator<asset_claim_fees_evaluator>();
+   register_evaluator<asset_claim_pool_evaluator>();
 }
 
 void database::initialize_indexes()

--- a/libraries/chain/db_notify.cpp
+++ b/libraries/chain/db_notify.cpp
@@ -31,6 +31,7 @@ struct get_impacted_account_visitor
    }
 
    void operator()( const asset_claim_fees_operation& op ){}
+   void operator()( const asset_claim_pool_operation& op ){}
    void operator()( const limit_order_create_operation& op ) {}
    void operator()( const limit_order_cancel_operation& op )
    {

--- a/libraries/chain/hardfork.d/413.hf
+++ b/libraries/chain/hardfork.d/413.hf
@@ -1,0 +1,4 @@
+// #413 Add operation to claim asset fees
+#ifndef HARDFORK_413_TIME
+#define HARDFORK_413_TIME (fc::time_point_sec( 1446652800 ))
+#endif

--- a/libraries/chain/hardfork.d/413.hf
+++ b/libraries/chain/hardfork.d/413.hf
@@ -1,4 +1,0 @@
-// #413 Add operation to claim asset fees
-#ifndef HARDFORK_413_TIME
-#define HARDFORK_413_TIME (fc::time_point_sec( 1446652800 ))
-#endif

--- a/libraries/chain/hardfork.d/CORE_188.hf
+++ b/libraries/chain/hardfork.d/CORE_188.hf
@@ -1,4 +1,4 @@
-// #188 Add operation to allow claiming of funds in an asset's the fee pool
+// #188 Add operation to allow claiming of funds in an asset's fee pool
 #ifndef HARDFORK_CORE_188_TIME
 #define HARDFORK_CORE_188_TIME (fc::time_point_sec( 1446652800 ))
 #endif

--- a/libraries/chain/hardfork.d/CORE_188.hf
+++ b/libraries/chain/hardfork.d/CORE_188.hf
@@ -1,0 +1,4 @@
+// #413 Add operation to claim asset fees
+#ifndef HARDFORK_CORE_188_TIME
+#define HARDFORK_CORE_188_TIME (fc::time_point_sec( 1446652800 ))
+#endif

--- a/libraries/chain/hardfork.d/CORE_188.hf
+++ b/libraries/chain/hardfork.d/CORE_188.hf
@@ -1,4 +1,4 @@
 // #188 Add operation to allow claiming of funds in an asset's fee pool
 #ifndef HARDFORK_CORE_188_TIME
-#define HARDFORK_CORE_188_TIME (fc::time_point_sec( 1446652800 ))
+#define HARDFORK_CORE_188_TIME (fc::time_point_sec( 1600000000 ))
 #endif

--- a/libraries/chain/hardfork.d/CORE_188.hf
+++ b/libraries/chain/hardfork.d/CORE_188.hf
@@ -1,4 +1,4 @@
-// #413 Add operation to claim asset fees
+// #188 Add operation to allow claiming of funds in an asset's the fee pool
 #ifndef HARDFORK_CORE_188_TIME
 #define HARDFORK_CORE_188_TIME (fc::time_point_sec( 1446652800 ))
 #endif

--- a/libraries/chain/include/graphene/chain/asset_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/asset_evaluator.hpp
@@ -161,28 +161,6 @@ namespace graphene { namespace chain {
          void_result do_apply( const asset_claim_pool_operation& o );
    };
 
-   namespace impl { // TODO: remove after HARDFORK_CORE_429_TIME has passed
-      class hf_429_visitor {
-         public:
-            typedef void result_type;
-
-            template<typename T>
-            void operator()( const T& v )const {}
-
-            void operator()( const graphene::chain::bid_collateral_operation& v )const {
-               FC_ASSERT( false, "Not allowed until hardfork" );
-            }
-
-            void operator()( const graphene::chain::asset_create_operation& v )const {
-               FC_ASSERT( v.fee.asset_id == asset_id_type(), "Can only pay fee in BTS since block #21040000" );
-            }
-
-            void operator()( const graphene::chain::proposal_create_operation& v )const {
-               for( const op_wrapper& op : v.proposed_ops )
-                   op.op.visit( *this );
-            }
-      };
-
    namespace impl { // TODO: remove after HARDFORK_CORE_188_TIME has passed
       class hf_188_visitor {
          public:

--- a/libraries/chain/include/graphene/chain/asset_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/asset_evaluator.hpp
@@ -151,12 +151,12 @@ namespace graphene { namespace chain {
          void_result do_evaluate( const asset_claim_fees_operation& o );
          void_result do_apply( const asset_claim_fees_operation& o );
    };
-    
+
    class asset_claim_pool_evaluator : public evaluator<asset_claim_pool_evaluator>
    {
       public:
          typedef asset_claim_pool_operation operation_type;
-        
+
          void_result do_evaluate( const asset_claim_pool_operation& o );
          void_result do_apply( const asset_claim_pool_operation& o );
    };

--- a/libraries/chain/include/graphene/chain/asset_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/asset_evaluator.hpp
@@ -183,7 +183,8 @@ namespace graphene { namespace chain {
             }
       };
 
-      class hf_413_visitor {
+   namespace impl { // TODO: remove after HARDFORK_CORE_188_TIME has passed
+      class hf_188_visitor {
          public:
             typedef void result_type;
 
@@ -191,7 +192,7 @@ namespace graphene { namespace chain {
             void operator()( const T& v )const {}
 
             void operator()( const graphene::chain::asset_claim_fees_operation& v )const {
-               FC_ASSERT( false, "Not allowed until hardfork 413" );
+               FC_ASSERT( false, "Not allowed until hardfork 188" );
             }
 
             void operator()( const graphene::chain::proposal_create_operation& v )const {
@@ -200,4 +201,5 @@ namespace graphene { namespace chain {
             }
       };
    }
+
 } } // graphene::chain

--- a/libraries/chain/include/graphene/chain/asset_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/asset_evaluator.hpp
@@ -161,4 +161,22 @@ namespace graphene { namespace chain {
          void_result do_apply( const asset_claim_pool_operation& o );
    };
 
+   namespace impl { // TODO: remove after HARDFORK_413_TIME has passed
+      class hf_413_visitor {
+         public:
+            typedef void result_type;
+
+            template<typename T>
+            void operator()( const T& v )const {}
+
+            void operator()( const graphene::chain::asset_claim_fees_operation& v )const {
+               FC_ASSERT( false, "Not allowed until hardfork 413" );
+            }
+
+            void operator()( const graphene::chain::proposal_create_operation& v )const {
+               for( const op_wrapper& op : v.proposed_ops )
+                   op.op.visit( *this );
+            }
+      };
+   }
 } } // graphene::chain

--- a/libraries/chain/include/graphene/chain/asset_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/asset_evaluator.hpp
@@ -161,7 +161,28 @@ namespace graphene { namespace chain {
          void_result do_apply( const asset_claim_pool_operation& o );
    };
 
-   namespace impl { // TODO: remove after HARDFORK_413_TIME has passed
+   namespace impl { // TODO: remove after HARDFORK_CORE_429_TIME has passed
+      class hf_429_visitor {
+         public:
+            typedef void result_type;
+
+            template<typename T>
+            void operator()( const T& v )const {}
+
+            void operator()( const graphene::chain::bid_collateral_operation& v )const {
+               FC_ASSERT( false, "Not allowed until hardfork" );
+            }
+
+            void operator()( const graphene::chain::asset_create_operation& v )const {
+               FC_ASSERT( v.fee.asset_id == asset_id_type(), "Can only pay fee in BTS since block #21040000" );
+            }
+
+            void operator()( const graphene::chain::proposal_create_operation& v )const {
+               for( const op_wrapper& op : v.proposed_ops )
+                   op.op.visit( *this );
+            }
+      };
+
       class hf_413_visitor {
          public:
             typedef void result_type;

--- a/libraries/chain/include/graphene/chain/asset_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/asset_evaluator.hpp
@@ -151,5 +151,14 @@ namespace graphene { namespace chain {
          void_result do_evaluate( const asset_claim_fees_operation& o );
          void_result do_apply( const asset_claim_fees_operation& o );
    };
+    
+   class asset_claim_pool_evaluator : public evaluator<asset_claim_pool_evaluator>
+   {
+      public:
+         typedef asset_claim_pool_operation operation_type;
+        
+         void_result do_evaluate( const asset_claim_pool_operation& o );
+         void_result do_apply( const asset_claim_pool_operation& o );
+   };
 
 } } // graphene::chain

--- a/libraries/chain/include/graphene/chain/asset_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/asset_evaluator.hpp
@@ -191,7 +191,7 @@ namespace graphene { namespace chain {
             template<typename T>
             void operator()( const T& v )const {}
 
-            void operator()( const graphene::chain::asset_claim_fees_operation& v )const {
+            void operator()( const graphene::chain::asset_claim_pool_operation& v )const {
                FC_ASSERT( false, "Not allowed until hardfork 188" );
             }
 

--- a/libraries/chain/include/graphene/chain/proposal_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/proposal_evaluator.hpp
@@ -27,6 +27,8 @@
 #include <graphene/chain/evaluator.hpp>
 #include <graphene/chain/database.hpp>
 #include <graphene/chain/transaction_evaluation_state.hpp>
+#include <graphene/chain/asset_evaluator.hpp>
+#include <graphene/chain/hardfork.hpp>
 
 namespace graphene { namespace chain {
 

--- a/libraries/chain/include/graphene/chain/protocol/asset_ops.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/asset_ops.hpp
@@ -444,13 +444,13 @@ namespace graphene { namespace chain {
 
    /**
     * @brief Transfers BTS from the fee pool of a specified asset back to the issuer's balance
-    
+
     * @param fee Payment for the operation execution
     * @param issuer Account which will be used for transfering BTS
     * @param asset_id Id of the asset whose fee pool is going to be drained
     * @param amount_to_claim Amount of BTS to claim from the fee pool
     * @param extensions Field for future expansion
-    
+
     * @pre @ref fee must be paid in the asset other than the one whose pool is being drained
     * @pre @ref amount_to_claim should be specified in the core asset
     * @pre @ref amount_to_claim should be nonnegative
@@ -460,13 +460,13 @@ namespace graphene { namespace chain {
       struct fee_parameters_type {
          uint64_t fee = 20 * GRAPHENE_BLOCKCHAIN_PRECISION;
       };
-        
+
       asset           fee;
       account_id_type issuer;
       asset_id_type   asset_id;        /// fee.asset_id must != asset_id
       asset           amount_to_claim; /// core asset
       extensions_type extensions;
-        
+
       account_id_type fee_payer()const { return issuer; }
       void            validate()const;
    };

--- a/libraries/chain/include/graphene/chain/protocol/asset_ops.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/asset_ops.hpp
@@ -442,11 +442,42 @@ namespace graphene { namespace chain {
       void            validate()const;
    };
 
+   /**
+    * @brief Transfers BTS from the fee pool of a specified asset back to the issuer's balance
+    
+    * @param fee Payment for the operation execution
+    * @param issuer Account which will be used for transfering BTS
+    * @param asset_id Id of the asset whose fee pool is going to be drained
+    * @param amount_to_claim Amount of BTS to claim from the fee pool
+    * @param extensions Field for future expansion
+    
+    * @pre @ref fee must be paid in the asset other than the one whose pool is being drained
+    * @pre @ref amount_to_claim should be specified in the core asset
+    * @pre @ref amount_to_claim should be nonnegative
+    */
+   struct asset_claim_pool_operation : public base_operation
+   {
+      struct fee_parameters_type {
+         uint64_t fee = 20 * GRAPHENE_BLOCKCHAIN_PRECISION;
+      };
+        
+      asset           fee;
+      account_id_type issuer;
+      asset_id_type   asset_id;        /// fee.asset_id must != asset_id
+      asset           amount_to_claim; /// core asset
+      extensions_type extensions;
+        
+      account_id_type fee_payer()const { return issuer; }
+      void            validate()const;
+   };
+
 
 } } // graphene::chain
 
 FC_REFLECT( graphene::chain::asset_claim_fees_operation, (fee)(issuer)(amount_to_claim)(extensions) )
 FC_REFLECT( graphene::chain::asset_claim_fees_operation::fee_parameters_type, (fee) )
+FC_REFLECT( graphene::chain::asset_claim_pool_operation, (fee)(issuer)(asset_id)(amount_to_claim)(extensions) )
+FC_REFLECT( graphene::chain::asset_claim_pool_operation::fee_parameters_type, (fee) )
 
 FC_REFLECT( graphene::chain::asset_options,
             (max_supply)

--- a/libraries/chain/include/graphene/chain/protocol/fee_schedule.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/fee_schedule.hpp
@@ -77,6 +77,21 @@ namespace graphene { namespace chain {
       }
    };
 
+   template<>
+   class fee_helper<asset_claim_pool_operation> {
+     public:
+      const asset_claim_pool_operation::fee_parameters_type& cget(const flat_set<fee_parameters>& parameters)const
+      {
+         auto itr = parameters.find( asset_claim_pool_operation::fee_parameters_type() );
+         if ( itr != parameters.end() )
+            return itr->get<asset_claim_pool_operation::fee_parameters_type>();
+
+         static asset_claim_pool_operation::fee_parameters_type asset_claim_pool_dummy;
+         asset_claim_pool_dummy.fee = fee_helper<asset_fund_fee_pool_operation>().cget(parameters).fee;
+         return asset_claim_pool_dummy;
+      }
+   };
+
    /**
     *  @brief contains all of the parameters necessary to calculate the fee for any operation
     */

--- a/libraries/chain/include/graphene/chain/protocol/operations.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/operations.hpp
@@ -93,7 +93,8 @@ namespace graphene { namespace chain {
             asset_claim_fees_operation,
             fba_distribute_operation,       // VIRTUAL
             bid_collateral_operation,
-            execute_bid_operation           // VIRTUAL
+            execute_bid_operation,          // VIRTUAL
+            asset_claim_pool_operation
          > operation;
 
    /// @} // operations group

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -26,6 +26,8 @@
 #include <graphene/chain/account_object.hpp>
 #include <graphene/chain/protocol/fee_schedule.hpp>
 #include <graphene/chain/exceptions.hpp>
+#include <graphene/chain/asset_evaluator.hpp>
+
 
 #include <fc/smart_ref_impl.hpp>
 
@@ -74,6 +76,12 @@ void_result proposal_create_evaluator::do_evaluate(const proposal_create_operati
    for( const op_wrapper& op : o.proposed_ops )
       _proposed_trx.operations.push_back(op.op);
    _proposed_trx.validate();
+
+   if( d.head_block_time() <= HARDFORK_413_TIME )
+   { // TODO: remove after HARDFORK_413_TIME has passed
+      graphene::chain::impl::hf_413_visitor hf_413;
+      hf_413( o );
+   }
 
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (o) ) }

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -85,7 +85,7 @@ void_result proposal_create_evaluator::do_evaluate(const proposal_create_operati
 
    if( d.head_block_time() <= HARDFORK_CORE_188_TIME )
    { // TODO: remove after HARDFORK_CORE_188_TIME has passed
-      graphene::chain::impl::hf_413_visitor hf_413;
+      graphene::chain::impl::hf_188_visitor hf_413;
       hf_413( o );
    }
 

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -77,8 +77,14 @@ void_result proposal_create_evaluator::do_evaluate(const proposal_create_operati
       _proposed_trx.operations.push_back(op.op);
    _proposed_trx.validate();
 
-   if( d.head_block_time() <= HARDFORK_413_TIME )
-   { // TODO: remove after HARDFORK_413_TIME has passed
+   if( d.head_block_time() <= HARDFORK_CORE_429_TIME )
+   { // TODO: remove after HARDFORK_CORE_429_TIME has passed
+      graphene::chain::impl::hf_429_visitor hf_429;
+      hf_429( o );
+   }
+
+   if( d.head_block_time() <= HARDFORK_CORE_188_TIME )
+   { // TODO: remove after HARDFORK_CORE_188_TIME has passed
       graphene::chain::impl::hf_413_visitor hf_413;
       hf_413( o );
    }

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -77,13 +77,7 @@ void_result proposal_create_evaluator::do_evaluate(const proposal_create_operati
       _proposed_trx.operations.push_back(op.op);
    _proposed_trx.validate();
 
-   if( d.head_block_time() <= HARDFORK_CORE_429_TIME )
-   { // TODO: remove after HARDFORK_CORE_429_TIME has passed
-      graphene::chain::impl::hf_429_visitor hf_429;
-      hf_429( o );
-   }
-
-   if( d.head_block_time() <= HARDFORK_CORE_188_TIME )
+   if( d.head_block_time() < HARDFORK_CORE_188_TIME )
    { // TODO: remove after HARDFORK_CORE_188_TIME has passed
       graphene::chain::impl::hf_188_visitor hf_188;
       hf_188( o );

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -85,8 +85,8 @@ void_result proposal_create_evaluator::do_evaluate(const proposal_create_operati
 
    if( d.head_block_time() <= HARDFORK_CORE_188_TIME )
    { // TODO: remove after HARDFORK_CORE_188_TIME has passed
-      graphene::chain::impl::hf_188_visitor hf_413;
-      hf_413( o );
+      graphene::chain::impl::hf_188_visitor hf_188;
+      hf_188( o );
    }
 
    return void_result();

--- a/libraries/chain/protocol/asset_ops.cpp
+++ b/libraries/chain/protocol/asset_ops.cpp
@@ -233,7 +233,7 @@ void asset_claim_fees_operation::validate()const {
    FC_ASSERT( fee.amount >= 0 );
    FC_ASSERT( amount_to_claim.amount > 0 );
 }
-    
+
 void asset_claim_pool_operation::validate()const {
    FC_ASSERT( fee.amount >= 0 );
    FC_ASSERT( fee.asset_id != asset_id);

--- a/libraries/chain/protocol/asset_ops.cpp
+++ b/libraries/chain/protocol/asset_ops.cpp
@@ -233,5 +233,12 @@ void asset_claim_fees_operation::validate()const {
    FC_ASSERT( fee.amount >= 0 );
    FC_ASSERT( amount_to_claim.amount > 0 );
 }
+    
+void asset_claim_pool_operation::validate()const {
+   FC_ASSERT( fee.amount >= 0 );
+   FC_ASSERT( fee.asset_id != asset_id);
+   FC_ASSERT( amount_to_claim.amount > 0 );
+   FC_ASSERT( amount_to_claim.asset_id == asset_id_type());
+}
 
 } } // namespace graphene::chain

--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -1113,6 +1113,23 @@ class wallet_api
                                              string amount,
                                              bool broadcast = false);
 
+      /** Claim funds from the fee pool for the given asset.
+       *
+       * User-issued assets can optionally have a pool of the core asset which is 
+       * automatically used to pay transaction fees for any transaction using that
+       * asset (using the asset's core exchange rate).
+       *
+       * This command allows the issuer to withdraw those funds from the fee pool.
+       *
+       * @param symbol the name or id of the asset whose fee pool you wish to fund
+       * @param amount the amount of the core asset to withdraw
+       * @param broadcast true to broadcast the transaction on the network
+       * @returns the signed transaction funding the fee pool
+       */
+      signed_transaction claim_asset_fee_pool(string symbol,
+                                              string amount,
+                                              bool broadcast = false);
+
       /** Burns the given user-issued asset.
        *
        * This command burns the user-issued asset to reduce the amount in circulation.
@@ -1663,6 +1680,7 @@ FC_API( graphene::wallet::wallet_api,
         (get_asset)
         (get_bitasset_data)
         (fund_asset_fee_pool)
+        (claim_asset_fee_pool)
         (reserve_asset)
         (global_settle_asset)
         (settle_asset)

--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -1121,10 +1121,10 @@ class wallet_api
        *
        * This command allows the issuer to withdraw those funds from the fee pool.
        *
-       * @param symbol the name or id of the asset whose fee pool you wish to fund
+       * @param symbol the name or id of the asset whose fee pool you wish to claim
        * @param amount the amount of the core asset to withdraw
        * @param broadcast true to broadcast the transaction on the network
-       * @returns the signed transaction funding the fee pool
+       * @returns the signed transaction claiming from the fee pool
        */
       signed_transaction claim_asset_fee_pool(string symbol,
                                               string amount,

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -1273,14 +1273,14 @@ public:
                                            string amount,
                                            bool broadcast /* = false */)
    { try {
-      optional<asset_object> asset_to_fund = find_asset(symbol);
-      if (!asset_to_fund)
+      optional<asset_object> asset_pool_to_claim = find_asset(symbol);
+      if (!asset_pool_to_claim)
         FC_THROW("No asset with that symbol exists!");
       asset_object core_asset = get_asset(asset_id_type());
 
       asset_claim_pool_operation claim_op;
-      claim_op.issuer = asset_to_fund->issuer;
-      claim_op.asset_id = asset_to_fund->id;
+      claim_op.issuer = asset_pool_to_claim->issuer;
+      claim_op.asset_id = asset_pool_to_claim->id;
       claim_op.amount_to_claim = core_asset.amount_from_string(amount).amount;
 
       signed_transaction tx;

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -897,6 +897,7 @@ void database_fixture::fund_fee_pool( const account_object& from, const asset_ob
 
    for( auto& op : trx.operations ) db.current_fee_schedule().set_fee(op);
    trx.validate();
+   set_expiration( db, trx );
    db.push_transaction(trx, ~0);
    trx.operations.clear();
    verify_asset_supplies(db);

--- a/tests/tests/fee_tests.cpp
+++ b/tests/tests/fee_tests.cpp
@@ -231,6 +231,9 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
 
         const asset_object& alicecoin = create_user_issued_asset( "ALICECOIN", alice,  0 );
         const asset_object& aliceusd = create_user_issued_asset( "ALICEUSD", alice, 0 );
+
+        asset_id_type alicecoin_id = alicecoin.id;
+        asset_id_type aliceusd_id = aliceusd.id;
         asset_id_type bobcoin_id = create_user_issued_asset( "BOBCOIN", bob, 0).id;
 
         // prepare users' balance
@@ -286,49 +289,49 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
         const asset_object& core_asset = asset_id_type()(db);
 
         // deposit 100 BTS to the fee pool of ALICEUSD asset
-        fund_fee_pool( alice_id(db), aliceusd, _core(100).amount );
+        fund_fee_pool( alice, aliceusd_id(db), _core(100).amount );
 
         // Unable to claim pool before the hardfork
-        GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, aliceusd.id, _core(1), core_asset), fc::exception );
-        GRAPHENE_REQUIRE_THROW( claim_pool_proposal( alice_id, aliceusd.id, _core(1), core_asset), fc::exception );
+        GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, aliceusd_id, _core(1), core_asset), fc::exception );
+        GRAPHENE_REQUIRE_THROW( claim_pool_proposal( alice_id, aliceusd_id, _core(1), core_asset), fc::exception );
 
         // Fast forward to hard fork date
         generate_blocks( HARDFORK_CORE_188_TIME );
 
         // can't claim pool because it is empty
-        GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, alicecoin.id, _core(1), core_asset), fc::exception );
+        GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, alicecoin_id, _core(1), core_asset), fc::exception );
 
         // deposit 300 BTS to the fee pool of ALICECOIN asset
-        fund_fee_pool( alice_id(db), alicecoin, _core(300).amount );
+        fund_fee_pool( alice, alicecoin_id(db), _core(300).amount );
 
         // Test amount of CORE in fee pools
-        BOOST_CHECK( alicecoin.dynamic_asset_data_id(db).fee_pool.value == _core(300).amount );
-        BOOST_CHECK( aliceusd.dynamic_asset_data_id(db).fee_pool.value == _core(100).amount );
+        BOOST_CHECK( alicecoin_id(db).dynamic_asset_data_id(db).fee_pool == _core(300).amount );
+        BOOST_CHECK( aliceusd_id(db).dynamic_asset_data_id(db).fee_pool == _core(100).amount );
 
         // can't claim pool of an asset that doesn't belong to you
         GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, bobcoin_id, _core(200), core_asset), fc::exception );
 
         // can't claim more than is available in the fee pool
-        GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, alicecoin.id, _core(400), core_asset ), fc::exception );
+        GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, alicecoin_id, _core(400), core_asset ), fc::exception );
 
         // can't pay fee in the same asset whose pool is being drained
-        GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, alicecoin.id, _core(200), alicecoin ), fc::exception );
+        GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, alicecoin_id, _core(200), alicecoin_id(db) ), fc::exception );
 
         // can claim BTS back from the fee pool
-        claim_pool( alice_id, alicecoin.id, _core(200), core_asset );
-        BOOST_CHECK( alicecoin.dynamic_asset_data_id(db).fee_pool == _core(100).amount );
+        claim_pool( alice_id, alicecoin_id, _core(200), core_asset );
+        BOOST_CHECK( alicecoin_id(db).dynamic_asset_data_id(db).fee_pool == _core(100).amount );
 
         // can pay fee in the asset other than the one whose pool is being drained
         share_type balance_before_claim = get_balance( alice_id, asset_id_type() );
-        claim_pool( alice_id, alicecoin.id, _core(100), aliceusd );
-        BOOST_CHECK( alicecoin.dynamic_asset_data_id(db).fee_pool == _core(0).amount );
+        claim_pool( alice_id, alicecoin_id, _core(100), aliceusd_id(db) );
+        BOOST_CHECK( alicecoin_id(db).dynamic_asset_data_id(db).fee_pool == _core(0).amount );
 
         //check balance after claiming pool
         share_type current_balance = get_balance( alice_id, asset_id_type() );
         BOOST_CHECK( balance_before_claim + _core(100).amount == current_balance );
 
-        // can claim pool with a proposal after hard fork
-        claim_pool_proposal( alice_id, aliceusd.id, _core(1), core_asset);
+        // can create a proposal to claim claim pool after hard fork
+        claim_pool_proposal( alice_id, aliceusd_id, _core(1), core_asset)
     }
     FC_LOG_AND_RETHROW()
 }

--- a/tests/tests/fee_tests.cpp
+++ b/tests/tests/fee_tests.cpp
@@ -213,6 +213,87 @@ BOOST_AUTO_TEST_CASE(asset_claim_fees_test)
    FC_LOG_AND_RETHROW()
 }
 
+BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
+{
+    try
+    {
+        ACTORS((alice)(bob));
+        // Alice and Bob create some user issued assets
+        // Alice deposits BTS to the fee pool
+        // Alice claimes fee pool of her asset and can't claim pool of Bob's asset
+        
+        const share_type core_prec = asset::scaled_precision( asset_id_type()(db).precision );
+        
+        // return number of core shares (times precision)
+        auto _core = [&core_prec]( int64_t x ) -> asset
+        {  return asset( x*core_prec );    };
+        
+        const asset_object& alicecoin = create_user_issued_asset( "ALICECOIN", alice,  0 );
+        const asset_object& aliceusd = create_user_issued_asset( "ALICEUSD", alice, 0 );
+        asset_id_type bobcoin_id = create_user_issued_asset( "BOBCOIN", bob, 0).id;
+        
+        // prepare users' balance
+        issue_uia( alice, aliceusd.amount( 20000000 ) );
+        issue_uia( alice, alicecoin.amount( 10000000 ) );
+        
+        transfer( committee_account, alice_id, _core(1000) );
+        transfer( committee_account, bob_id, _core(1000) );
+        
+        enable_fees();
+        
+        auto claim_pool = [&]( const account_id_type& issuer, const asset_id_type& asset_to_claim,
+                              const asset& amount_to_fund, const asset_object& fee_asset  )
+        {
+            asset_claim_pool_operation claim_op;
+            claim_op.issuer = issuer;
+            claim_op.asset_id = asset_to_claim;
+            claim_op.amount_to_claim = amount_to_fund;
+            
+            signed_transaction tx;
+            tx.operations.push_back( claim_op );
+            db.current_fee_schedule().set_fee( tx.operations.back(), fee_asset.options.core_exchange_rate );
+            set_expiration( db, tx );
+            sign( tx, alice_private_key );
+            PUSH_TX( db, tx );
+
+        };
+        
+        // deposit 300 BTS to the fee pool of ALICECOIN asset
+        fund_fee_pool( alice, alicecoin, _core(300).amount );
+        
+        // deposit 100 BTS to the fee pool of ALICEUSD asset
+        fund_fee_pool( alice, aliceusd, _core(100).amount );
+
+        BOOST_CHECK( alicecoin.dynamic_asset_data_id(db).fee_pool == _core(300).amount );
+        
+        const asset_object& core_asset = asset_id_type()(db);
+
+        // can't claim pool of an asset that doesn't belong to you
+        GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, bobcoin_id, _core(200), core_asset), fc::exception );
+        
+        // can't claim more than is available in the fee pool
+        GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, alicecoin.id, _core(400), core_asset ), fc::exception );
+        
+        // can't pay fee in the same asset whose pool is being drained
+        GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, alicecoin.id, _core(200), alicecoin ), fc::exception );
+        
+        // can claim BTS back from the fee pool
+        claim_pool( alice_id, alicecoin.id, _core(200), core_asset );
+        BOOST_CHECK( alicecoin.dynamic_asset_data_id(db).fee_pool == _core(100).amount );
+        
+        // can pay fee in the asset other than the one whose pool is being drained
+        share_type balance_before_claim = get_balance( alice_id, asset_id_type() );
+        claim_pool( alice_id, alicecoin.id, _core(100), aliceusd );
+        BOOST_CHECK( alicecoin.dynamic_asset_data_id(db).fee_pool == _core(0).amount );
+        
+        //check balance after claiming pool
+        share_type current_balance = get_balance( alice_id, asset_id_type() );
+        BOOST_CHECK( balance_before_claim + _core(100).amount == current_balance );
+        
+    }
+    FC_LOG_AND_RETHROW()
+}
+
 ///////////////////////////////////////////////////////////////
 // cashback_test infrastructure                              //
 ///////////////////////////////////////////////////////////////
@@ -947,7 +1028,7 @@ BOOST_AUTO_TEST_CASE( stealth_fba_test )
 BOOST_AUTO_TEST_CASE( defaults_test )
 { try {
     fee_schedule schedule;
-    const limit_order_create_operation::fee_parameters_type default_order_fee;
+    const limit_order_create_operation::fee_parameters_type default_order_fee {};
 
     // no fees set yet -> default
     asset fee = schedule.calculate_fee( limit_order_create_operation() );
@@ -961,7 +1042,7 @@ BOOST_AUTO_TEST_CASE( defaults_test )
 
     // bid_collateral fee defaults to call_order_update fee
     // call_order_update fee is unset -> default
-    const call_order_update_operation::fee_parameters_type default_short_fee;
+    const call_order_update_operation::fee_parameters_type default_short_fee {};
     call_order_update_operation::fee_parameters_type new_short_fee; new_short_fee.fee = 123;
     fee = schedule.calculate_fee( bid_collateral_operation() );
     BOOST_CHECK_EQUAL( default_short_fee.fee, fee.amount.value );

--- a/tests/tests/fee_tests.cpp
+++ b/tests/tests/fee_tests.cpp
@@ -262,7 +262,7 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
 
         };
 
-        auto claim_pool_proposal = [&]( const account_id_type& issuer, const asset_id_type& asset_to_claim,
+        auto claim_pool_proposal = [&]( const account_id_type issuer, const asset_id_type asset_to_claim,
                                         const asset& amount_to_fund, const asset_object& fee_asset  )
         {
             asset_claim_pool_operation claim_op;
@@ -299,8 +299,11 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
         // Fast forward to hard fork date
         generate_blocks( HARDFORK_CORE_188_TIME );
 
+        // New reference for core_asset after having produced blocks
+        const asset_object& core_asset_hf = asset_id_type()(db);
+
         // can't claim pool because it is empty
-        GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, alicecoin_id, _core(1), core_asset), fc::exception );
+        GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, alicecoin_id, _core(1), core_asset_hf), fc::exception );
 
         // deposit 300 BTS to the fee pool of ALICECOIN asset
         fund_fee_pool( alice_id(db), alicecoin_id(db), _core(300).amount );
@@ -310,16 +313,16 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
         BOOST_CHECK( aliceusd_id(db).dynamic_asset_data_id(db).fee_pool == _core(100).amount );
 
         // can't claim pool of an asset that doesn't belong to you
-        GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, bobcoin_id, _core(200), core_asset), fc::exception );
+        GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, bobcoin_id, _core(200), core_asset_hf), fc::exception );
 
         // can't claim more than is available in the fee pool
-        GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, alicecoin_id, _core(400), core_asset ), fc::exception );
+        GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, alicecoin_id, _core(400), core_asset_hf ), fc::exception );
 
         // can't pay fee in the same asset whose pool is being drained
         GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, alicecoin_id, _core(200), alicecoin_id(db) ), fc::exception );
 
         // can claim BTS back from the fee pool
-        claim_pool( alice_id, alicecoin_id, _core(200), core_asset );
+        claim_pool( alice_id, alicecoin_id, _core(200), core_asset_hf );
         BOOST_CHECK( alicecoin_id(db).dynamic_asset_data_id(db).fee_pool == _core(100).amount );
 
         // can pay fee in the asset other than the one whose pool is being drained
@@ -332,7 +335,7 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
         BOOST_CHECK( balance_before_claim + _core(100).amount == current_balance );
 
         // can create a proposal to claim claim pool after hard fork
-        claim_pool_proposal( alice_id, aliceusd_id, _core(1), core_asset);
+        claim_pool_proposal( alice_id, aliceusd_id, _core(1), core_asset_hf);
     }
     FC_LOG_AND_RETHROW()
 }

--- a/tests/tests/fee_tests.cpp
+++ b/tests/tests/fee_tests.cpp
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
         const asset_object& core_asset = asset_id_type()(db);
 
         // deposit 100 BTS to the fee pool of ALICEUSD asset
-        fund_fee_pool( alice, aliceusd, _core(100).amount );
+        fund_fee_pool( alice_id(db), aliceusd, _core(100).amount );
 
         // Unable to claim pool before the hardfork
         GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, aliceusd.id, _core(1), core_asset), fc::exception );
@@ -299,11 +299,11 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
         GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, alicecoin.id, _core(1), core_asset), fc::exception );
 
         // deposit 300 BTS to the fee pool of ALICECOIN asset
-        fund_fee_pool( alice, alicecoin, _core(300).amount );
+        fund_fee_pool( alice_id(db), alicecoin, _core(300).amount );
 
         // Test amount of CORE in fee pools
-        BOOST_CHECK( alicecoin.dynamic_asset_data_id(db).fee_pool == _core(300).amount );
-        BOOST_CHECK( aliceusd.dynamic_asset_data_id(db).fee_pool == _core(100).amount );
+        BOOST_CHECK( alicecoin.dynamic_asset_data_id(db).fee_pool.value == _core(300).amount );
+        BOOST_CHECK( aliceusd.dynamic_asset_data_id(db).fee_pool.value == _core(100).amount );
 
         // can't claim pool of an asset that doesn't belong to you
         GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, bobcoin_id, _core(200), core_asset), fc::exception );

--- a/tests/tests/fee_tests.cpp
+++ b/tests/tests/fee_tests.cpp
@@ -174,12 +174,12 @@ BOOST_AUTO_TEST_CASE(asset_claim_fees_test)
 
       }
 
-      if( db.head_block_time() <= HARDFORK_CORE_188_TIME )
+      if( db.head_block_time() <= HARDFORK_413_TIME )
       {
          // can't claim before hardfork
          GRAPHENE_REQUIRE_THROW( claim_fees( izzy_id, _izzy(1) ), fc::exception );
-         generate_blocks( HARDFORK_CORE_188_TIME );
-         while( db.head_block_time() <= HARDFORK_CORE_188_TIME )
+         generate_blocks( HARDFORK_413_TIME );
+         while( db.head_block_time() <= HARDFORK_413_TIME )
          {
             generate_block();
          }
@@ -258,6 +258,21 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
 
         };
 
+        const asset_object& core_asset = asset_id_type()(db);
+
+        if( db.head_block_time() <= HARDFORK_CORE_188_TIME )
+        {
+           // can't claim pool before hardfork
+           GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, bobcoin_id, _core(200), core_asset), fc::exception );
+
+           generate_blocks( HARDFORK_CORE_188_TIME );
+           while( db.head_block_time() <= HARDFORK_CORE_188_TIME )
+           {
+              generate_block();
+           }
+        }
+
+
         // deposit 300 BTS to the fee pool of ALICECOIN asset
         fund_fee_pool( alice, alicecoin, _core(300).amount );
 
@@ -265,8 +280,6 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
         fund_fee_pool( alice, aliceusd, _core(100).amount );
 
         BOOST_CHECK( alicecoin.dynamic_asset_data_id(db).fee_pool == _core(300).amount );
-
-        const asset_object& core_asset = asset_id_type()(db);
 
         // can't claim pool of an asset that doesn't belong to you
         GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, bobcoin_id, _core(200), core_asset), fc::exception );

--- a/tests/tests/fee_tests.cpp
+++ b/tests/tests/fee_tests.cpp
@@ -263,7 +263,7 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
         if( db.head_block_time() <= HARDFORK_CORE_188_TIME )
         {
            // can't claim pool before hardfork
-           GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, bobcoin_id, _core(200), core_asset), fc::exception );
+           GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, aliceusd.id, _core(200), core_asset), fc::exception );
 
            generate_blocks( HARDFORK_CORE_188_TIME );
            while( db.head_block_time() <= HARDFORK_CORE_188_TIME )
@@ -272,6 +272,8 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
            }
         }
 
+        // can't claim pool because it is empty
+        GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, aliceusd.id, _core(1), core_asset), fc::exception );
 
         // deposit 300 BTS to the fee pool of ALICECOIN asset
         fund_fee_pool( alice, alicecoin, _core(300).amount );

--- a/tests/tests/fee_tests.cpp
+++ b/tests/tests/fee_tests.cpp
@@ -327,6 +327,8 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
         share_type current_balance = get_balance( alice_id, asset_id_type() );
         BOOST_CHECK( balance_before_claim + _core(100).amount == current_balance );
 
+        // can claim pool with a proposal after hard fork
+        claim_pool_proposal( alice_id, aliceusd.id, _core(1), core_asset);
     }
     FC_LOG_AND_RETHROW()
 }

--- a/tests/tests/fee_tests.cpp
+++ b/tests/tests/fee_tests.cpp
@@ -331,7 +331,7 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
         BOOST_CHECK( balance_before_claim + _core(100).amount == current_balance );
 
         // can create a proposal to claim claim pool after hard fork
-        claim_pool_proposal( alice_id, aliceusd_id, _core(1), core_asset)
+        claim_pool_proposal( alice_id, aliceusd_id, _core(1), core_asset);
     }
     FC_LOG_AND_RETHROW()
 }

--- a/tests/tests/fee_tests.cpp
+++ b/tests/tests/fee_tests.cpp
@@ -270,7 +270,8 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
             claim_op.asset_id = asset_to_claim;
             claim_op.amount_to_claim = amount_to_fund;
 
-            const auto proposal_create_fees = fees.get<proposal_create_operation>();
+            const auto& curfees = *db.get_global_properties().parameters.current_fees;
+            const auto& proposal_create_fees = curfees.get<proposal_create_operation>();
             proposal_create_operation prop;
             prop.fee_paying_account = alice_id;
             prop.proposed_ops.emplace_back( claim_op );
@@ -289,7 +290,7 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
         const asset_object& core_asset = asset_id_type()(db);
 
         // deposit 100 BTS to the fee pool of ALICEUSD asset
-        fund_fee_pool( alice, aliceusd_id(db), _core(100).amount );
+        fund_fee_pool( alice_id(db), aliceusd_id(db), _core(100).amount );
 
         // Unable to claim pool before the hardfork
         GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, aliceusd_id, _core(1), core_asset), fc::exception );
@@ -302,7 +303,7 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
         GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, alicecoin_id, _core(1), core_asset), fc::exception );
 
         // deposit 300 BTS to the fee pool of ALICECOIN asset
-        fund_fee_pool( alice, alicecoin_id(db), _core(300).amount );
+        fund_fee_pool( alice_id(db), alicecoin_id(db), _core(300).amount );
 
         // Test amount of CORE in fee pools
         BOOST_CHECK( alicecoin_id(db).dynamic_asset_data_id(db).fee_pool == _core(300).amount );

--- a/tests/tests/fee_tests.cpp
+++ b/tests/tests/fee_tests.cpp
@@ -174,12 +174,12 @@ BOOST_AUTO_TEST_CASE(asset_claim_fees_test)
 
       }
 
-      if( db.head_block_time() <= HARDFORK_413_TIME )
+      if( db.head_block_time() <= HARDFORK_CORE_188_TIME )
       {
          // can't claim before hardfork
          GRAPHENE_REQUIRE_THROW( claim_fees( izzy_id, _izzy(1) ), fc::exception );
-         generate_blocks( HARDFORK_413_TIME );
-         while( db.head_block_time() <= HARDFORK_413_TIME )
+         generate_blocks( HARDFORK_CORE_188_TIME );
+         while( db.head_block_time() <= HARDFORK_CORE_188_TIME )
          {
             generate_block();
          }

--- a/tests/tests/fee_tests.cpp
+++ b/tests/tests/fee_tests.cpp
@@ -245,7 +245,7 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
 
         enable_fees();
 
-        auto claim_pool = [&]( const account_id_type& issuer, const asset_id_type& asset_to_claim,
+        auto claim_pool = [&]( const account_id_type issuer, const asset_id_type asset_to_claim,
                               const asset& amount_to_fund, const asset_object& fee_asset  )
         {
             asset_claim_pool_operation claim_op;


### PR DESCRIPTION
Blockchain Projects BV would like to contrinute his first proposal to the backend development with an implementation of "asset_claim_pool_operation".

In contrast to BSIP27, which proposes to modify the existing operation to fund the asset fee pool to allow negative amounts for a refund, we decided that the better approach would be to add a new operation, not just because of a clear name of the operation, but also because we didn't want to touch existing code and change existing behavior.

Please feel free to give any kind of feedback.

BTW, this commits is considered a contribution to BitShares and is licensed under MIT, of course.