### PR TITLE
Capture exceptions when initializing `vote_id_type` with a string

### DIFF
--- a/libraries/chain/include/graphene/chain/protocol/vote.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/vote.hpp
@@ -75,11 +75,11 @@ struct vote_id_type
    {}
    /// Construct this vote_id_type from a serial string in the form "type:instance"
    explicit vote_id_type(const std::string& serial)
-   {
+   { try {
       auto colon = serial.find(':');
       FC_ASSERT( colon != std::string::npos );
       *this = vote_id_type(vote_type(std::stoul(serial.substr(0, colon))), std::stoul(serial.substr(colon+1)));
-   }
+   } FC_CAPTURE_AND_RETHROW( (serial) ) }
 
    /// Set the type of this vote_id_type
    void set_type(vote_type type)

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -361,6 +361,9 @@ BOOST_AUTO_TEST_CASE( create_account_test )
       REQUIRE_THROW_WITH_VALUE(op, options.votes, boost::assign::list_of<vote_id_type>(vote_id_type("1:19")).convert_to_container<flat_set<vote_id_type>>());
       op.options.num_witness = 0;
       REQUIRE_THROW_WITH_VALUE(op, options.votes, boost::assign::list_of<vote_id_type>(vote_id_type("2:19")).convert_to_container<flat_set<vote_id_type>>());
+      REQUIRE_THROW_WITH_VALUE(op, options.votes, boost::assign::list_of<vote_id_type>(vote_id_type("3:99")).convert_to_container<flat_set<vote_id_type>>());
+      REQUIRE_THROW_WITH_VALUE(op, options.votes, boost::assign::list_of<vote_id_type>(vote_id_type("2:a")).convert_to_container<flat_set<vote_id_type>>());
+      REQUIRE_THROW_WITH_VALUE(op, options.votes, boost::assign::list_of<vote_id_type>(vote_id_type("")).convert_to_container<flat_set<vote_id_type>>());
       op.options.num_committee = save_num_committee;
       op.options.num_witness = save_num_witness;
 

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -362,8 +362,8 @@ BOOST_AUTO_TEST_CASE( create_account_test )
       op.options.num_witness = 0;
       REQUIRE_THROW_WITH_VALUE(op, options.votes, boost::assign::list_of<vote_id_type>(vote_id_type("2:19")).convert_to_container<flat_set<vote_id_type>>());
       REQUIRE_THROW_WITH_VALUE(op, options.votes, boost::assign::list_of<vote_id_type>(vote_id_type("3:99")).convert_to_container<flat_set<vote_id_type>>());
-      REQUIRE_THROW_WITH_VALUE(op, options.votes, boost::assign::list_of<vote_id_type>(vote_id_type("2:a")).convert_to_container<flat_set<vote_id_type>>());
-      REQUIRE_THROW_WITH_VALUE(op, options.votes, boost::assign::list_of<vote_id_type>(vote_id_type("")).convert_to_container<flat_set<vote_id_type>>());
+      GRAPHENE_REQUIRE_THROW( vote_id_type("2:a"), fc::exception );
+      GRAPHENE_REQUIRE_THROW( vote_id_type(""), fc::exception );
       op.options.num_committee = save_num_committee;
       op.options.num_witness = save_num_witness;
 


### PR DESCRIPTION
PR for #577.

The first two commits are test cases to reproduce the issue, the 3rd commit is the fix.