### PR TITLE
remove wdumps from database_api.cpp and wallet.cpp

### DIFF
--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -499,7 +499,6 @@ vector<vector<account_id_type>> database_api::get_key_references( vector<public_
  */
 vector<vector<account_id_type>> database_api_impl::get_key_references( vector<public_key_type> keys )const
 {
-   wdump( (keys) );
    vector< vector<account_id_type> > final_result;
    final_result.reserve(keys.size());
 
@@ -533,7 +532,6 @@ vector<vector<account_id_type>> database_api_impl::get_key_references( vector<pu
              result.reserve( itr->second.size() );
              for( auto item : itr->second )
              {
-                wdump((a)(item)(item(_db).name));
                 result.push_back(item);
              }
           }
@@ -1782,13 +1780,11 @@ set<public_key_type> database_api::get_required_signatures( const signed_transac
 
 set<public_key_type> database_api_impl::get_required_signatures( const signed_transaction& trx, const flat_set<public_key_type>& available_keys )const
 {
-   wdump((trx)(available_keys));
    auto result = trx.get_required_signatures( _db.get_chain_id(),
                                        available_keys,
                                        [&]( account_id_type id ){ return &id(_db).active; },
                                        [&]( account_id_type id ){ return &id(_db).owner; },
                                        _db.get_global_properties().parameters.max_authority_depth );
-   wdump((result));
    return result;
 }
 
@@ -1803,7 +1799,6 @@ set<address> database_api::get_potential_address_signatures( const signed_transa
 
 set<public_key_type> database_api_impl::get_potential_signatures( const signed_transaction& trx )const
 {
-   wdump((trx));
    set<public_key_type> result;
    trx.get_required_signatures(
       _db.get_chain_id(),
@@ -1834,7 +1829,6 @@ set<public_key_type> database_api_impl::get_potential_signatures( const signed_t
       for( const auto& key : auth.get_keys() )
          result.insert( key );
 
-   wdump((result));
    return result;
 }
 

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -3784,7 +3784,6 @@ vector< signed_transaction > wallet_api_impl::import_balance( string name_or_id,
    }
 
    vector< balance_object > balances = _remote_db->get_balance_objects( addrs );
-   wdump((balances));
    addrs.clear();
 
    set<asset_id_type> bal_types;


### PR DESCRIPTION
when testing https://github.com/bitshares/bitshares-core/pull/675 i noticed too many output from the node when calling some functions, more specifically in `database_api.cpp`

this pull removes them all and also one found in `wallet.cpp`. There are also more in wallet related to the blind functions that by now i left there.

