### PR TITLE
change core token to 1.3.0

### DIFF
--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -316,7 +316,7 @@ BOOST_AUTO_TEST_CASE( cli_vote_for_2_witnesses )
 
       // attempt to give jmjatlanta some bitsahres
       BOOST_TEST_MESSAGE("Transferring bitshares from Nathan to jmjatlanta");
-      signed_transaction transfer_tx = con.wallet_api_ptr->transfer("nathan", "jmjatlanta", "10000", "BTS", "Here are some BTS for your new account", true);
+      signed_transaction transfer_tx = con.wallet_api_ptr->transfer("nathan", "jmjatlanta", "10000", "1.3.0", "Here are some BTS for your new account", true);
 
       // get the details for init1
       witness_object init1_obj = con.wallet_api_ptr->get_witness("init1");
@@ -412,7 +412,7 @@ BOOST_AUTO_TEST_CASE( cli_set_voting_proxy )
 
       // attempt to give jmjatlanta some bitsahres
       BOOST_TEST_MESSAGE("Transferring bitshares from Nathan to jmjatlanta");
-      signed_transaction transfer_tx = con.wallet_api_ptr->transfer("nathan", "jmjatlanta", "10000", "BTS", "Here are some BTS for your new account", true);
+      signed_transaction transfer_tx = con.wallet_api_ptr->transfer("nathan", "jmjatlanta", "10000", "1.3.0", "Here are some BTS for your new account", true);
 
       // grab account for comparison
       account_object prior_voting_account = con.wallet_api_ptr->get_account("jmjatlanta");


### PR DESCRIPTION
needed to the testnet to pass this tests, also to have the less differences possible between testnet and develop branch we are using 1.3.0 instead of BTS in mainnet and TEST in testnet.