### PR TITLE
remove "temp for testing" code using BTS string literal

### DIFF
--- a/libraries/chain/include/graphene/chain/protocol/types.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/types.hpp
@@ -259,8 +259,6 @@ namespace graphene { namespace chain {
        friend bool operator == ( const public_key_type& p1, const fc::ecc::public_key& p2);
        friend bool operator == ( const public_key_type& p1, const public_key_type& p2);
        friend bool operator != ( const public_key_type& p1, const public_key_type& p2);
-       // TODO: This is temporary for testing
-       bool is_valid_v1( const std::string& base58str );
    };
 
    struct extended_public_key_type

--- a/libraries/chain/protocol/types.cpp
+++ b/libraries/chain/protocol/types.cpp
@@ -44,17 +44,6 @@ namespace graphene { namespace chain {
       // TODO:  Refactor syntactic checks into static is_valid()
       //        to make public_key_type API more similar to address API
        std::string prefix( GRAPHENE_ADDRESS_PREFIX );
-
-       // TODO: This is temporary for testing
-       try
-       {
-           if( is_valid_v1( base58str ) )
-               prefix = std::string( "BTS" );
-       }
-       catch( ... )
-       {
-       }
-
        const size_t prefix_len = prefix.size();
        FC_ASSERT( base58str.size() > prefix_len );
        FC_ASSERT( base58str.substr( 0, prefix_len ) ==  prefix , "", ("base58str", base58str) );
@@ -63,20 +52,6 @@ namespace graphene { namespace chain {
        key_data = bin_key.data;
        FC_ASSERT( fc::ripemd160::hash( key_data.data, key_data.size() )._hash[0] == bin_key.check );
     };
-
-    // TODO: This is temporary for testing
-    bool public_key_type::is_valid_v1( const std::string& base58str )
-    {
-       std::string prefix( "BTS" );
-       const size_t prefix_len = prefix.size();
-       FC_ASSERT( base58str.size() > prefix_len );
-       FC_ASSERT( base58str.substr( 0, prefix_len ) ==  prefix , "", ("base58str", base58str) );
-       auto bin = fc::from_base58( base58str.substr( prefix_len ) );
-       auto bin_key = fc::raw::unpack<binary_key>(bin);
-       fc::ecc::public_key_data key_data = bin_key.data;
-       FC_ASSERT( fc::ripemd160::hash( key_data.data, key_data.size() )._hash[0] == bin_key.check );
-       return true;
-    }
 
     public_key_type::operator fc::ecc::public_key_data() const
     {


### PR DESCRIPTION
This PR is part of original #553. The temp code was added in this commit fc7fb86cd20fad30ea1bc6f9de42d1e83aa2a27a.  Then it was deleted from the address.cpp but is still present in the types.cpp (by mistake?).