### PR TITLE
remove temporary code for handling BTS snapshot

### DIFF
--- a/libraries/chain/db_init.cpp
+++ b/libraries/chain/db_init.cpp
@@ -448,11 +448,6 @@ void database::init_genesis(const genesis_state_type& genesis_state)
    const auto& assets_by_symbol = get_index_type<asset_index>().indices().get<by_symbol>();
    const auto get_asset_id = [&assets_by_symbol](const string& symbol) {
       auto itr = assets_by_symbol.find(symbol);
-
-      // TODO: This is temporary for handling BTS snapshot
-      if( symbol == "BTS" )
-          itr = assets_by_symbol.find(GRAPHENE_SYMBOL);
-
       FC_ASSERT(itr != assets_by_symbol.end(),
                 "Unable to find asset '${sym}'. Did you forget to add a record for it to initial_assets?",
                 ("sym", symbol));


### PR DESCRIPTION
This PR is part of original #553. I propose to remove this code since it does not look like covering any valid use case for bitshares-core, or does it? Why should I have the BTS balances in the genesis state while the the GRAPHENE_SYMBOL has different value? If it is a hardfork, why is the code annotated as temporary?