### PR TITLE
fixed change in api constructor signature

### DIFF
--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -202,7 +202,7 @@ public:
       wallet_data.ws_password = "";
       websocket_connection  = websocket_client.connect( wallet_data.ws_server );
 
-      api_connection = std::make_shared<fc::rpc::websocket_api_connection>(*websocket_connection);
+      api_connection = std::make_shared<fc::rpc::websocket_api_connection>(*websocket_connection, GRAPHENE_MAX_NESTED_OBJECTS);
 
       remote_login_api = api_connection->get_remote_api< graphene::app::login_api >(1);
       BOOST_CHECK(remote_login_api->login( wallet_data.ws_user, wallet_data.ws_password ) );
@@ -213,7 +213,7 @@ public:
 
       wallet_api = fc::api<graphene::wallet::wallet_api>(wallet_api_ptr);
 
-      wallet_cli = std::make_shared<fc::rpc::cli>();
+      wallet_cli = std::make_shared<fc::rpc::cli>(GRAPHENE_MAX_NESTED_OBJECTS);
       for( auto& name_formatter : wallet_api_ptr->get_result_formatters() )
          wallet_cli->format_result( name_formatter.first, name_formatter.second );
 

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -129,6 +129,7 @@ std::shared_ptr<graphene::app::application> start_application(fc::temp_directory
    app1->register_plugin<graphene::account_history::account_history_plugin>();
    app1->register_plugin< graphene::market_history::market_history_plugin >();
    app1->register_plugin< graphene::witness_plugin::witness_plugin >();
+   app1->register_plugin< graphene::grouped_orders::grouped_orders_plugin>();
    app1->startup_plugins();
    boost::program_options::variables_map cfg;
    server_port_number = get_available_port();


### PR DESCRIPTION
A change in the fc::api signature caused the build of the cli test to fail. This PR fixes the issue.