### PR TITLE
Handle acc_trx_his_object in get_relevant_accounts

### DIFF
--- a/libraries/chain/db_notify.cpp
+++ b/libraries/chain/db_notify.cpp
@@ -228,60 +228,60 @@ static void get_relevant_accounts( const object* obj, flat_set<account_id_type>&
            break;
         } case asset_object_type:{
            const auto& aobj = dynamic_cast<const asset_object*>(obj);
-           assert( aobj != nullptr );
+           FC_ASSERT( aobj != nullptr );
            accounts.insert( aobj->issuer );
            break;
         } case force_settlement_object_type:{
            const auto& aobj = dynamic_cast<const force_settlement_object*>(obj);
-           assert( aobj != nullptr );
+           FC_ASSERT( aobj != nullptr );
            accounts.insert( aobj->owner );
            break;
         } case committee_member_object_type:{
            const auto& aobj = dynamic_cast<const committee_member_object*>(obj);
-           assert( aobj != nullptr );
+           FC_ASSERT( aobj != nullptr );
            accounts.insert( aobj->committee_member_account );
            break;
         } case witness_object_type:{
            const auto& aobj = dynamic_cast<const witness_object*>(obj);
-           assert( aobj != nullptr );
+           FC_ASSERT( aobj != nullptr );
            accounts.insert( aobj->witness_account );
            break;
         } case limit_order_object_type:{
            const auto& aobj = dynamic_cast<const limit_order_object*>(obj);
-           assert( aobj != nullptr );
+           FC_ASSERT( aobj != nullptr );
            accounts.insert( aobj->seller );
            break;
         } case call_order_object_type:{
            const auto& aobj = dynamic_cast<const call_order_object*>(obj);
-           assert( aobj != nullptr );
+           FC_ASSERT( aobj != nullptr );
            accounts.insert( aobj->borrower );
            break;
         } case custom_object_type:{
           break;
         } case proposal_object_type:{
            const auto& aobj = dynamic_cast<const proposal_object*>(obj);
-           assert( aobj != nullptr );
+           FC_ASSERT( aobj != nullptr );
            transaction_get_impacted_accounts( aobj->proposed_transaction, accounts );
            break;
         } case operation_history_object_type:{
            const auto& aobj = dynamic_cast<const operation_history_object*>(obj);
-           assert( aobj != nullptr );
+           FC_ASSERT( aobj != nullptr );
            operation_get_impacted_accounts( aobj->op, accounts );
            break;
         } case withdraw_permission_object_type:{
            const auto& aobj = dynamic_cast<const withdraw_permission_object*>(obj);
-           assert( aobj != nullptr );
+           FC_ASSERT( aobj != nullptr );
            accounts.insert( aobj->withdraw_from_account );
            accounts.insert( aobj->authorized_account );
            break;
         } case vesting_balance_object_type:{
            const auto& aobj = dynamic_cast<const vesting_balance_object*>(obj);
-           assert( aobj != nullptr );
+           FC_ASSERT( aobj != nullptr );
            accounts.insert( aobj->owner );
            break;
         } case worker_object_type:{
            const auto& aobj = dynamic_cast<const worker_object*>(obj);
-           assert( aobj != nullptr );
+           FC_ASSERT( aobj != nullptr );
            accounts.insert( aobj->worker_account );
            break;
         } case balance_object_type:{
@@ -306,22 +306,22 @@ static void get_relevant_accounts( const object* obj, flat_set<account_id_type>&
               break;
              case impl_account_balance_object_type:{
               const auto& aobj = dynamic_cast<const account_balance_object*>(obj);
-              assert( aobj != nullptr );
+              FC_ASSERT( aobj != nullptr );
               accounts.insert( aobj->owner );
               break;
            } case impl_account_statistics_object_type:{
               const auto& aobj = dynamic_cast<const account_statistics_object*>(obj);
-              assert( aobj != nullptr );
+              FC_ASSERT( aobj != nullptr );
               accounts.insert( aobj->owner );
               break;
            } case impl_transaction_object_type:{
               const auto& aobj = dynamic_cast<const transaction_object*>(obj);
-              assert( aobj != nullptr );
+              FC_ASSERT( aobj != nullptr );
               transaction_get_impacted_accounts( aobj->trx, accounts );
               break;
            } case impl_blinded_balance_object_type:{
               const auto& aobj = dynamic_cast<const blinded_balance_object*>(obj);
-              assert( aobj != nullptr );
+              FC_ASSERT( aobj != nullptr );
               for( const auto& a : aobj->owner.account_auths )
                 accounts.insert( a.first );
               break;
@@ -329,7 +329,7 @@ static void get_relevant_accounts( const object* obj, flat_set<account_id_type>&
               break;
              case impl_account_transaction_history_object_type: {
               const auto& aobj = dynamic_cast<const account_transaction_history_object*>(obj);
-              assert( aobj != nullptr );
+              FC_ASSERT( aobj != nullptr );
               accounts.insert( aobj->account );
               break;
            } case impl_chain_property_object_type:
@@ -346,7 +346,7 @@ static void get_relevant_accounts( const object* obj, flat_set<account_id_type>&
               break;
              case impl_collateral_bid_object_type:{
               const auto& aobj = dynamic_cast<const collateral_bid_object*>(obj);
-              assert( aobj != nullptr );
+              FC_ASSERT( aobj != nullptr );
               accounts.insert( aobj->bidder );
               break;
            }

--- a/libraries/chain/db_notify.cpp
+++ b/libraries/chain/db_notify.cpp
@@ -327,9 +327,12 @@ static void get_relevant_accounts( const object* obj, flat_set<account_id_type>&
               break;
            } case impl_block_summary_object_type:
               break;
-             case impl_account_transaction_history_object_type:
+             case impl_account_transaction_history_object_type: {
+              const auto& aobj = dynamic_cast<const account_transaction_history_object*>(obj);
+              assert( aobj != nullptr );
+              accounts.insert( aobj->account );
               break;
-             case impl_chain_property_object_type:
+           } case impl_chain_property_object_type:
               break;
              case impl_witness_schedule_object_type:
               break;


### PR DESCRIPTION
Actually, I'm not sure if it's skipped intentionally. See [this code](https://github.com/bitshares/bitshares-core/blob/3fcadc62da81c3b2078a434ec719eef9bd8cb72d/libraries/app/database_api.cpp#L301-L302):
```
         if( id.type() == operation_history_object_type && id.space() == protocol_ids ) continue;
         if( id.type() == impl_account_transaction_history_object_type && id.space() == implementation_ids ) continue;
```