### PR TITLE
fix memory access violation

### DIFF
--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -151,9 +151,9 @@ namespace graphene { namespace app {
              {
                 auto block_num = b.block_num();
                 auto& callback = _callbacks.find(id)->second;
-                fc::async( [capture_this,this,id,block_num,trx_num,trx,callback]() {
-                   callback( fc::variant( transaction_confirmation{ id, block_num, trx_num, trx },
-                                          GRAPHENE_MAX_NESTED_OBJECTS ) );
+                auto v = fc::variant( transaction_confirmation{ id, block_num, trx_num, trx }, GRAPHENE_MAX_NESTED_OBJECTS );
+                fc::async( [capture_this,v,callback]() {
+                   callback(v);
                 } );
              }
           }


### PR DESCRIPTION
when running chain_tests on macOS the network_broadcast_api_tests fails with fatal error: in "network_broadcast_api_tests/broadcast_transaction_with_callback_test": signal: SIGSEGV, si_code: 0 (memory access violation at address: 0x00000000)
this code modification fixes it