### PR TITLE
Cleanup for issue 353

### DIFF
--- a/libraries/chain/db_maint.cpp
+++ b/libraries/chain/db_maint.cpp
@@ -262,16 +262,17 @@ void database::update_active_committee_members()
          stake_tally += _committee_count_histogram_buffer[++committee_member_count];
    if( stake_target != old_stake_target && old_stake_target > 0 && head_block_time() < fc::time_point_sec(HARDFORK_CORE_353_TIME) )
    {
+      uint32_t candidates = get_index_type<committee_member_index>().indices().size();
       uint64_t old_stake_tally = 0;
       size_t old_committee_member_count = 0;
       while( (old_committee_member_count < _committee_count_histogram_buffer.size() - 1)
              && (old_stake_tally <= old_stake_target) )
          old_stake_tally += _committee_count_histogram_buffer[++old_committee_member_count];
       if( old_committee_member_count != committee_member_count
-              && (old_committee_member_count > GRAPHENE_DEFAULT_MIN_COMMITTEE_MEMBER_COUNT
-                  || committee_member_count > GRAPHENE_DEFAULT_MIN_COMMITTEE_MEMBER_COUNT) )
+              && (old_committee_member_count*2+1 > GRAPHENE_DEFAULT_MIN_COMMITTEE_MEMBER_COUNT
+                  || committee_member_count*2+1 > GRAPHENE_DEFAULT_MIN_COMMITTEE_MEMBER_COUNT) )
       {
-          ilog( "Committee member count mismatch ${old} / ${new}", ("old",old_committee_member_count)("new", committee_member_count) );
+          ilog( "Committee member count mismatch ${old} / ${new} at block ${num} with ${count} candidates", ("old",old_committee_member_count)("new", committee_member_count)("num",head_block_num())("count",candidates) );
           committee_member_count = old_committee_member_count;
       }
    }

--- a/libraries/chain/db_maint.cpp
+++ b/libraries/chain/db_maint.cpp
@@ -245,12 +245,6 @@ void database::update_active_committee_members()
 { try {
    assert( _committee_count_histogram_buffer.size() > 0 );
    share_type stake_target = (_total_voting_stake-_committee_count_histogram_buffer[0]) / 2;
-   share_type old_stake_target = (_total_voting_stake-_witness_count_histogram_buffer[0]) / 2;
-   // TODO
-   // all the stuff about old_stake_target can *hopefully* be removed after the
-   // hardfork date has passed
-   //if( stake_target != old_stake_target )
-   //    ilog( "Different stake targets: ${old} / ${new}", ("old",old_stake_target)("new",stake_target) );
 
    /// accounts that vote for 0 or 1 witness do not get to express an opinion on
    /// the number of witnesses to have (they abstain and are non-voting accounts)
@@ -260,22 +254,6 @@ void database::update_active_committee_members()
       while( (committee_member_count < _committee_count_histogram_buffer.size() - 1)
              && (stake_tally <= stake_target) )
          stake_tally += _committee_count_histogram_buffer[++committee_member_count];
-   if( stake_target != old_stake_target && old_stake_target > 0 && head_block_time() < fc::time_point_sec(HARDFORK_CORE_353_TIME) )
-   {
-      uint32_t candidates = get_index_type<committee_member_index>().indices().size();
-      uint64_t old_stake_tally = 0;
-      size_t old_committee_member_count = 0;
-      while( (old_committee_member_count < _committee_count_histogram_buffer.size() - 1)
-             && (old_stake_tally <= old_stake_target) )
-         old_stake_tally += _committee_count_histogram_buffer[++old_committee_member_count];
-      if( old_committee_member_count != committee_member_count
-              && (old_committee_member_count*2+1 > GRAPHENE_DEFAULT_MIN_COMMITTEE_MEMBER_COUNT
-                  || committee_member_count*2+1 > GRAPHENE_DEFAULT_MIN_COMMITTEE_MEMBER_COUNT) )
-      {
-          ilog( "Committee member count mismatch ${old} / ${new} at block ${num} with ${count} candidates", ("old",old_committee_member_count)("new", committee_member_count)("num",head_block_num())("count",candidates) );
-          committee_member_count = old_committee_member_count;
-      }
-   }
 
    const chain_property_object& cpo = get_chain_properties();
    auto committee_members = sort_votable_objects<committee_member_index>(std::max(committee_member_count*2+1, (size_t)cpo.immutable_parameters.min_committee_member_count));

--- a/libraries/chain/hardfork.d/353.hf
+++ b/libraries/chain/hardfork.d/353.hf
@@ -1,4 +1,0 @@
-// bitshares-core #353 Computation of number of committee members is wrong
-#ifndef HARDFORK_CORE_353_TIME
-#define HARDFORK_CORE_353_TIME (fc::time_point_sec( 1512747600 ))
-#endif


### PR DESCRIPTION
The first commit adds more detail to the log message for issue #353 . With a replay I verified that the message is only triggered within the first 30000 blocks, and that in each case the resulting committee consists solely of the 11 init members.
This means that the change does not result in different behaviour when applied to the chain before the hardfork, which means the hf protection can be removed entirely. This is what the 2nd commit does.