### PR TITLE
Add application option to disable `notify_remove_create` parameter in `set_subscribe_callback` API

### DIFF
--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -78,7 +78,7 @@ namespace graphene { namespace app {
     {
        if( api_name == "database_api" )
        {
-          _database_api = std::make_shared< database_api >( std::ref( *_app.chain_database() ) );
+          _database_api = std::make_shared< database_api >( std::ref( *_app.chain_database() ), &( _app.get_options() ) );
        }
        else if( api_name == "block_api" )
        {

--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -414,6 +414,9 @@ namespace detail {
          if( _options->count("enable-subscribe-to-all") )
             _app_options.enable_subscribe_to_all = _options->at("enable-subscribe-to-all").as<bool>();
 
+         if( _active_plugins.find( "market_history" ) != _active_plugins.end() )
+            _app_options.has_market_history_plugin = true;
+
          if( _options->count("api-access") ) {
 
             if(fc::exists(_options->at("api-access").as<boost::filesystem::path>()))

--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -111,6 +111,7 @@ namespace detail {
       fc::optional<fc::temp_file> _lock_file;
       bool _is_block_producer = false;
       bool _force_validate = false;
+      application_options _app_options;
 
       void reset_p2p_node(const fc::path& data_dir)
       { try {
@@ -404,6 +405,9 @@ namespace detail {
             _force_validate = true;
          }
 
+         if( _options->count("enable-subscribe-to-all") )
+            _app_options.enable_subscribe_to_all = _options->at("enable-subscribe-to-all").as<bool>();
+
          if( _options->count("api-access") ) {
 
             if(fc::exists(_options->at("api-access").as<boost::filesystem::path>()))
@@ -419,7 +423,6 @@ namespace detail {
                std::exit(EXIT_FAILURE);
             }
          }
-
          else
          {
             // TODO:  Remove this generous default access policy
@@ -933,6 +936,7 @@ void application::set_program_options(boost::program_options::options_descriptio
          ("dbg-init-key", bpo::value<string>(), "Block signing key to use for init witnesses, overrides genesis file")
          ("api-access", bpo::value<boost::filesystem::path>(), "JSON file specifying API permissions")
          ("plugins", bpo::value<string>(), "Space-separated list of plugins to activate")
+         ("enable-subscribe-to-all", bpo::value<bool>()->implicit_value(false), "Whether allow API clients to subscribe to universal object creation and removal events")
          ;
    command_line_options.add(configuration_file_options);
    command_line_options.add_options()
@@ -1096,6 +1100,11 @@ void application::startup_plugins()
    for( auto& entry : my->_active_plugins )
       entry.second->plugin_startup();
    return;
+}
+
+const application_options& application::get_options()
+{
+   return my->_app_options;
 }
 
 // namespace detail

--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -226,7 +226,9 @@ namespace detail {
                std::string hostname = endpoint_string.substr(0, colon_pos);
                std::vector<fc::ip::endpoint> endpoints = fc::resolve(hostname, port);
                if (endpoints.empty())
-                  FC_THROW_EXCEPTION(fc::unknown_host_exception, "The host name can not be resolved: ${hostname}", ("hostname", hostname));
+                  FC_THROW_EXCEPTION( fc::unknown_host_exception,
+                                      "The host name can not be resolved: ${hostname}",
+                                      ("hostname", hostname) );
                return endpoints;
             }
             catch (const boost::bad_lexical_cast&)
@@ -335,10 +337,14 @@ namespace detail {
                bool modified_genesis = false;
                if( _options->count("genesis-timestamp") )
                {
-                  genesis.initial_timestamp = fc::time_point_sec( fc::time_point::now() ) + genesis.initial_parameters.block_interval + _options->at("genesis-timestamp").as<uint32_t>();
-                  genesis.initial_timestamp -= genesis.initial_timestamp.sec_since_epoch() % genesis.initial_parameters.block_interval;
+                  genesis.initial_timestamp = fc::time_point_sec( fc::time_point::now() )
+                                            + genesis.initial_parameters.block_interval
+                                            + _options->at("genesis-timestamp").as<uint32_t>();
+                  genesis.initial_timestamp -= ( genesis.initial_timestamp.sec_since_epoch()
+                                                 % genesis.initial_parameters.block_interval );
                   modified_genesis = true;
-                  std::cerr << "Used genesis timestamp:  " << genesis.initial_timestamp.to_iso_string() << " (PLEASE RECORD THIS)\n";
+                  std::cerr << "Used genesis timestamp:  " << genesis.initial_timestamp.to_iso_string()
+                            << " (PLEASE RECORD THIS)\n";
                }
                if( _options->count("dbg-init-key") )
                {
@@ -509,7 +515,9 @@ namespace detail {
             // you can help the network code out by throwing a block_older_than_undo_history exception.
             // when the net code sees that, it will stop trying to push blocks from that chain, but
             // leave that peer connected so that they can get sync blocks from us
-            bool result = _chain_db->push_block(blk_msg.block, (_is_block_producer | _force_validate) ? database::skip_nothing : database::skip_transaction_signatures);
+            bool result = _chain_db->push_block( blk_msg.block,
+                                                 (_is_block_producer | _force_validate) ?
+                                                    database::skip_nothing : database::skip_transaction_signatures );
 
             // the block was accepted, so we now know all of the transactions contained in the block
             if (!sync_mode)
@@ -530,7 +538,9 @@ namespace detail {
          } catch ( const graphene::chain::unlinkable_block_exception& e ) {
             // translate to a graphene::net exception
             elog("Error when pushing block:\n${e}", ("e", e.to_detail_string()));
-            FC_THROW_EXCEPTION(graphene::net::unlinkable_block_exception, "Error when pushing block:\n${e}", ("e", e.to_detail_string()));
+            FC_THROW_EXCEPTION( graphene::net::unlinkable_block_exception,
+                                "Error when pushing block:\n${e}",
+                                ("e", e.to_detail_string()) );
          } catch( const fc::exception& e ) {
             elog("Error when pushing block:\n${e}", ("e", e.to_detail_string()));
             throw;
@@ -613,7 +623,8 @@ namespace detail {
                break;
              }
            if (!found_a_block_in_synopsis)
-             FC_THROW_EXCEPTION(graphene::net::peer_is_on_an_unreachable_fork, "Unable to provide a list of blocks starting at any of the blocks in peer's synopsis");
+             FC_THROW_EXCEPTION( graphene::net::peer_is_on_an_unreachable_fork,
+                                 "Unable to provide a list of blocks starting at any of the blocks in peer's synopsis" );
          }
          for( uint32_t num = block_header::num_from_id(last_known_block_id);
               num <= _chain_db->head_block_num() && result.size() < limit;
@@ -778,7 +789,8 @@ namespace detail {
               {
                 // unable to get fork history for some reason.  maybe not linked?
                 // we can't return a synopsis of its chain
-                elog("Unable to construct a blockchain synopsis for reference hash ${hash}: ${exception}", ("hash", reference_point)("exception", e));
+                elog( "Unable to construct a blockchain synopsis for reference hash ${hash}: ${exception}",
+                      ("hash", reference_point)("exception", e) );
                 throw;
               }
               if (non_fork_high_block_num < low_block_num)
@@ -925,18 +937,24 @@ void application::set_program_options(boost::program_options::options_descriptio
 {
    configuration_file_options.add_options()
          ("p2p-endpoint", bpo::value<string>(), "Endpoint for P2P node to listen on")
-         ("seed-node,s", bpo::value<vector<string>>()->composing(), "P2P nodes to connect to on startup (may specify multiple times)")
-         ("seed-nodes", bpo::value<string>()->composing(), "JSON array of P2P nodes to connect to on startup")
-         ("checkpoint,c", bpo::value<vector<string>>()->composing(), "Pairs of [BLOCK_NUM,BLOCK_ID] that should be enforced as checkpoints.")
-         ("rpc-endpoint", bpo::value<string>()->implicit_value("127.0.0.1:8090"), "Endpoint for websocket RPC to listen on")
-         ("rpc-tls-endpoint", bpo::value<string>()->implicit_value("127.0.0.1:8089"), "Endpoint for TLS websocket RPC to listen on")
+         ("seed-node,s", bpo::value<vector<string>>()->composing(),
+          "P2P nodes to connect to on startup (may specify multiple times)")
+         ("seed-nodes", bpo::value<string>()->composing(),
+          "JSON array of P2P nodes to connect to on startup")
+         ("checkpoint,c", bpo::value<vector<string>>()->composing(),
+          "Pairs of [BLOCK_NUM,BLOCK_ID] that should be enforced as checkpoints.")
+         ("rpc-endpoint", bpo::value<string>()->implicit_value("127.0.0.1:8090"),
+          "Endpoint for websocket RPC to listen on")
+         ("rpc-tls-endpoint", bpo::value<string>()->implicit_value("127.0.0.1:8089"),
+          "Endpoint for TLS websocket RPC to listen on")
          ("server-pem,p", bpo::value<string>()->implicit_value("server.pem"), "The TLS certificate file for this server")
          ("server-pem-password,P", bpo::value<string>()->implicit_value(""), "Password for this certificate")
          ("genesis-json", bpo::value<boost::filesystem::path>(), "File to read Genesis State from")
          ("dbg-init-key", bpo::value<string>(), "Block signing key to use for init witnesses, overrides genesis file")
          ("api-access", bpo::value<boost::filesystem::path>(), "JSON file specifying API permissions")
          ("plugins", bpo::value<string>(), "Space-separated list of plugins to activate")
-         ("enable-subscribe-to-all", bpo::value<bool>()->implicit_value(false), "Whether allow API clients to subscribe to universal object creation and removal events")
+         ("enable-subscribe-to-all", bpo::value<bool>()->implicit_value(false),
+          "Whether allow API clients to subscribe to universal object creation and removal events")
          ;
    command_line_options.add(configuration_file_options);
    command_line_options.add_options()
@@ -947,7 +965,8 @@ void application::set_program_options(boost::program_options::options_descriptio
          ("replay-blockchain", "Rebuild object graph by replaying all blocks")
          ("resync-blockchain", "Delete all blocks and re-sync with network from scratch")
          ("force-validate", "Force validation of all transactions")
-         ("genesis-timestamp", bpo::value<uint32_t>(), "Replace timestamp from genesis.json with current time plus this many seconds (experts only!)")
+         ("genesis-timestamp", bpo::value<uint32_t>(),
+          "Replace timestamp from genesis.json with current time plus this many seconds (experts only!)")
          ;
    command_line_options.add(_cli_options);
    configuration_file_options.add(_cfg_options);

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -2187,7 +2187,8 @@ void database_api_impl::handle_object_changed(bool force_notify, bool full_objec
          }
       }
 
-      broadcast_updates(updates);
+      if( updates.size() )
+         broadcast_updates(updates);
    }
 
    if( _market_subscriptions.size() )
@@ -2206,7 +2207,8 @@ void database_api_impl::handle_object_changed(bool force_notify, bool full_objec
          }
       }
 
-      broadcast_market_updates(broadcast_queue);
+      if( broadcast_queue.size() )
+         broadcast_market_updates(broadcast_queue);
    }
 }
 

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -1174,20 +1174,22 @@ market_ticker database_api::get_ticker( const string& base, const string& quote 
 
 market_ticker database_api_impl::get_ticker( const string& base, const string& quote, bool skip_order_book )const
 {
-    const auto assets = lookup_asset_symbols( {base, quote} );
-    FC_ASSERT( assets[0], "Invalid base asset symbol: ${s}", ("s",base) );
-    FC_ASSERT( assets[1], "Invalid quote asset symbol: ${s}", ("s",quote) );
+   FC_ASSERT( _app_options && _app_options->has_market_history_plugin, "Market history plugin is not enabled." );
 
-    const fc::time_point_sec now = fc::time_point::now();
+   const auto assets = lookup_asset_symbols( {base, quote} );
+   FC_ASSERT( assets[0], "Invalid base asset symbol: ${s}", ("s",base) );
+   FC_ASSERT( assets[1], "Invalid quote asset symbol: ${s}", ("s",quote) );
 
-    market_ticker result;
-    result.time = now;
-    result.base = base;
-    result.quote = quote;
-    result.latest = "0";
-    result.lowest_ask = "0";
-    result.highest_bid = "0";
-    result.percent_change = "0";
+   const fc::time_point_sec now = fc::time_point::now();
+
+   market_ticker result;
+   result.time = now;
+   result.base = base;
+   result.quote = quote;
+   result.latest = "0";
+   result.lowest_ask = "0";
+   result.highest_bid = "0";
+   result.percent_change = "0";
 
    auto base_id = assets[0]->id;
    auto quote_id = assets[1]->id;
@@ -1244,16 +1246,16 @@ market_volume database_api::get_24_volume( const string& base, const string& quo
 
 market_volume database_api_impl::get_24_volume( const string& base, const string& quote )const
 {
-    const auto& ticker = get_ticker( base, quote, true );
+   const auto& ticker = get_ticker( base, quote, true );
 
-    market_volume result;
-    result.time = ticker.time;
-    result.base = ticker.base;
-    result.quote = ticker.quote;
-    result.base_volume = ticker.base_volume;
-    result.quote_volume = ticker.quote_volume;
+   market_volume result;
+   result.time = ticker.time;
+   result.base = ticker.base;
+   result.quote = ticker.quote;
+   result.base_volume = ticker.base_volume;
+   result.quote_volume = ticker.quote_volume;
 
-    return result;
+   return result;
 }
 
 order_book database_api::get_order_book( const string& base, const string& quote, unsigned limit )const
@@ -1308,6 +1310,8 @@ vector<market_volume> database_api::get_top_markets(uint32_t limit)const
 
 vector<market_volume> database_api_impl::get_top_markets(uint32_t limit)const
 {
+   FC_ASSERT( _app_options && _app_options->has_market_history_plugin, "Market history plugin is not enabled." );
+
    FC_ASSERT( limit <= 100 );
 
    const auto& volume_idx = _db.get_index_type<graphene::market_history::market_ticker_index>().indices().get<by_volume>();
@@ -1347,6 +1351,8 @@ vector<market_trade> database_api_impl::get_trade_history( const string& base,
                                                            fc::time_point_sec stop,
                                                            unsigned limit )const
 {
+   FC_ASSERT( _app_options && _app_options->has_market_history_plugin, "Market history plugin is not enabled." );
+
    FC_ASSERT( limit <= 100 );
 
    auto assets = lookup_asset_symbols( {base, quote} );
@@ -1436,6 +1442,8 @@ vector<market_trade> database_api_impl::get_trade_history_by_sequence(
                                                            fc::time_point_sec stop,
                                                            unsigned limit )const
 {
+   FC_ASSERT( _app_options && _app_options->has_market_history_plugin, "Market history plugin is not enabled." );
+
    FC_ASSERT( limit <= 100 );
    FC_ASSERT( start >= 0 );
    int64_t start_seq = -start;

--- a/libraries/app/include/graphene/app/application.hpp
+++ b/libraries/app/include/graphene/app/application.hpp
@@ -35,6 +35,12 @@ namespace graphene { namespace app {
 
    class abstract_plugin;
 
+   class application_options
+   {
+      public:
+         bool enable_subscribe_to_all = false;
+   };
+
    class application
    {
       public:
@@ -88,6 +94,8 @@ namespace graphene { namespace app {
          bool is_finished_syncing()const;
          /// Emitted when syncing finishes (is_finished_syncing will return true)
          boost::signals2::signal<void()> syncing_finished;
+
+         const application_options& get_options();
 
       private:
          void enable_plugin( const string& name );

--- a/libraries/app/include/graphene/app/application.hpp
+++ b/libraries/app/include/graphene/app/application.hpp
@@ -39,6 +39,7 @@ namespace graphene { namespace app {
    {
       public:
          bool enable_subscribe_to_all = false;
+         bool has_market_history_plugin = false;
    };
 
    class application

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -122,7 +122,7 @@ struct market_trade
 class database_api
 {
    public:
-      database_api(graphene::chain::database& db);
+      database_api(graphene::chain::database& db, const application_options* app_options = nullptr );
       ~database_api();
 
       /////////////

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -142,8 +142,29 @@ class database_api
       // Subscriptions //
       ///////////////////
 
-      void set_subscribe_callback( std::function<void(const variant&)> cb, bool clear_filter );
-      void set_pending_transaction_callback( std::function<void(const variant&)> cb );
+      /**
+       * @brief Register a callback handle which then can be used to subscribe to object database changes
+       * @param cb The callback handle to register
+       * @param nofity_remove_create Whether subscribe to universal object creation and removal events.
+       *        If this is set to true, the API server will notify all newly created objects and ID of all
+       *        newly removed objects to the client, no matter whether client subscribed to the objects.
+       *        By default, API servers don't allow subscribing to universal events, which can be changed
+       *        on server startup.
+       */
+      void set_subscribe_callback( std::function<void(const variant&)> cb, bool notify_remove_create );
+      /**
+       * @brief Register a callback handle which will get notified when a transaction is pushed to database
+       * @param cb The callback handle to register
+       *
+       * Note: a transaction can be pushed to database and be popped from database several times while
+       *   processing, before and after included in a block. Everytime when a push is done, the client will
+       *   be notified.
+       */
+      void set_pending_transaction_callback( std::function<void(const variant& signed_transaction_object)> cb );
+      /**
+       * @brief Register a callback handle which will get notified when a block is pushed to database
+       * @param cb The callback handle to register
+       */
       void set_block_applied_callback( std::function<void(const variant& block_id)> cb );
       /**
        * @brief Stop receiving any notifications

--- a/libraries/chain/db_notify.cpp
+++ b/libraries/chain/db_notify.cpp
@@ -382,7 +382,8 @@ void database::notify_changed_objects()
             get_relevant_accounts(obj, new_accounts_impacted);
         }
 
-        GRAPHENE_TRY_NOTIFY( new_objects, new_ids, new_accounts_impacted)
+        if( new_ids.size() )
+           GRAPHENE_TRY_NOTIFY( new_objects, new_ids, new_accounts_impacted)
       }
 
       // Changed
@@ -396,7 +397,8 @@ void database::notify_changed_objects()
           get_relevant_accounts(item.second.get(), changed_accounts_impacted);
         }
 
-        GRAPHENE_TRY_NOTIFY( changed_objects, changed_ids, changed_accounts_impacted)
+        if( changed_ids.size() )
+           GRAPHENE_TRY_NOTIFY( changed_objects, changed_ids, changed_accounts_impacted)
       }
 
       // Removed
@@ -413,7 +415,8 @@ void database::notify_changed_objects()
           get_relevant_accounts(obj, removed_accounts_impacted);
         }
 
-        GRAPHENE_TRY_NOTIFY( removed_objects, removed_ids, removed, removed_accounts_impacted)
+        if( removed_ids.size() )
+           GRAPHENE_TRY_NOTIFY( removed_objects, removed_ids, removed, removed_accounts_impacted)
       }
    }
 } FC_CAPTURE_AND_LOG( (0) ) }

--- a/tests/tests/database_api_tests.cpp
+++ b/tests/tests/database_api_tests.cpp
@@ -603,4 +603,67 @@ BOOST_AUTO_TEST_CASE( get_required_signatures_partially_signed_or_not ) {
    } FC_LOG_AND_RETHROW()
 }
 
+BOOST_AUTO_TEST_CASE( set_subscribe_callback_disable_notify_all_test ) {
+   try {
+      ACTORS( (alice) );
+
+      uint32_t objects_changed1 = 0;
+      uint32_t objects_changed2 = 0;
+      uint32_t objects_changed3 = 0;
+      auto callback1 = [&]( const variant& v )
+      {
+         ++objects_changed1;
+      };
+      auto callback2 = [&]( const variant& v )
+      {
+         ++objects_changed2;
+      };
+      auto callback3 = [&]( const variant& v )
+      {
+         ++objects_changed3;
+      };
+
+      uint32_t expected_objects_changed1 = 0;
+      uint32_t expected_objects_changed2 = 0;
+      uint32_t expected_objects_changed3 = 0;
+
+      graphene::app::database_api db_api1(db);
+
+      // subscribing to all should fail
+      BOOST_CHECK_THROW( db_api1.set_subscribe_callback( callback1, true ), fc::exception );
+
+      db_api1.set_subscribe_callback( callback1, false );
+
+      graphene::app::application_options opt;
+      opt.enable_subscribe_to_all = true;
+
+      graphene::app::database_api db_api2( db, &opt );
+      db_api2.set_subscribe_callback( callback2, true );
+
+      graphene::app::database_api db_api3( db, &opt );
+      db_api3.set_subscribe_callback( callback3, false );
+
+      vector<object_id_type> ids;
+      ids.push_back( alice_id );
+
+      db_api1.get_objects( ids ); // db_api1 subscribe to Alice
+      db_api2.get_objects( ids ); // db_api2 subscribe to Alice
+
+      generate_block();
+      ++expected_objects_changed2; // subscribed to all, notify block changes
+
+      transfer( account_id_type(), alice_id, asset(1) );
+      generate_block();
+      ++expected_objects_changed1; // subscribed to Alice, notify Alice balance change
+      ++expected_objects_changed2; // subscribed to all, notify block changes
+
+      fc::usleep(fc::milliseconds(200)); // sleep a while to execute callback in another thread
+
+      BOOST_CHECK_EQUAL( expected_objects_changed1, objects_changed1 );
+      BOOST_CHECK_EQUAL( expected_objects_changed2, objects_changed2 );
+      BOOST_CHECK_EQUAL( expected_objects_changed3, objects_changed3 );
+
+   } FC_LOG_AND_RETHROW()
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
<del>Temporarily commented out for future improvement.</del>

Update:
Added an `"enable-subscribe-to-all"` option in `application.cpp`, default value is `false`. Force-pushed.