### PR TITLE
add ssl, boost and websocket to version commands

### DIFF
--- a/programs/cli_wallet/main.cpp
+++ b/programs/cli_wallet/main.cpp
@@ -51,6 +51,9 @@
 #include <fc/log/logger_config.hpp>
 
 #include <graphene/utilities/git_revision.hpp>
+#include <boost/version.hpp>
+#include <boost/algorithm/string/replace.hpp>
+#include <websocketpp/version.hpp>
 
 #ifdef WIN32
 # include <signal.h>
@@ -99,6 +102,9 @@ int main( int argc, char** argv )
          std::cout << "Version: " << graphene::utilities::git_revision_description << "\n";
          std::cout << "SHA: " << graphene::utilities::git_revision_sha << "\n";
          std::cout << "Timestamp: " << fc::get_approximate_relative_time_string(fc::time_point_sec(graphene::utilities::git_revision_unix_timestamp)) << "\n";
+         std::cout << "SSL: " << OPENSSL_VERSION_TEXT << "\n";
+         std::cout << "Boost: " << boost::replace_all_copy(std::string(BOOST_LIB_VERSION), "_", ".") << "\n";
+         std::cout << "Websocket++: " << websocketpp::major_version << "." << websocketpp::minor_version << "." << websocketpp::patch_version << "\n";
          return 0;
       }
 

--- a/programs/witness_node/main.cpp
+++ b/programs/witness_node/main.cpp
@@ -49,6 +49,9 @@
 #include <boost/container/flat_set.hpp>
 
 #include <graphene/utilities/git_revision.hpp>
+#include <boost/version.hpp>
+#include <boost/algorithm/string/replace.hpp>
+#include <websocketpp/version.hpp>
 
 #include <iostream>
 #include <fstream>
@@ -218,6 +221,9 @@ int main(int argc, char** argv) {
          std::cout << "Version: " << graphene::utilities::git_revision_description << "\n";
          std::cout << "SHA: " << graphene::utilities::git_revision_sha << "\n";
          std::cout << "Timestamp: " << fc::get_approximate_relative_time_string(fc::time_point_sec(graphene::utilities::git_revision_unix_timestamp)) << "\n";
+         std::cout << "SSL: " << OPENSSL_VERSION_TEXT << "\n";
+         std::cout << "Boost: " << boost::replace_all_copy(std::string(BOOST_LIB_VERSION), "_", ".") << "\n";
+         std::cout << "Websocket++: " << websocketpp::major_version << "." << websocketpp::minor_version << "." << websocketpp::patch_version << "\n";
          return 0;
       }
 


### PR DESCRIPTION
for issue https://github.com/bitshares/bitshares-core/issues/579

output:

```
alfredo@alfredo-Inspiron-5559 ~/CLionProjects/issue579 $ programs/witness_node/witness_node --version
Version: 2.0.171025-minor-fix-1-176-gb2afc7a
SHA: b2afc7a36b34b58c3cb29914d59168616b159fc9
Timestamp: 23 hours ago
SSL: OpenSSL 1.0.2g  1 Mar 2016
Boost: 1.57
Websocket++: 0.7.0
alfredo@alfredo-Inspiron-5559 ~/CLionProjects/issue579 $ programs/cli_wallet/cli_wallet --version
Version: 2.0.171025-minor-fix-1-176-gb2afc7a
SHA: b2afc7a36b34b58c3cb29914d59168616b159fc9
Timestamp: 23 hours ago
SSL: OpenSSL 1.0.2g  1 Mar 2016
Boost: 1.57
Websocket++: 0.7.0
alfredo@alfredo-Inspiron-5559 ~/CLionProjects/issue579 $ 
```