### PR TITLE
Cleanup some obsolete hardfork protections

### DIFF
--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -114,12 +114,6 @@ void_result asset_create_evaluator::do_evaluate( const asset_create_operation& o
       FC_ASSERT( op.precision == op.bitasset_opts->short_backing_asset(d).precision );
    }
 
-   if( d.head_block_time() <= HARDFORK_CORE_429_TIME )
-   { // TODO: remove after HARDFORK_CORE_429_TIME has passed
-      graphene::chain::impl::hf_429_visitor hf_429;
-      hf_429( op );
-   }
-
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (op) ) }
 

--- a/libraries/chain/db_maint.cpp
+++ b/libraries/chain/db_maint.cpp
@@ -763,9 +763,6 @@ void database::process_bids( const asset_bitasset_data_object& bad )
    }
    if( covered < bdd.current_supply ) return;
 
-   if( head_block_time() <= HARDFORK_CORE_216_TIME )
-       wlog( "Premature bitasset revival of ${sym} at block ${num}", ("sym",to_revive.symbol)("num",head_block_num()) );
-
    const auto end = itr;
    share_type to_cover = bdd.current_supply;
    share_type remaining_fund = bad.settlement_fund;

--- a/libraries/chain/db_maint.cpp
+++ b/libraries/chain/db_maint.cpp
@@ -741,7 +741,6 @@ void database::process_bids( const asset_bitasset_data_object& bad )
 {
    if( bad.is_prediction_market ) return;
    if( bad.current_feed.settlement_price.is_null() ) return;
-   if( head_block_time() <= HARDFORK_CORE_216_TIME ) return; // remove after HF date
 
    asset_id_type to_revive_id = (asset( 0, bad.options.short_backing_asset ) * bad.settlement_price).asset_id;
    const asset_object& to_revive = to_revive_id( *this );
@@ -763,6 +762,9 @@ void database::process_bids( const asset_bitasset_data_object& bad )
       ++itr;
    }
    if( covered < bdd.current_supply ) return;
+
+   if( head_block_time() <= HARDFORK_CORE_216_TIME )
+       wlog( "Premature bitasset revival of ${sym} at block ${num}", ("sym",to_revive.symbol)("num",head_block_num()) );
 
    const auto end = itr;
    share_type to_cover = bdd.current_supply;

--- a/libraries/chain/include/graphene/chain/asset_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/asset_evaluator.hpp
@@ -160,10 +160,6 @@ namespace graphene { namespace chain {
             template<typename T>
             void operator()( const T& v )const {}
 
-            void operator()( const graphene::chain::bid_collateral_operation& v )const {
-               FC_ASSERT( false, "Not allowed until hardfork" );
-            }
-
             void operator()( const graphene::chain::asset_create_operation& v )const {
                FC_ASSERT( v.fee.asset_id == asset_id_type(), "Can only pay fee in BTS since block #21040000" );
             }

--- a/libraries/chain/include/graphene/chain/asset_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/asset_evaluator.hpp
@@ -152,22 +152,4 @@ namespace graphene { namespace chain {
          void_result do_apply( const asset_claim_fees_operation& o );
    };
 
-   namespace impl { // TODO: remove after HARDFORK_CORE_429_TIME has passed
-      class hf_429_visitor {
-         public:
-            typedef void result_type;
-
-            template<typename T>
-            void operator()( const T& v )const {}
-
-            void operator()( const graphene::chain::asset_create_operation& v )const {
-               FC_ASSERT( v.fee.asset_id == asset_id_type(), "Can only pay fee in BTS since block #21040000" );
-            }
-
-            void operator()( const graphene::chain::proposal_create_operation& v )const {
-               for( const op_wrapper& op : v.proposed_ops )
-                   op.op.visit( *this );
-            }
-      };
-   }
 } } // graphene::chain

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -21,13 +21,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#include <graphene/chain/asset_evaluator.hpp>
 #include <graphene/chain/proposal_evaluator.hpp>
 #include <graphene/chain/proposal_object.hpp>
 #include <graphene/chain/account_object.hpp>
 #include <graphene/chain/protocol/fee_schedule.hpp>
 #include <graphene/chain/exceptions.hpp>
-#include <graphene/chain/hardfork.hpp>
 
 #include <fc/smart_ref_impl.hpp>
 
@@ -76,12 +74,6 @@ void_result proposal_create_evaluator::do_evaluate(const proposal_create_operati
    for( const op_wrapper& op : o.proposed_ops )
       _proposed_trx.operations.push_back(op.op);
    _proposed_trx.validate();
-
-   if( d.head_block_time() <= HARDFORK_CORE_429_TIME )
-   { // TODO: remove after HARDFORK_CORE_429_TIME has passed
-      graphene::chain::impl::hf_429_visitor hf_429;
-      hf_429( o );
-   }
 
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (o) ) }


### PR DESCRIPTION
The first commit adds a log message that can be used to verify that the issue didn't happen in the main chain before the hardfork. After verifying this, I removed the check with the second commit.

The other two revert softfork protections added before the hardfork. This also resolves #566 .