### PR TITLE
bsip30 part 2: disallow increasing debt when updating short position

### DIFF
--- a/libraries/chain/market_evaluator.cpp
+++ b/libraries/chain/market_evaluator.cpp
@@ -213,6 +213,7 @@ void_result call_order_update_evaluator::do_apply(const call_order_update_operat
    const call_order_object* call_obj = nullptr;
 
    optional<price> old_collateralization;
+   optional<share_type> old_debt;
 
    if( itr == call_idx.end() )
    {
@@ -232,6 +233,7 @@ void_result call_order_update_evaluator::do_apply(const call_order_update_operat
    {
       call_obj = &*itr;
       old_collateralization = call_obj->collateralization();
+      old_debt = call_obj->debt;
 
       d.modify( *call_obj, [&]( call_order_object& call ){
           call.collateral += o.delta_collateral.amount;
@@ -244,8 +246,7 @@ void_result call_order_update_evaluator::do_apply(const call_order_update_operat
       });
    }
 
-   auto debt = call_obj->get_debt();
-   if( debt.amount == 0 )
+   if( call_obj->debt == 0 )
    {
       FC_ASSERT( call_obj->collateral == 0 );
       d.remove( *call_obj );
@@ -295,19 +296,22 @@ void_result call_order_update_evaluator::do_apply(const call_order_update_operat
                ("a", ~call_obj->call_price )("b", _bitasset_data->current_feed.settlement_price)
                );
          }
-         else // after hard fork, always allow call order to be updated if collateral ratio is increased
+         else // after hard fork, always allow call order to be updated if collateral ratio is increased and debt is not increased
          {
             // We didn't fill any call orders.  This may be because we
             // aren't in margin call territory, or it may be because there
             // were no matching orders. In the latter case,
-            // if collateral ratio is not increased, we throw.
+            // if collateral ratio is not increased or debt is increased, we throw.
             // be here, we know no margin call was executed,
             // so call_obj's collateral ratio should be set only by op
-            FC_ASSERT( ( old_collateralization.valid() && call_obj->collateralization() > *old_collateralization )
+            FC_ASSERT( ( old_collateralization.valid() && call_obj->debt <= *old_debt
+                                                       && call_obj->collateralization() > *old_collateralization )
                        || ~call_obj->call_price < _bitasset_data->current_feed.settlement_price,
-               "Can only update to higher collateral ratio if it would trigger a margin call that cannot be fully filled",
+               "Can only increase collateral ratio without increasing debt if would trigger a margin call that cannot be fully filled",
                ("new_call_price", ~call_obj->call_price )
                ("settlement_price", _bitasset_data->current_feed.settlement_price)
+               ("old_debt", old_debt)
+               ("new_debt", call_obj->debt)
                ("old_collateralization", old_collateralization)
                ("new_collateralization", call_obj->collateralization() )
                );

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -547,11 +547,8 @@ BOOST_AUTO_TEST_CASE( more_call_order_update_test_after_hardfork_583 )
       BOOST_TEST_MESSAGE( "dan borrow 2500 more usd wth 5002 more core should not be allowed..." );
       GRAPHENE_REQUIRE_THROW( borrow( dan, bitusd.amount(2500), core.amount(5002)  ), fc::exception );
 
-      BOOST_TEST_MESSAGE( "dan borrow 2500 more usd wth 5003 more core should be allowed..." );
-      borrow( dan, bitusd.amount(2500), asset(5003));
-      BOOST_REQUIRE_EQUAL( get_balance( dan, bitusd ), 5000 );
-      BOOST_REQUIRE_EQUAL( get_balance( dan, core ), 10000000 - 10000 + 4999 - 1 - 5003 );
-
+      BOOST_TEST_MESSAGE( "dan borrow 2500 more usd wth 5003 more core should not be allowed..." );
+      GRAPHENE_REQUIRE_THROW( borrow( dan, bitusd.amount(2500), asset(5003) ), fc::exception );
 
    } catch (fc::exception& e) {
       edump((e.to_detail_string()));


### PR DESCRIPTION
For [BSIP 30](https://github.com/bitshares/bsips/blob/master/bsip-0030.md).
The first part has been merged in https://github.com/bitshares/bitshares-core/pull/655, this is the second part, described in #672.