### PR TITLE
Fix broken HTTP headers in elasticsearch requests

### DIFF
--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -270,7 +270,7 @@ void elasticsearch_plugin_impl::sendBulk(std::string _elasticsearch_node_url, bo
    //wlog((bulking));
 
    struct curl_slist *headers = NULL;
-   curl_slist_append(headers, "Content-Type: application/json");
+   headers = curl_slist_append(headers, "Content-Type: application/json");
    std::string url = _elasticsearch_node_url + "_bulk";
    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
    curl_easy_setopt(curl, CURLOPT_POST, true);


### PR DESCRIPTION
The bug results in Content-Type header not being set and this way preventing Elasticsearch from accepting the request. Every single request would fail with error 406. 

Starting from version 6.0 Elasticsearch demands the Content-Type to be present and set. See [the official post on the subject](https://www.elastic.co/blog/strict-content-type-checking-for-elasticsearch-rest-requests).

Tested with Elasticsearch 6.2.0