### PR TITLE
fix content-type not working bug in elastic search

### DIFF
--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -270,7 +270,7 @@ void elasticsearch_plugin_impl::sendBulk(std::string _elasticsearch_node_url, bo
    //wlog((bulking));
 
    struct curl_slist *headers = NULL;
-   curl_slist_append(headers, "Content-Type: application/json");
+   headers = curl_slist_append(headers, "Content-Type: application/json");
    std::string url = _elasticsearch_node_url + "_bulk";
    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
    curl_easy_setopt(curl, CURLOPT_POST, true);


### PR DESCRIPTION
as official document shows

> CURL *handle;
> struct curl_slist *slist=NULL;
>  
> slist = curl_slist_append(slist, "pragma:");

but in elastic search plugin

> curl_slist_append(headers, "Content-Type: application/json");

so headers remain NULL