### PR TITLE
Fix #805, Add parameters to configure log rotation

### DIFF
--- a/programs/witness_node/main.cpp
+++ b/programs/witness_node/main.cpp
@@ -117,7 +117,7 @@ static void load_config_file( const fc::path& config_ini_path, const bpo::option
    }
    catch (const fc::exception&)
    {
-      FC_THROW_EXCEPTION(fc::parse_error_exception, "Error parsing logging config from config file ${config}", ("config", config_ini_path.preferred_string()));
+      wlog("Error parsing logging config from config file ${config}, using default config", ("config", config_ini_path.preferred_string()));
    }
 }
 

--- a/programs/witness_node/main.cpp
+++ b/programs/witness_node/main.cpp
@@ -362,8 +362,9 @@ fc::optional<fc::logging_config> load_logging_config_from_ini_file(const fc::pat
             fc::path file_name = section_tree.get<std::string>("filename");
             if (file_name.is_relative())
                file_name = fc::absolute(config_ini_filename).parent_path() / file_name;
+
             int interval = section_tree.get_optional<int>("rotation_interval").get_value_or(60);
-            int limit = section_tree.get_optional<int>("rotation_limit").get_value_or(7);
+            int limit = section_tree.get_optional<int>("rotation_limit").get_value_or(1);
 
             // construct a default file appender config here
             // filename will be taken from ini file, everything else hard-coded here


### PR DESCRIPTION
Following cases passed:

1. First time witness startup config.ini was generated  `rotation_interval`, `rotation_limit` with default value: 60, 7
2. Modify these two configs manually and restart witness, the two configs prints right value (tested by adding a ilog)
3. Modify `rotation_interval`, `rotation_limit` to non-number value, like "abcd", "qwer", the two configs prints the default value: 60, 7
4. Modify `rotation_interval` to 6 (minutes), the p2p log rotates as expected
5. Modify my system time to 2 days ago, and modify `rotation_limit` to 2, the start witness, thus output a log timed 2 days ago; then modify system time back, and restart witness, the log be removed
6. Same as 5th case except output a 1 day ago log, modify system time back and restart witness, the log not be removed