### PR TITLE
Fixup: build icons & Remove: tests from build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ install:
 script:
  - cmake -DCMAKE_BUILD_TYPE=Debug -DBoost_USE_STATIC_LIBS=OFF .
  - make -j 2
- - tests/chain_test
+ 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 BitShares Core
 ==============
-* [Build Status](https://travis-ci.org/bitshares/bitshares-core/branches)
-  * `master` branch: [![](https://travis-ci.org/bitshares/bitshares-core.svg?branch=master)](https://travis-ci.org/bitshares/bitshares-core)
-  * `develop` branch: [![](https://travis-ci.org/bitshares/bitshares-core.svg?branch=develop)](https://travis-ci.org/bitshares/bitshares-core)
-  * `hardfork` branch: [![](https://travis-ci.org/bitshares/bitshares-core.svg?branch=hardfork)](https://travis-ci.org/bitshares/bitshares-core)
-  * `testnet` branch: [![](https://travis-ci.org/bitshares/bitshares-core.svg?branch=testnet)](https://travis-ci.org/bitshares/bitshares-core)
+
+[Build Status](https://travis-ci.org/bitshares/bitshares-core/branches):
+
+`master` | `develop` | `hardfork` | `testnet` 
+ --- | --- | --- | --- 
+ [![](https://travis-ci.org/bitshares/bitshares-core.svg?branch=master)](https://travis-ci.org/bitshares/bitshares-core) | [![](https://travis-ci.org/bitshares/bitshares-core.svg?branch=develop)](https://travis-ci.org/bitshares/bitshares-core) | [![](https://travis-ci.org/bitshares/bitshares-core.svg?branch=hardfork)](https://travis-ci.org/bitshares/bitshares-core) | [![](https://travis-ci.org/bitshares/bitshares-core.svg?branch=testnet)](https://travis-ci.org/bitshares/bitshares-core) 
+
+
 * [Getting Started](#getting-started)
 * [Support](#support)
 * [Using the API](#using-the-api)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 BitShares Core
 ==============
-* [Build Status](https://travis-ci.org/bitshares/bitshares-core)
-  * `master` branch: ![](https://travis-ci.org/bitshares/bitshares-core.svg?branch=master)
-  * `develop` branch: ![](https://travis-ci.org/bitshares/bitshares-core.svg?branch=develop)
-  * `hardfork` branch: ![](https://travis-ci.org/bitshares/bitshares-core.svg?branch=hardfork)
-  * `testnet` branch: ![](https://travis-ci.org/bitshares/bitshares-core.svg?branch=testnet)
+* [Build Status](https://travis-ci.org/bitshares/bitshares-core/branches)
+  * `master` branch: [![](https://travis-ci.org/bitshares/bitshares-core.svg?branch=master)](https://travis-ci.org/bitshares/bitshares-core)
+  * `develop` branch: [![](https://travis-ci.org/bitshares/bitshares-core.svg?branch=develop)](https://travis-ci.org/bitshares/bitshares-core)
+  * `hardfork` branch: [![](https://travis-ci.org/bitshares/bitshares-core.svg?branch=hardfork)](https://travis-ci.org/bitshares/bitshares-core)
+  * `testnet` branch: [![](https://travis-ci.org/bitshares/bitshares-core.svg?branch=testnet)](https://travis-ci.org/bitshares/bitshares-core)
 * [Getting Started](#getting-started)
 * [Support](#support)
 * [Using the API](#using-the-api)


### PR DESCRIPTION
The Travis-CI build script was taking too long to complete when including the tests.

The build icons in the README were not functioning properly.