### PR TITLE
Fix history ids

### DIFF
--- a/libraries/plugins/account_history/account_history_plugin.cpp
+++ b/libraries/plugins/account_history/account_history_plugin.cpp
@@ -98,6 +98,7 @@ void account_history_plugin_impl::update_account_histories( const signed_block& 
       optional<operation_history_object> oho;
 
       auto create_oho = [&]() {
+         is_first = false;
          return optional<operation_history_object>( db.create<operation_history_object>( [&]( operation_history_object& h )
          {
             if( o_op.valid() )

--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -90,6 +90,16 @@ void elasticsearch_plugin_impl::update_account_histories( const signed_block& b 
 {
    graphene::chain::database& db = database();
    const vector<optional< operation_history_object > >& hist = db.get_applied_operations();
+   bool is_first = true;
+   auto skip_oho_id = [&is_first,&db,this]() {
+      if( is_first && db._undo_db.enabled() ) // this ensures that the current id is rolled back on undo
+      {
+         db.remove( db.create<operation_history_object>( []( operation_history_object& obj) {} ) );
+         is_first = false;
+      }
+      else
+         _oho_index->use_next_id();
+   };
    for( const optional< operation_history_object >& o_op : hist ) {
       optional <operation_history_object> oho;
 
@@ -109,7 +119,7 @@ void elasticsearch_plugin_impl::update_account_histories( const signed_block& b 
       };
 
       if( !o_op.valid() ) {
-         _oho_index->use_next_id();
+         skip_oho_id();
          continue;
       }
       oho = create_oho();

--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -104,6 +104,7 @@ void elasticsearch_plugin_impl::update_account_histories( const signed_block& b 
       optional <operation_history_object> oho;
 
       auto create_oho = [&]() {
+         is_first = false;
          return optional<operation_history_object>(
                db.create<operation_history_object>([&](operation_history_object &h) {
                   if (o_op.valid())

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -102,6 +102,7 @@ database_fixture::database_fixture()
       std::string track = "\"1.2.17\"";
       track_account.push_back(track);
       options.insert(std::make_pair("track-account", boost::program_options::variable_value(track_account, false)));
+      options.insert(std::make_pair("partial-operations", boost::program_options::variable_value(true, false)));
    }
    // account tracking 2 accounts
    if( !options.count("track-account") && boost::unit_test::framework::current_test_case().p_name.value == "track_account2") {


### PR DESCRIPTION
Fixes #585 

The first time we need to skip an operation_history ID we use create/remove, this will store the previous "next_id" in undo_database. For subsequent operations we still use use_next_id for better performance.