### PR TITLE
BSIP38 add target_cr option to call order

### DIFF
--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -84,6 +84,7 @@ add_library( graphene_chain
              account_object.cpp
              asset_object.cpp
              fba_object.cpp
+             market_object.cpp
              proposal_object.cpp
              vesting_balance_object.cpp
 

--- a/libraries/chain/hardfork.d/CORE_834.hf
+++ b/libraries/chain/hardfork.d/CORE_834.hf
@@ -1,0 +1,4 @@
+// bitshares-core issue #834 "BSIP38: add target CR option to short positions"
+#ifndef HARDFORK_CORE_834_TIME
+#define HARDFORK_CORE_834_TIME (fc::time_point_sec( 1600000000 ))
+#endif

--- a/libraries/chain/include/graphene/chain/database.hpp
+++ b/libraries/chain/include/graphene/chain/database.hpp
@@ -366,7 +366,8 @@ namespace graphene { namespace chain {
           */
          ///@{
          int match( const limit_order_object& taker, const limit_order_object& maker, const price& trade_price );
-         int match( const limit_order_object& taker, const call_order_object& maker, const price& trade_price );
+         int match( const limit_order_object& taker, const call_order_object& maker, const price& trade_price,
+                    const price& feed_price, const uint16_t maintenance_collateral_ratio );
          /// @return the amount of asset settled
          asset match(const call_order_object& call,
                    const force_settlement_object& settle,

--- a/libraries/chain/include/graphene/chain/market_object.hpp
+++ b/libraries/chain/include/graphene/chain/market_object.hpp
@@ -125,12 +125,20 @@ class call_order_object : public abstract_object<call_order_object>
       share_type       debt;        ///< call_price.quote.asset_id, access via get_debt
       price            call_price;  ///< Collateral / Debt
 
+      optional<uint16_t> target_collateral_ratio; ///< maximum CR to maintain when selling collateral on margin call
+
       pair<asset_id_type,asset_id_type> get_market()const
       {
          auto tmp = std::make_pair( call_price.base.asset_id, call_price.quote.asset_id );
          if( tmp.first > tmp.second ) std::swap( tmp.first, tmp.second );
          return tmp;
       }
+
+      /// Calculate maximum quantity of collateral to sell and debt to cover to meet @ref target_collateral_ratio.
+      /// @return a pair of assets, the first item is collateral to sell, the second is debt to cover
+      pair<asset, asset> get_max_sell_receive_pair( const price& match_price,
+                                                    const price& feed_price,
+                                                    const uint16_t maintenance_collateral_ratio )const;
 };
 
 /**
@@ -259,7 +267,7 @@ FC_REFLECT_DERIVED( graphene::chain::limit_order_object,
                   )
 
 FC_REFLECT_DERIVED( graphene::chain::call_order_object, (graphene::db::object),
-                    (borrower)(collateral)(debt)(call_price) )
+                    (borrower)(collateral)(debt)(call_price)(target_collateral_ratio) )
 
 FC_REFLECT_DERIVED( graphene::chain::force_settlement_object,
                     (graphene::db::object),

--- a/libraries/chain/include/graphene/chain/protocol/market.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/market.hpp
@@ -23,6 +23,7 @@
  */
 #pragma once
 #include <graphene/chain/protocol/base.hpp>
+#include <graphene/chain/protocol/ext.hpp>
 
 namespace graphene { namespace chain { 
 
@@ -94,8 +95,6 @@ namespace graphene { namespace chain {
       void            validate()const;
    };
 
-
-
    /**
     *  @ingroup operations
     *
@@ -110,6 +109,16 @@ namespace graphene { namespace chain {
     */
    struct call_order_update_operation : public base_operation
    {
+      /**
+       * Options to be used in @ref call_order_update_operation.
+       *
+       * @note this struct can be expanded by adding more options in the end.
+       */
+      struct options_type
+      {
+         optional<uint16_t> target_collateral_ratio; ///< maximum CR to maintain when selling collateral on margin call
+      };
+
       /** this is slightly more expensive than limit orders, this pricing impacts prediction markets */
       struct fee_parameters_type { uint64_t fee = 20 * GRAPHENE_BLOCKCHAIN_PRECISION; };
 
@@ -117,7 +126,9 @@ namespace graphene { namespace chain {
       account_id_type     funding_account; ///< pays fee, collateral, and cover
       asset               delta_collateral; ///< the amount of collateral to add to the margin position
       asset               delta_debt; ///< the amount of the debt to be paid off, may be negative to issue new debt
-      extensions_type     extensions;
+
+      typedef vector<extension<options_type>> extension_type; // use a vector here to be compatible with old JSON
+      extension_type      extensions;
 
       account_id_type fee_payer()const { return funding_account; }
       void            validate()const;
@@ -213,6 +224,10 @@ FC_REFLECT( graphene::chain::call_order_update_operation::fee_parameters_type, (
 FC_REFLECT( graphene::chain::bid_collateral_operation::fee_parameters_type, (fee) )
 FC_REFLECT( graphene::chain::fill_order_operation::fee_parameters_type,  ) // VIRTUAL
 FC_REFLECT( graphene::chain::execute_bid_operation::fee_parameters_type,  ) // VIRTUAL
+
+FC_REFLECT( graphene::chain::call_order_update_operation::options_type, (target_collateral_ratio) )
+
+FC_REFLECT_TYPENAME( graphene::chain::call_order_update_operation::extension_type )
 
 FC_REFLECT( graphene::chain::limit_order_create_operation,(fee)(seller)(amount_to_sell)(min_to_receive)(expiration)(fill_or_kill)(extensions))
 FC_REFLECT( graphene::chain::limit_order_cancel_operation,(fee)(fee_paying_account)(order)(extensions) )

--- a/libraries/chain/market_evaluator.cpp
+++ b/libraries/chain/market_evaluator.cpp
@@ -157,6 +157,11 @@ void_result call_order_update_evaluator::do_evaluate(const call_order_update_ope
 { try {
    database& d = db();
 
+   // TODO: remove this check and the assertion after hf_834
+   if( d.get_dynamic_global_properties().next_maintenance_time <= HARDFORK_CORE_834_TIME )
+      FC_ASSERT( o.extensions.empty(),
+                 "Can not specify non-empty extensions in call_order_update_operation before hardfork 834." );
+
    _paying_account = &o.funding_account(d);
    _debt_asset     = &o.delta_debt.asset_id(d);
    FC_ASSERT( _debt_asset->is_market_issued(), "Unable to cover ${sym} as it is not a collateralized asset.",
@@ -221,6 +226,10 @@ void_result call_order_update_evaluator::do_apply(const call_order_update_operat
 
    optional<price> old_collateralization;
 
+   optional<uint16_t> new_target_cr; // new target collateral ratio
+   if( o.extensions.size() > 0 )
+      new_target_cr = o.extensions.front().value.target_collateral_ratio;
+
    if( itr == call_idx.end() )
    {
       FC_ASSERT( o.delta_collateral.amount > 0 );
@@ -232,7 +241,7 @@ void_result call_order_update_evaluator::do_apply(const call_order_update_operat
          call.debt = o.delta_debt.amount;
          call.call_price = price::call_price(o.delta_debt, o.delta_collateral,
                                              _bitasset_data->current_feed.maintenance_collateral_ratio);
-
+         call.target_collateral_ratio = new_target_cr;
       });
    }
    else
@@ -241,13 +250,14 @@ void_result call_order_update_evaluator::do_apply(const call_order_update_operat
       old_collateralization = call_obj->collateralization();
 
       d.modify( *call_obj, [&]( call_order_object& call ){
-          call.collateral += o.delta_collateral.amount;
-          call.debt       += o.delta_debt.amount;
-          if( call.debt > 0 )
-          {
-             call.call_price  =  price::call_price(call.get_debt(), call.get_collateral(),
-                                                   _bitasset_data->current_feed.maintenance_collateral_ratio);
-          }
+         call.collateral += o.delta_collateral.amount;
+         call.debt       += o.delta_debt.amount;
+         if( call.debt > 0 )
+         {
+            call.call_price  =  price::call_price(call.get_debt(), call.get_collateral(),
+                                                  _bitasset_data->current_feed.maintenance_collateral_ratio);
+         }
+         call.target_collateral_ratio = new_target_cr;
       });
    }
 

--- a/libraries/chain/market_object.cpp
+++ b/libraries/chain/market_object.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2018 Abit More, and contributors.
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <graphene/chain/market_object.hpp>
+
+#include <boost/multiprecision/cpp_int.hpp>
+
+using namespace graphene::chain;
+
+/*
+target_CR = max( target_CR, MCR )
+
+target_CR = new_collateral / ( new_debt / feed_price )
+          = ( collateral - max_amount_to_sell ) * feed_price
+            / ( debt - amount_to_get )
+          = ( collateral - max_amount_to_sell ) * feed_price
+            / ( debt - max_amount_to_sell * match_price )
+=>
+max_amount_to_sell = (debt * target_CR - collateral * feed_price)
+                     / (target_CR * match_price - feed_price)
+                   = (debt * tCR / DENOM - collateral * fp_debt_amt / fp_coll_amt)
+                     / ( (tCR / DENOM) * (mp_debt_amt / mp_coll_amt) - fp_debt_amt / fp_coll_amt )
+                   = (debt * tCR * fp_coll_amt * mp_coll_amt - collateral * fp_debt_amt * DENOM * mp_coll_amt)
+                     / ( tCR * mp_debt_amt * fp_coll_amt - fp_debt_amt * DENOM * mp_coll_amt )
+max_debt_to_cover = max_amount_to_sell * match_price
+                  = max_amount_to_sell * mp_debt_amt / mp_coll_amt
+                  = (debt * tCR * fp_coll_amt * mp_debt_amt - collateral * fp_debt_amt * DENOM * mp_debt_amt)
+                    / (tCR * mp_debt_amt * fp_coll_amt - fp_debt_amt * DENOM * mp_coll_amt)
+*/
+pair<asset, asset> call_order_object::get_max_sell_receive_pair( const price& match_price,
+                                                                 const price& feed_price,
+                                                                 const uint16_t maintenance_collateral_ratio )const
+{
+   if( !target_collateral_ratio.valid() )
+      return make_pair( get_collateral(), get_debt() );
+
+   if( call_price > feed_price ) // feed protected
+      return make_pair( asset( 0, collateral_type() ), asset( 0, debt_type() ) );
+
+   uint16_t tcr = std::max( *target_collateral_ratio, maintenance_collateral_ratio );
+
+   typedef boost::multiprecision::int256_t i256;
+   i256 mp_debt_amt, mp_coll_amt, fp_debt_amt, fp_coll_amt;
+
+   if( match_price.base.asset_id == call_price.base.asset_id )
+   {
+      mp_debt_amt = match_price.quote.amount.value;
+      mp_coll_amt = match_price.base.amount.value;
+   }
+   else
+   {
+      mp_debt_amt = match_price.base.amount.value;
+      mp_coll_amt = match_price.quote.amount.value;
+   }
+   if( feed_price.base.asset_id == call_price.base.asset_id )
+   {
+      fp_debt_amt = feed_price.quote.amount.value;
+      fp_coll_amt = feed_price.base.amount.value;
+   }
+   else
+   {
+      fp_debt_amt = feed_price.base.amount.value;
+      fp_coll_amt = feed_price.quote.amount.value;
+   }
+
+   i256 numerator = fp_coll_amt * mp_debt_amt * debt.value * tcr
+                  - fp_debt_amt * mp_debt_amt * collateral.value * GRAPHENE_COLLATERAL_RATIO_DENOM;
+   FC_ASSERT( numerator >= 0 );
+
+   i256 denominator = fp_coll_amt * mp_debt_amt * tcr - fp_debt_amt * mp_coll_amt * GRAPHENE_COLLATERAL_RATIO_DENOM;
+   FC_ASSERT( denominator > 0 );
+
+   i256 to_cover_i256 = ( numerator + denominator - 1 ) / denominator; // aka round_up( numerator / denominator )
+   share_type to_cover_amt = static_cast< int64_t >( to_cover_i256 );
+   FC_ASSERT( to_cover_amt >= 0 );
+
+   if( to_cover_amt >= debt )
+      return make_pair( get_collateral(), get_debt() );
+
+   // calculate paying collateral (round up), then re-calculate amount of debt would cover (round down)
+   asset to_pay = asset( to_cover_amt, debt_type() ) ^ match_price;
+   asset to_cover = to_pay * match_price;
+
+   if( to_cover.amount >= debt || to_pay.amount >= collateral )
+      return make_pair( get_collateral(), get_debt() );
+
+   // check collateral ratio after filled
+   if( ( get_collateral() / get_debt() ) <= ( to_pay / to_cover ) )
+      return make_pair( get_collateral(), get_debt() );
+
+   return make_pair( std::move(to_pay), std::move(to_cover) );
+}

--- a/libraries/chain/protocol/market.cpp
+++ b/libraries/chain/protocol/market.cpp
@@ -43,6 +43,17 @@ void call_order_update_operation::validate()const
    FC_ASSERT( fee.amount >= 0 );
    FC_ASSERT( delta_collateral.asset_id != delta_debt.asset_id );
    FC_ASSERT( delta_collateral.amount != 0 || delta_debt.amount != 0 );
+
+   FC_ASSERT( extensions.size() <= 1, "At most one object is allowed in extensions of call_order_update_operation" );
+   if( extensions.size() > 0 )
+   {
+      const auto& options = extensions.front().value;
+      size_t count = 0; // use a count variable for future expansions
+      if( options.target_collateral_ratio.valid() )
+         ++count;
+      FC_ASSERT( count > 0, "Empty object is not allowed in extensions of call_order_update_operation" );
+   }
+
 } FC_CAPTURE_AND_RETHROW((*this)) }
 
 void bid_collateral_operation::validate()const

--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -971,6 +971,26 @@ class wallet_api
       signed_transaction borrow_asset(string borrower_name, string amount_to_borrow, string asset_symbol,
                                       string amount_of_collateral, bool broadcast = false);
 
+      /** Borrow an asset or update the debt/collateral ratio for the loan, with additional options.
+       *
+       * This is the first step in shorting an asset.  Call \c sell_asset() to complete the short.
+       *
+       * @param borrower_name the name or id of the account associated with the transaction.
+       * @param amount_to_borrow the amount of the asset being borrowed.  Make this value
+       *                         negative to pay back debt.
+       * @param asset_symbol the symbol or id of the asset being borrowed.
+       * @param amount_of_collateral the amount of the backing asset to add to your collateral
+       *        position.  Make this negative to claim back some of your collateral.
+       *        The backing asset is defined in the \c bitasset_options for the asset being borrowed.
+       * @param extensions additional options
+       * @param broadcast true to broadcast the transaction on the network
+       * @returns the signed transaction borrowing the asset
+       */
+      signed_transaction borrow_asset_ext( string borrower_name, string amount_to_borrow, string asset_symbol,
+                                           string amount_of_collateral,
+                                           call_order_update_operation::extension_type extensions,
+                                           bool broadcast = false );
+
       /** Cancel an existing order
        *
        * @param order_id the id of order to be cancelled
@@ -1688,6 +1708,7 @@ FC_API( graphene::wallet::wallet_api,
         (create_account_with_brain_key)
         (sell_asset)
         (borrow_asset)
+        (borrow_asset_ext)
         (cancel_order)
         (transfer)
         (transfer2)


### PR DESCRIPTION
This is PR for #834, aka [BSIP38: Add target collateral ratio option to short positions](https://github.com/bitshares/bsips/blob/master/bsip-0038.md).

The code is ready for review, but still need (lots of) test cases.