### PR TITLE
fix warning: 'index_entry' defined as a struct here but previously declared as a class

### DIFF
--- a/libraries/chain/include/graphene/chain/block_database.hpp
+++ b/libraries/chain/include/graphene/chain/block_database.hpp
@@ -26,7 +26,7 @@
 #include <graphene/chain/protocol/block.hpp>
 
 namespace graphene { namespace chain {
-   class index_entry;
+   struct index_entry;
 
    class block_database 
    {


### PR DESCRIPTION
…clared as a class