### PR TITLE
Fix #864

### DIFF
--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -1820,6 +1820,7 @@ public:
       owned_keys.reserve( pks.size() );
       std::copy_if( pks.begin(), pks.end(), std::inserter(owned_keys, owned_keys.end()),
                     [this](const public_key_type& pk){ return _keys.find(pk) != _keys.end(); } );
+      tx.signatures.clear();
       set<public_key_type> approving_key_set = _remote_db->get_required_signatures( tx, owned_keys );
 
       auto dyn_props = get_dynamic_global_properties();


### PR DESCRIPTION
sign_transaction calls get_required_signatures to find out which signatures need to be added. get_required_signatures will not report signatures that are already present. Later, however, sign_transaction removes the signatures that were already there, and only adds those reported by get_required_signatures.

The fix is to clear all signatures before calling get_required_signatures.

Resolves #864 