### PR TITLE
clean feeds at maint time

### DIFF
--- a/libraries/chain/db_maint.cpp
+++ b/libraries/chain/db_maint.cpp
@@ -945,11 +945,26 @@ void database::perform_chain_maintenance(const signed_block& next_block, const g
    });
 
    // Reset all BitAsset force settlement volumes to zero
+
    for( const auto& d : get_index_type<asset_bitasset_data_index>().indices() )
    {
-      modify( d, [](asset_bitasset_data_object& o) { o.force_settled_volume = 0; });
+      modify( d, [this](asset_bitasset_data_object& o) {
+         o.force_settled_volume = 0;
+
+         // Remove all expired feeds
+         for( auto itr = o.feeds.begin(); itr != o.feeds.end();)
+         {
+            auto feed_time = itr[1].second.first;
+            if( feed_time + (o.options.feed_lifetime_sec) < head_block_time() && o.feeds.size() > o.options.minimum_feeds)
+               itr = o.feeds.erase(itr);
+            else
+               ++itr;
+         }
+         //o.update_median_feeds(head_block_time());
+      });
       if( d.has_settlement() )
          process_bids(d);
+
    }
 
    // process_budget needs to run at the bottom because


### PR DESCRIPTION
the pull attempts to remove not needed feeds from the bitasset object at maint time. it deletes the feeds that are expired according to the options (default 1 day) and it keep the min number of feeds required(default 7).

problem is replay fails at here:

```
2883742ms th_a       application.cpp:499           handle_block         ] Got block: #60000 time: 2015-10-15T18:13:18 latency: 71948085742 ms from: triox-delegate  irreversible: 59979 (-21)
2885695ms th_a       db_block.cpp:202              _push_block          ] Failed to push new block:
10 assert_exception: Assert Exception
d.get_balance(*_paying_account, _bitasset_data->options.short_backing_asset(d)) >= o.delta_collateral: Cannot increase collateral by 433763148 when payer only has 28651500
    {"c":433763148,"b":28651500}
    th_a  market_evaluator.cpp:161 do_evaluate

    {"o":{"fee":{"amount":2000000,"asset_id":"1.3.0"},"funding_account":"1.2.91204","delta_collateral":{"amount":433763148,"asset_id":"1.3.0"},"delta_debt":{"amount":0,"asset_id":"1.3.121"},"extensions":[]}}
    th_a  market_evaluator.cpp:165 do_evaluate

    {}
    th_a  evaluator.cpp:51 start_evaluate

    {"op":[3,{"fee":{"amount":2000000,"asset_id":"1.3.0"},"funding_account":"1.2.91204","delta_collateral":{"amount":433763148,"asset_id":"1.3.0"},"delta_debt":{"amount":0,"asset_id":"1.3.121"},"extensions":[]}]}
    th_a  db_block.cpp:645 apply_operation

    {"trx":{"ref_block_num":64327,"ref_block_prefix":2666126845,"expiration":"2015-10-15T21:52:45","operations":[[3,{"fee":{"amount":2000000,"asset_id":"1.3.0"},"funding_account":"1.2.91204","delta_collateral":{"amount":433763148,"asset_id":"1.3.0"},"delta_debt":{"amount":0,"asset_id":"1.3.121"},"extensions":[]}]],"extensions":[],"signatures":["207e751b2029bc07a71dc83a581d9a80c196244d2a13aca71131c11e49783886853eb9a846fb82d674ab7636b330d0e33a8041c3f26f957e8c98e95ad8e6921ae0"]}}
    th_a  db_block.cpp:628 _apply_transaction

    {"next_block.block_num()":64329}
    th_a  db_block.cpp:545 _apply_block
2885695ms th_a       application.cpp:531           handle_block         ] Error when pushing block:
10 assert_exception: Assert Exception
d.get_balance(*_paying_account, _bitasset_data->options.short_backing_asset(d)) >= o.delta_collateral: Cannot increase collateral by 433763148 when payer only has 28651500
```

any light in this is appreciated, i cant get why it is failing.