### PR TITLE
Fixed namespace collision on bind in test

### DIFF
--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -109,7 +109,7 @@ int get_available_port()
    sin.sin_family = AF_INET;
    sin.sin_port = 0;
    sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-   if (bind(socket_fd, (struct sockaddr*)&sin, sizeof(struct sockaddr_in)) == -1)
+   if (::bind(socket_fd, (struct sockaddr*)&sin, sizeof(struct sockaddr_in)) == -1)
       return -1;
    socklen_t len = sizeof(sin);
    if (getsockname(socket_fd, (struct sockaddr *)&sin, &len) == -1)


### PR DESCRIPTION
When compiling on a mac, there is a namespace collision between ::bind() and std::bind() in tests/cli/main.cpp. This PR fixes the issue.