### PR TITLE
Issue #151

### DIFF
--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -565,8 +565,6 @@ public:
    }
    account_object get_account(account_id_type id) const
    {
-      if( _wallet.my_accounts.get<by_id>().count(id) )
-         return *_wallet.my_accounts.get<by_id>().find(id);
       auto rec = _remote_db->get_accounts({id}).front();
       FC_ASSERT(rec);
       return *rec;
@@ -580,19 +578,6 @@ public:
          // It's an ID
          return get_account(*id);
       } else {
-         // It's a name
-         if( _wallet.my_accounts.get<by_name>().count(account_name_or_id) )
-         {
-            auto local_account = *_wallet.my_accounts.get<by_name>().find(account_name_or_id);
-            auto blockchain_account = _remote_db->lookup_account_names({account_name_or_id}).front();
-            FC_ASSERT( blockchain_account );
-            if (local_account.id != blockchain_account->id)
-               elog("my account id ${id} different from blockchain id ${id2}", ("id", local_account.id)("id2", blockchain_account->id));
-            if (local_account.name != blockchain_account->name)
-               elog("my account name ${id} different from blockchain name ${id2}", ("id", local_account.name)("id2", blockchain_account->name));
-
-            return *_wallet.my_accounts.get<by_name>().find(account_name_or_id);
-         }
          auto rec = _remote_db->lookup_account_names({account_name_or_id}).front();
          FC_ASSERT( rec && rec->name == account_name_or_id );
          return *rec;


### PR DESCRIPTION
We have extensive experience with cli_wallet and we find that the cached account_object could easily go stale thus ruining any further transactions, meaning the new transactions issued with cli_wallet would contain out-of-date information, this way you can loose your data (votes, keys, etc) and your money (you'll need to issue more transactions to restore the previous valid state). 

When working simultaneously with cli_wallet and the web UI the issue only exacerbates: now you just can't switch from one tool to another, you're basically bound to the UI. The only safe workaround is to kill wallet.json and re-import the keys and do this every time you want to use cli_wallet. 

We think there is no better solution other than removing the caching altogether. Granted, this would incur some extra RPC requests but it's a small pay for the predactability and stability of the essential tool. 

