### PR TITLE
remove memo elog in printer

### DIFF
--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2713,7 +2713,6 @@ string operation_printer::operator()(const transfer_operation& op) const
             }
          } catch (const fc::exception& e) {
             out << " -- could not decrypt memo";
-            elog("Error when decrypting memo: ${e}", ("e", e.to_detail_string()));
          }
       }
    }


### PR DESCRIPTION
https://github.com/bitshares/bitshares-core/issues/91

The elog on the operation printer is not needed, the "could not decrypt memo" message is enough.

```
unlocked >>> get_relative_account_history blocktrades 0 4 0
get_relative_account_history blocktrades 0 4 0
2015-10-14T23:41:54 Transfer 0.00210000 TRADE.BTC from btsnow to blocktrades -- could not decrypt memo   (Fee: 21.21093 BTS) 
2015-10-14T23:39:18 Transfer 0.00008000 TRADE.BTC from btsnow to blocktrades -- could not decrypt memo   (Fee: 21.21093 BTS) 
2015-10-14T22:07:06 asset_issue_operation blocktrades fee: 20.00097 BTS 
2015-10-14T22:01:54 Transfer 0.00091508 TRADE.BTC from blocktrades to btsnow   (Fee: 20 BTS) 

unlocked >>> 

```