### PR TITLE
Issue #659 - add P2P security options

### DIFF
--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -170,7 +170,14 @@ void application_impl::reset_p2p_node(const fc::path& data_dir)
    ilog("Configured p2p node to listen on ${ip}", ("ip", _p2p_network->get_actual_listening_endpoint()));
 
    if (_options->count("advertise-peer-algorithm") )
-      _p2p_network->set_advertise_algorithm( _options->at("advertise-peer-algorithm").as<string>() );
+   {
+      if ( _options->count("advertise-peer-list") )
+         _p2p_network->set_advertise_algorithm( 
+               _options->at("advertise-peer-algorithm").as<string>(),
+               _options->at("advertise-peer-list").as<std::vector<std::string>>() );
+      else
+         _p2p_network->set_advertise_algorithm( _options->at("advertise-peer-algorithm").as<string>() );
+   }
 
    if (_options->count("accept-incoming-connections") )
       _p2p_network->accept_incoming_connections( _options->at("accept-incoming-connections").as<bool>() );
@@ -960,6 +967,8 @@ void application::set_program_options(boost::program_options::options_descriptio
          ("plugins", bpo::value<string>(), "Space-separated list of plugins to activate")
          ("accept-incoming-connections", bpo::value<bool>()->implicit_value(true), "Accept incoming connections")
          ("advertise-peer-algorithm", bpo::value<string>()->implicit_value("all"), "Determines which peers are advertised")
+         ("advertise-peer-list", bpo::value<vector<string>>()->composing(), 
+            "P2P nodes to advertise (may specify multiple times")
          ;
    command_line_options.add(configuration_file_options);
    command_line_options.add_options()

--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -191,8 +191,8 @@ void application_impl::reset_p2p_node(const fc::path& data_dir)
    _p2p_network->listen_to_p2p_network();
    ilog("Configured p2p node to listen on ${ip}", ("ip", _p2p_network->get_actual_listening_endpoint()));
 
-   if (_options->count("advertise-peer-algorithm") && _options->at("advertise-peer-algorithm").as<string>() == "nothing" )
-      _p2p_network->disable_peer_advertising();
+   if (_options->count("advertise-peer-algorithm") )
+      _p2p_network->set_advertise_algorithm( _options->at("advertise-peer-algorithm").as<string>() );
 
    if (_options->count("accept-incoming-connections") )
       _p2p_network->accept_incoming_connections( _options->at("accept-incoming-connections").as<bool>() );

--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -208,6 +208,12 @@ void application_impl::reset_p2p_node(const fc::path& data_dir)
    _p2p_network->listen_to_p2p_network();
    ilog("Configured p2p node to listen on ${ip}", ("ip", _p2p_network->get_actual_listening_endpoint()));
 
+   if (_options->count("disable-peer-advertising") && _options->at("disable-peer-advertising").as<bool>() )
+      _p2p_network->disable_peer_advertising();
+
+   if (_options->count("accept-incoming-connections") )
+      _p2p_network->accept_incoming_connections( _options->at("accept-incoming-connections").as<bool>() );
+
    _p2p_network->connect_to_p2p_network();
    _p2p_network->sync_from(net::item_id(net::core_message_type_enum::block_message_type,
                                         _chain_db->head_block_id()),
@@ -1029,6 +1035,8 @@ void application::set_program_options(boost::program_options::options_descriptio
          ("force-validate", "Force validation of all transactions during normal operation")
          ("genesis-timestamp", bpo::value<uint32_t>(),
           "Replace timestamp from genesis.json with current time plus this many seconds (experts only!)")
+         ("disable-peer-advertising", bpo::value<bool>()->implicit_value(false), "Disable peer advertising")
+         ("accept-incoming-connections", bpo::value<bool>()->implicit_value(true), "Accept incoming connections")
          ;
    command_line_options.add(_cli_options);
    configuration_file_options.add(_cfg_options);

--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -125,7 +125,7 @@ void application_impl::reset_p2p_node(const fc::path& data_dir)
    if( _options->count("seed-node") )
    {
       auto seeds = _options->at("seed-node").as<vector<string>>();
-      _p2p_network->add_seed_nodes(seeds, true);
+      _p2p_network->add_seed_nodes(seeds);
    }
 
    // passed as a collection of URLs in a string
@@ -133,7 +133,7 @@ void application_impl::reset_p2p_node(const fc::path& data_dir)
    {
       auto seeds_str = _options->at("seed-nodes").as<string>();
       auto seeds = fc::json::from_string(seeds_str).as<vector<string>>(2);
-      _p2p_network->add_seed_nodes(seeds, false);
+      _p2p_network->add_seed_nodes(seeds);
    }
    else
    {
@@ -159,7 +159,7 @@ void application_impl::reset_p2p_node(const fc::path& data_dir)
          "seed.bts.bangzi.info:55501",        // Bangzi       (Germany)
          "seeds.bitshares.eu:1776"            // pc           (http://seeds.quisquis.de/bitshares.html)
       };
-      _p2p_network->add_seed_nodes(seeds, false);
+      _p2p_network->add_seed_nodes(seeds);
    }
 
    if( _options->count("p2p-endpoint") )

--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -121,33 +121,19 @@ void application_impl::reset_p2p_node(const fc::path& data_dir)
    _p2p_network->load_configuration(data_dir / "p2p");
    _p2p_network->set_node_delegate(this);
 
+   // passed as one URL per parameter
    if( _options->count("seed-node") )
    {
       auto seeds = _options->at("seed-node").as<vector<string>>();
-      for( const string& endpoint_string : seeds )
-      {
-         try {
-            _p2p_network->add_seed_node(endpoint_string, true);
-         } catch( const fc::exception& e ) {
-            wlog( "caught exception ${e} while adding seed node ${endpoint}",
-                     ("e", e.to_detail_string())("endpoint", endpoint_string) );
-         }
-      }
+      _p2p_network->add_seed_nodes(seeds, true);
    }
 
+   // passed as a collection of URLs in a string
    if( _options->count("seed-nodes") )
    {
       auto seeds_str = _options->at("seed-nodes").as<string>();
       auto seeds = fc::json::from_string(seeds_str).as<vector<string>>(2);
-      for( const string& endpoint_string : seeds )
-      {
-         try {
-            _p2p_network->add_seed_node(endpoint_string, false);
-         } catch( const fc::exception& e ) {
-            wlog( "caught exception ${e} while adding seed node ${endpoint}",
-                     ("e", e.to_detail_string())("endpoint", endpoint_string) );
-         }
-      }
+      _p2p_network->add_seed_nodes(seeds, false);
    }
    else
    {
@@ -173,15 +159,7 @@ void application_impl::reset_p2p_node(const fc::path& data_dir)
          "seed.bts.bangzi.info:55501",        // Bangzi       (Germany)
          "seeds.bitshares.eu:1776"            // pc           (http://seeds.quisquis.de/bitshares.html)
       };
-      for( const string& endpoint_string : seeds )
-      {
-         try {
-            _p2p_network->add_seed_node(endpoint_string, false);
-         } catch( const fc::exception& e ) {
-            wlog( "caught exception ${e} while adding seed node ${endpoint}",
-                     ("e", e.to_detail_string())("endpoint", endpoint_string) );
-         }
-      }
+      _p2p_network->add_seed_nodes(seeds, false);
    }
 
    if( _options->count("p2p-endpoint") )

--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -964,7 +964,6 @@ void application::set_program_options(boost::program_options::options_descriptio
           "For asset_api::get_asset_holders to set its default limit value as 100")
 		   ("api-limit-get-key-references",boost::program_options::value<uint64_t>()->default_value(100),
 		    "For database_api_impl::get_key_references to set its default limit value as 100")
-         ("plugins", bpo::value<string>(), "Space-separated list of plugins to activate")
          ("accept-incoming-connections", bpo::value<bool>()->implicit_value(true), "Accept incoming connections")
          ("advertise-peer-algorithm", bpo::value<string>()->implicit_value("all"), "Determines which peers are advertised")
          ("advertise-peer-list", bpo::value<vector<string>>()->composing(), 

--- a/libraries/app/application_impl.hxx
+++ b/libraries/app/application_impl.hxx
@@ -22,8 +22,6 @@ class application_impl : public net::node_delegate
 
       void reset_p2p_node(const fc::path& data_dir);
 
-      std::vector<fc::ip::endpoint> resolve_string_to_ip_endpoints(const std::string& endpoint_string);
-
       void new_connection( const fc::http::websocket_connection_ptr& c );
 
       void reset_websocket_server();

--- a/libraries/net/include/graphene/net/node.hpp
+++ b/libraries/net/include/graphene/net/node.hpp
@@ -199,7 +199,7 @@ namespace graphene { namespace net {
         void close();
 
         void      set_node_delegate( node_delegate* del );
-        void      set_advertise_algorithm( std::string algo );
+        void      set_advertise_algorithm( std::string algo, std::vector<std::string> advertise_list = std::vector<std::string>() );
 
         void      load_configuration( const fc::path& configuration_directory );
 

--- a/libraries/net/include/graphene/net/node.hpp
+++ b/libraries/net/include/graphene/net/node.hpp
@@ -346,8 +346,8 @@ namespace graphene { namespace net {
          * @param transaction_id the transaction id
          * @returns propagation data for that transaction
          */
-        message_propagation_data get_transaction_propagation_data(const graphene::chain::transaction_id_type& transaction_id);
-        message_propagation_data get_block_propagation_data(const graphene::chain::block_id_type& block_id);
+        message_propagation_data get_transaction_propagation_data(const graphene::protocol::transaction_id_type& transaction_id);
+        message_propagation_data get_block_propagation_data(const graphene::protocol::block_id_type& block_id);
 
         /******
          * @returns the node id (public key) for this node

--- a/libraries/net/include/graphene/net/node.hpp
+++ b/libraries/net/include/graphene/net/node.hpp
@@ -199,7 +199,8 @@ namespace graphene { namespace net {
         void close();
 
         void      set_node_delegate( node_delegate* del );
-        void      set_advertise_algorithm( std::string algo, fc::optional<std::vector<std::string>> advertise_list = fc::optional<std::vector<std::string>>() );
+        void      set_advertise_algorithm( std::string algo, 
+            const fc::optional<std::vector<std::string>>& advertise_list = fc::optional<std::vector<std::string>>() );
 
         void      load_configuration( const fc::path& configuration_directory );
 

--- a/libraries/net/include/graphene/net/node.hpp
+++ b/libraries/net/include/graphene/net/node.hpp
@@ -262,14 +262,14 @@ namespace graphene { namespace net {
          * @param seed_string the url
          * @param connect_immediately will start the connection process immediately
          */
-        void add_seed_node(const std::string& seed_string, bool connect_immediately);
+        void add_seed_node(const std::string& seed_string);
 
         /*****
          * @brief add a list of nodes to seed the p2p network
          * @param seeds a vector of url strings
          * @param connect_immediately attempt a connection immediately
          */
-        void add_seed_nodes(std::vector<std::string> seeds, bool connect_immediately);
+        void add_seed_nodes(std::vector<std::string> seeds);
 
         /**
          *  Attempt to connect to the specified endpoint immediately.

--- a/libraries/net/include/graphene/net/node.hpp
+++ b/libraries/net/include/graphene/net/node.hpp
@@ -321,7 +321,6 @@ namespace graphene { namespace net {
         fc::variant_object get_call_statistics() const;
       protected:
         std::unique_ptr<detail::node_impl, detail::node_impl_deleter> my;
-      protected:
         // This should only be used for testing
         std::shared_ptr<fc::thread> get_thread();
    };

--- a/libraries/net/include/graphene/net/node.hpp
+++ b/libraries/net/include/graphene/net/node.hpp
@@ -212,6 +212,14 @@ namespace graphene { namespace net {
          */
         void      add_node( const fc::ip::endpoint& ep );
 
+        /****
+         * @brief Add an endpoint as a seed to the p2p network
+         *
+         * @param seed_string the url
+         * @param connect_immediately will start the connection process immediately
+         */
+        void add_seed_node(std::string seed_string, bool connect_immediately);
+
         /**
          *  Attempt to connect to the specified endpoint immediately.
          */
@@ -222,6 +230,17 @@ namespace graphene { namespace net {
          *  connections should be accepted.
          */
         void      listen_on_endpoint( const fc::ip::endpoint& ep, bool wait_if_not_available );
+
+        /***
+         * @brief Helper to convert a string to a collection of endpoints
+         *
+         * This converts a string (i.e. "bitshares.eu:665535" to a collection of endpoints.
+         * NOTE: Throws an exception if not in correct format or was unable to resolve URL.
+         *
+         * @param in the incoming string
+         * @returns a vector of endpoints
+         */
+        static std::vector<fc::ip::endpoint> resolve_string_to_ip_endpoints(std::string in);
 
         /**
          *  Call with true to enable listening for incoming connections

--- a/libraries/net/include/graphene/net/node.hpp
+++ b/libraries/net/include/graphene/net/node.hpp
@@ -199,7 +199,7 @@ namespace graphene { namespace net {
         void close();
 
         void      set_node_delegate( node_delegate* del );
-        void      set_advertise_algorithm( std::string algo, std::vector<std::string> advertise_list = std::vector<std::string>() );
+        void      set_advertise_algorithm( std::string algo, fc::optional<std::vector<std::string>> advertise_list = fc::optional<std::vector<std::string>>() );
 
         void      load_configuration( const fc::path& configuration_directory );
 

--- a/libraries/net/include/graphene/net/node.hpp
+++ b/libraries/net/include/graphene/net/node.hpp
@@ -199,6 +199,7 @@ namespace graphene { namespace net {
         void close();
 
         void      set_node_delegate( node_delegate* del );
+        void      set_advertise_algorithm( std::string algo );
 
         void      load_configuration( const fc::path& configuration_directory );
 

--- a/libraries/net/include/graphene/net/node.hpp
+++ b/libraries/net/include/graphene/net/node.hpp
@@ -23,6 +23,7 @@
  */
 #pragma once
 
+#include <fc/thread/thread.hpp>
 #include <graphene/net/core_messages.hpp>
 #include <graphene/net/message.hpp>
 #include <graphene/net/peer_database.hpp>
@@ -292,8 +293,11 @@ namespace graphene { namespace net {
 
         void disable_peer_advertising();
         fc::variant_object get_call_statistics() const;
-      private:
+      protected:
         std::unique_ptr<detail::node_impl, detail::node_impl_deleter> my;
+      protected:
+        // This should only be used for testing
+        std::shared_ptr<fc::thread> get_thread();
    };
 
     class simulated_network : public node

--- a/libraries/net/include/graphene/net/node.hpp
+++ b/libraries/net/include/graphene/net/node.hpp
@@ -219,7 +219,13 @@ namespace graphene { namespace net {
          * @param seed_string the url
          * @param connect_immediately will start the connection process immediately
          */
-        void add_seed_node(std::string seed_string, bool connect_immediately);
+        void add_seed_node(const std::string& seed_string, bool connect_immediately);
+        /*****
+         * @brief add a list of nodes to seed the p2p network
+         * @param seeds a vector of url strings
+         * @param connect_immediately attempt a connection immediately
+         */
+        void add_seed_nodes(std::vector<std::string> seeds, bool connect_immediately);
 
         /**
          *  Attempt to connect to the specified endpoint immediately.
@@ -241,7 +247,7 @@ namespace graphene { namespace net {
          * @param in the incoming string
          * @returns a vector of endpoints
          */
-        static std::vector<fc::ip::endpoint> resolve_string_to_ip_endpoints(std::string in);
+        static std::vector<fc::ip::endpoint> resolve_string_to_ip_endpoints(const std::string& in);
 
         /**
          *  Call with true to enable listening for incoming connections

--- a/libraries/net/include/graphene/net/peer_connection.hpp
+++ b/libraries/net/include/graphene/net/peer_connection.hpp
@@ -272,8 +272,9 @@ namespace graphene { namespace net
       unsigned _send_message_queue_tasks_running; // temporary debugging
 #endif
       bool _currently_handling_message; // true while we're in the middle of handling a message from the remote system
-    private:
+    protected:
       peer_connection(peer_connection_delegate* delegate);
+    private:
       void destroy();
     public:
       static peer_connection_ptr make_shared(peer_connection_delegate* delegate); // use this instead of the constructor
@@ -287,7 +288,7 @@ namespace graphene { namespace net
       void on_connection_closed(message_oriented_connection* originating_connection) override;
 
       void send_queueable_message(std::unique_ptr<queued_message>&& message_to_send);
-      void send_message(const message& message_to_send, size_t message_send_time_field_offset = (size_t)-1);
+      virtual void send_message(const message& message_to_send, size_t message_send_time_field_offset = (size_t)-1);
       void send_item(const item_id& item_to_send);
       void close_connection();
       void destroy_connection();

--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -4219,7 +4219,7 @@ namespace graphene { namespace net { namespace detail {
       trigger_p2p_network_connect_loop();
     }
 
-    void node_impl::add_seed_node(std::string endpoint_string, bool connect_immediately)
+    void node_impl::add_seed_node(const std::string& endpoint_string, bool connect_immediately)
     {
        VERIFY_CORRECT_THREAD();
        std::vector<fc::ip::endpoint> endpoints = graphene::net::node::resolve_string_to_ip_endpoints(endpoint_string);
@@ -5158,7 +5158,7 @@ namespace graphene { namespace net { namespace detail {
    * @param in the incoming string
    * @returns a vector of endpoints
    */
-  std::vector<fc::ip::endpoint> node::resolve_string_to_ip_endpoints(std::string in)
+  std::vector<fc::ip::endpoint> node::resolve_string_to_ip_endpoints(const std::string& in)
   {
      try
      {
@@ -5187,9 +5187,28 @@ namespace graphene { namespace net { namespace detail {
      FC_CAPTURE_AND_RETHROW((in))
   }
 
-  void node::add_seed_node(std::string endpoint_string, bool connect_immediately)
+  void node::add_seed_node(const std::string& endpoint_string, bool connect_immediately)
   {
      my->add_seed_node(endpoint_string, connect_immediately);
+  }
+
+  /*****
+   * @brief add a list of nodes to seed the p2p network
+   * @param seeds a vector of url strings
+   * @param connect_immediately attempt a connection immediately
+   */
+  void node::add_seed_nodes(std::vector<std::string> seeds, bool connect_immediately)
+  {
+     for(const std::string& endpoint_string : seeds )
+     {
+        try {
+           my->add_seed_node(endpoint_string, connect_immediately);
+        } catch( const fc::exception& e ) {
+           wlog( "caught exception ${e} while adding seed node ${endpoint}",
+                    ("e", e.to_detail_string())("endpoint", endpoint_string) );
+        }
+     }
+
   }
 
   void node::set_advertise_algorithm( std::string algo )

--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -116,11 +116,6 @@
 
 #include "node_impl.hxx"
 
-FC_REFLECT(graphene::net::detail::node_configuration, (listen_endpoint)
-                                                 (accept_incoming_connections)
-                                                 (wait_if_endpoint_is_busy)
-                                                 (private_key));
-
 namespace graphene { namespace net { namespace detail {
 
     void blockchain_tied_message_cache::block_accepted()

--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -4803,6 +4803,17 @@ namespace graphene { namespace net { namespace detail {
     INVOKE_IN_IMPL(close);
   }
 
+  /******
+   * @brief provides access to the node implementation's thread
+   *
+   * This should only be used for testing
+   * @returns the thread that the node_impl is on
+   */
+  std::shared_ptr<fc::thread> node::get_thread()
+  {
+     return my->_thread;
+  }
+
   struct simulated_network::node_info
   {
     node_delegate* delegate;

--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -4181,7 +4181,7 @@ namespace graphene { namespace net { namespace detail {
       trigger_p2p_network_connect_loop();
     }
 
-    void node_impl::add_seed_node(const std::string& endpoint_string, bool connect_immediately)
+    void node_impl::add_seed_node(const std::string& endpoint_string)
     {
        VERIFY_CORRECT_THREAD();
        std::vector<fc::ip::endpoint> endpoints = graphene::net::node::resolve_string_to_ip_endpoints(endpoint_string);
@@ -4189,8 +4189,6 @@ namespace graphene { namespace net { namespace detail {
        {
           ilog("Adding seed node ${endpoint}", ("endpoint", endpoint));
           add_node(endpoint);
-          if (connect_immediately)
-             connect_to_endpoint(endpoint);
        }
     }
 
@@ -5138,9 +5136,9 @@ namespace graphene { namespace net { namespace detail {
      FC_CAPTURE_AND_RETHROW((in))
   }
 
-  void node::add_seed_node(const std::string& endpoint_string, bool connect_immediately)
+  void node::add_seed_node(const std::string& endpoint_string)
   {
-    INVOKE_IN_IMPL(add_seed_node, endpoint_string, connect_immediately);
+    INVOKE_IN_IMPL(add_seed_node, endpoint_string);
   }
 
   /*****
@@ -5148,12 +5146,12 @@ namespace graphene { namespace net { namespace detail {
    * @param seeds a vector of url strings
    * @param connect_immediately attempt a connection immediately
    */
-  void node::add_seed_nodes(std::vector<std::string> seeds, bool connect_immediately)
+  void node::add_seed_nodes(std::vector<std::string> seeds)
   {
      for(const std::string& endpoint_string : seeds )
      {
         try {
-          INVOKE_IN_IMPL(add_seed_node, endpoint_string, connect_immediately);
+          INVOKE_IN_IMPL(add_seed_node, endpoint_string);
         } catch( const fc::exception& e ) {
           wlog( "caught exception ${e} while adding seed node ${endpoint}",
               ("e", e.to_detail_string())("endpoint", endpoint_string) );

--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -250,23 +250,17 @@ namespace graphene { namespace net { namespace detail {
       }
       void build(node_impl* impl, address_message& reply)
       {
-         reply.addresses.reserve(impl->_active_connections.size());
-         for(const peer_connection_ptr& active_peer : impl->_active_connections)
-         {
-            if (!exists_in_list(active_peer, exclude_list))
-               reply.addresses.emplace_back(update_address_record(impl, active_peer));
-         }
-         reply.addresses.shrink_to_fit();
+        reply.addresses.reserve(impl->_active_connections.size());
+        // filter out those in the exclude list
+        for(const peer_connection_ptr& active_peer : impl->_active_connections)
+        {
+          if (exclude_list.find( *active_peer->get_remote_endpoint() ) == exclude_list.end())  
+            reply.addresses.emplace_back(update_address_record(impl, active_peer));
+        }
+        reply.addresses.shrink_to_fit();
       }
       private:
       fc::flat_set<std::string> exclude_list;
-      bool exists_in_list(const peer_connection_ptr& peer, const fc::flat_set<std::string>& exclude_list) const
-      {
-         std::string remote = *peer->get_remote_endpoint();
-         if ( std::find(exclude_list.begin(), exclude_list.end(), remote) != exclude_list.end() )
-           return true;
-         return false;
-      }
    };
 
    /***

--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -1763,7 +1763,8 @@ namespace graphene { namespace net { namespace detail {
       originating_peer->send_message(reply);
     }
 
-    void node_impl::set_advertise_algorithm( std::string algo, fc::optional<std::vector<std::string>> advertise_list )
+    void node_impl::set_advertise_algorithm( std::string algo, 
+         const fc::optional<std::vector<std::string>>& advertise_list )
     {
        if (algo == "random")
        {
@@ -5234,7 +5235,7 @@ namespace graphene { namespace net { namespace detail {
 
   }
 
-  void node::set_advertise_algorithm( std::string algo, fc::optional<std::vector<std::string>> advertise_list )
+  void node::set_advertise_algorithm( std::string algo, const fc::optional<std::vector<std::string>>& advertise_list )
   {
      my->set_advertise_algorithm( algo, advertise_list );
   }

--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -305,26 +305,29 @@ namespace graphene { namespace net { namespace detail {
    class list_address_builder : public node_impl::address_builder
    {
       public:
-      list_address_builder(std::vector<std::string> address_list)
+      list_address_builder(fc::optional<std::vector<std::string>> address_list)
       {
-         advertise_list.reserve( address_list.size() );
-         auto& list = advertise_list;
-         std::for_each( address_list.begin(), address_list.end(), [&list]( std::string str ) {
-               // ignore fc exceptions (like poorly formatted endpoints)
-               try
-               {
-                  list.emplace_back( graphene::net::address_info(
-                     fc::ip::endpoint::from_string(str),
-                     fc::time_point_sec(),
-                     fc::microseconds(0),
-                     node_id_t(),
-                     peer_connection_direction::unknown,
-                     firewalled_state::unknown ));
-               }
-               catch(const fc::exception& ) {
-                  wlog( "Address ${addr} invalid.", ("addr", str) );
-               } 
-            } );
+         if (address_list.valid())
+         {
+            advertise_list.reserve( address_list->size() );
+            auto& list = advertise_list;
+            std::for_each( address_list->begin(), address_list->end(), [&list]( std::string str ) {
+                  // ignore fc exceptions (like poorly formatted endpoints)
+                  try
+                  {
+                     list.emplace_back( graphene::net::address_info(
+                        fc::ip::endpoint::from_string(str),
+                        fc::time_point_sec(),
+                        fc::microseconds(0),
+                        node_id_t(),
+                        peer_connection_direction::unknown,
+                        firewalled_state::unknown ));
+                  }
+                  catch(const fc::exception& ) {
+                     wlog( "Address ${addr} invalid.", ("addr", str) );
+                  } 
+               } );
+         }
       }
 
       void build(node_impl* impl, address_message& reply)
@@ -1760,7 +1763,7 @@ namespace graphene { namespace net { namespace detail {
       originating_peer->send_message(reply);
     }
 
-    void node_impl::set_advertise_algorithm( std::string algo, std::vector<std::string> advertise_list )
+    void node_impl::set_advertise_algorithm( std::string algo, fc::optional<std::vector<std::string>> advertise_list )
     {
        if (algo == "random")
        {
@@ -5231,7 +5234,7 @@ namespace graphene { namespace net { namespace detail {
 
   }
 
-  void node::set_advertise_algorithm( std::string algo, std::vector<std::string> advertise_list )
+  void node::set_advertise_algorithm( std::string algo, fc::optional<std::vector<std::string>> advertise_list )
   {
      my->set_advertise_algorithm( algo, advertise_list );
   }

--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -201,27 +201,26 @@ namespace graphene { namespace net { namespace detail {
       public:
       list_address_builder(fc::optional<std::vector<std::string>> address_list)
       {
-         if (address_list.valid())
-         {
-            advertise_list.reserve( address_list->size() );
-            auto& list = advertise_list;
-            std::for_each( address_list->begin(), address_list->end(), [&list]( std::string str ) {
-                  // ignore fc exceptions (like poorly formatted endpoints)
-                  try
-                  {
-                     list.emplace_back( graphene::net::address_info(
-                        fc::ip::endpoint::from_string(str),
-                        fc::time_point_sec(),
-                        fc::microseconds(0),
-                        node_id_t(),
-                        peer_connection_direction::unknown,
-                        firewalled_state::unknown ));
-                  }
-                  catch(const fc::exception& ) {
-                     wlog( "Address ${addr} invalid.", ("addr", str) );
-                  } 
-               } );
-         }
+        FC_ASSERT( address_list.valid(), "advertise-peer-list must be included" );
+
+        advertise_list.reserve( address_list->size() );
+        auto& list = advertise_list;
+        std::for_each( address_list->begin(), address_list->end(), [&list]( std::string str ) {
+              // ignore fc exceptions (like poorly formatted endpoints)
+              try
+              {
+                list.emplace_back( graphene::net::address_info(
+                    fc::ip::endpoint::from_string(str),
+                    fc::time_point_sec(),
+                    fc::microseconds(0),
+                    node_id_t(),
+                    peer_connection_direction::unknown,
+                    firewalled_state::unknown ));
+              }
+              catch(const fc::exception& ) {
+                wlog( "Address ${addr} invalid.", ("addr", str) );
+              } 
+          } );
       }
 
       void build(node_impl* impl, address_message& reply)
@@ -240,13 +239,11 @@ namespace graphene { namespace net { namespace detail {
       public:
       exclude_address_builder(const fc::optional<std::vector<std::string>>& address_list)
       {
-         if (address_list.valid())
-         {
-            std::for_each(address_list->begin(), address_list->end(), [&exclude_list = exclude_list](std::string input)
-                {
-                  exclude_list.insert(input);
-                });
-         }
+        FC_ASSERT( address_list.valid(), "advertise-peer-list must be included" );
+        std::for_each(address_list->begin(), address_list->end(), [&exclude_list = exclude_list](std::string input)
+            {
+              exclude_list.insert(input);
+            });
       }
       void build(node_impl* impl, address_message& reply)
       {
@@ -313,7 +310,7 @@ namespace graphene { namespace net { namespace detail {
       _maximum_number_of_sync_blocks_to_prefetch(MAXIMUM_NUMBER_OF_BLOCKS_TO_PREFETCH),
       _maximum_blocks_per_peer_during_syncing(GRAPHENE_NET_MAX_BLOCKS_PER_PEER_DURING_SYNCING)
     {
-       _address_builder = std::make_shared<all_address_builder>();
+      _address_builder = std::make_shared<all_address_builder>();
       _rate_limiter.set_actual_rate_time_constant(fc::seconds(2));
       fc::rand_bytes(&_node_id.data[0], (int)_node_id.size());
     }

--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -71,7 +71,6 @@
 #include <fc/network/rate_limiting.hpp>
 #include <fc/network/ip.hpp>
 #include <fc/network/resolve.hpp>
-#include <fc/smart_ref_impl.hpp>
 
 #include <graphene/net/node.hpp>
 #include <graphene/net/peer_database.hpp>

--- a/libraries/net/node_impl.hxx
+++ b/libraries/net/node_impl.hxx
@@ -489,7 +489,7 @@ class node_impl : public peer_connection_delegate
       void listen_to_p2p_network();
       void connect_to_p2p_network();
       void add_node( const fc::ip::endpoint& ep );
-      void set_advertise_algorithm( std::string algo, fc::optional<std::vector<std::string>> advertise_list );
+      void set_advertise_algorithm( std::string algo, const fc::optional<std::vector<std::string>>& advertise_list );
       /****
        * @brief Add an endpoint as a seed to the p2p network
        *

--- a/libraries/net/node_impl.hxx
+++ b/libraries/net/node_impl.hxx
@@ -619,3 +619,8 @@ class node_impl : public peer_connection_delegate
     }; // end class node_impl
 
 }}} // end of namespace graphene::net::detail
+
+FC_REFLECT(graphene::net::detail::node_configuration, (listen_endpoint)
+                                                 (accept_incoming_connections)
+                                                 (wait_if_endpoint_is_busy)
+                                                 (private_key));

--- a/libraries/net/node_impl.hxx
+++ b/libraries/net/node_impl.hxx
@@ -489,7 +489,7 @@ class node_impl : public peer_connection_delegate
       void listen_to_p2p_network();
       void connect_to_p2p_network();
       void add_node( const fc::ip::endpoint& ep );
-      void set_advertise_algorithm( std::string algo, std::vector<std::string> advertise_list );
+      void set_advertise_algorithm( std::string algo, fc::optional<std::vector<std::string>> advertise_list );
       /****
        * @brief Add an endpoint as a seed to the p2p network
        *

--- a/libraries/net/node_impl.hxx
+++ b/libraries/net/node_impl.hxx
@@ -578,7 +578,7 @@ class node_impl : public peer_connection_delegate
        * @param seed_string the url
        * @param connect_immediately will start the connection process immediately
        */
-      void add_seed_node(const std::string& seed_string, bool connect_immediately);
+      void add_seed_node(const std::string& seed_string);
       void initiate_connect_to(const peer_connection_ptr& peer);
       void connect_to_endpoint(const fc::ip::endpoint& ep);
       void listen_on_endpoint(const fc::ip::endpoint& ep , bool wait_if_not_available);

--- a/libraries/net/node_impl.hxx
+++ b/libraries/net/node_impl.hxx
@@ -496,7 +496,7 @@ class node_impl : public peer_connection_delegate
        * @param seed_string the url
        * @param connect_immediately will start the connection process immediately
        */
-      void add_seed_node(std::string seed_string, bool connect_immediately);
+      void add_seed_node(const std::string& seed_string, bool connect_immediately);
       void initiate_connect_to(const peer_connection_ptr& peer);
       void connect_to_endpoint(const fc::ip::endpoint& ep);
       void listen_on_endpoint(const fc::ip::endpoint& ep , bool wait_if_not_available);

--- a/libraries/net/node_impl.hxx
+++ b/libraries/net/node_impl.hxx
@@ -199,7 +199,6 @@ class node_impl : public peer_connection_delegate
       /// used by the task that manages connecting to peers
       // @{
       std::list<potential_peer_record> _add_once_node_list; /// list of peers we want to connect to as soon as possible
-
       peer_database             _potential_peer_db;
       fc::promise<void>::ptr    _retrigger_connect_loop_promise;
       bool                      _potential_peer_database_updated;
@@ -401,7 +400,7 @@ class node_impl : public peer_connection_delegate
       void on_address_request_message( peer_connection* originating_peer,
                                        const address_request_message& address_request_message_received );
 
-      address_builder* _address_builder;
+      std::shared_ptr<address_builder> _address_builder;
 
       void on_address_message( peer_connection* originating_peer,
                                const address_message& address_message_received );
@@ -490,6 +489,7 @@ class node_impl : public peer_connection_delegate
       void listen_to_p2p_network();
       void connect_to_p2p_network();
       void add_node( const fc::ip::endpoint& ep );
+      void set_advertise_algorithm( std::string algo );
       /****
        * @brief Add an endpoint as a seed to the p2p network
        *

--- a/libraries/net/node_impl.hxx
+++ b/libraries/net/node_impl.hxx
@@ -489,7 +489,7 @@ class node_impl : public peer_connection_delegate
       void listen_to_p2p_network();
       void connect_to_p2p_network();
       void add_node( const fc::ip::endpoint& ep );
-      void set_advertise_algorithm( std::string algo );
+      void set_advertise_algorithm( std::string algo, std::vector<std::string> advertise_list );
       /****
        * @brief Add an endpoint as a seed to the p2p network
        *

--- a/libraries/net/node_impl.hxx
+++ b/libraries/net/node_impl.hxx
@@ -165,6 +165,14 @@ private:
 
 class node_impl : public peer_connection_delegate
 {
+   public:
+      class address_builder
+      {
+      public:
+         virtual void build( node_impl* impl, address_message& ) = 0;
+      protected:
+         address_info update_address_record( node_impl* impl, const peer_connection_ptr& active_peer);
+      };
     public:
 #ifdef P2P_IN_DEDICATED_THREAD
       std::shared_ptr<fc::thread> _thread;
@@ -292,8 +300,6 @@ class node_impl : public peer_connection_delegate
 
       uint32_t _last_reported_number_of_connections; // number of connections last reported to the client (to avoid sending duplicate messages)
 
-      bool _peer_advertising_disabled;
-
       fc::future<void> _fetch_updated_peer_lists_loop_done;
 
       boost::circular_buffer<uint32_t> _average_network_read_speed_seconds;
@@ -395,6 +401,8 @@ class node_impl : public peer_connection_delegate
       void on_address_request_message( peer_connection* originating_peer,
                                        const address_request_message& address_request_message_received );
 
+      address_builder* _address_builder;
+
       void on_address_message( peer_connection* originating_peer,
                                const address_message& address_message_received );
 
@@ -482,6 +490,13 @@ class node_impl : public peer_connection_delegate
       void listen_to_p2p_network();
       void connect_to_p2p_network();
       void add_node( const fc::ip::endpoint& ep );
+      /****
+       * @brief Add an endpoint as a seed to the p2p network
+       *
+       * @param seed_string the url
+       * @param connect_immediately will start the connection process immediately
+       */
+      void add_seed_node(std::string seed_string, bool connect_immediately);
       void initiate_connect_to(const peer_connection_ptr& peer);
       void connect_to_endpoint(const fc::ip::endpoint& ep);
       void listen_on_endpoint(const fc::ip::endpoint& ep , bool wait_if_not_available);

--- a/libraries/net/node_impl.hxx
+++ b/libraries/net/node_impl.hxx
@@ -1,8 +1,12 @@
 #pragma once
 #include <memory>
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics.hpp>
+#include <boost/accumulators/statistics/rolling_mean.hpp>
 #include <fc/thread/thread.hpp>
 #include <fc/log/logger.hpp>
 #include <fc/network/tcp_socket.hpp>
+#include <fc/network/rate_limiting.hpp>
 #include <graphene/chain/config.hpp>
 #include <graphene/protocol/types.hpp>
 #include <graphene/net/node.hpp>
@@ -10,6 +14,81 @@
 #include <graphene/net/peer_connection.hpp>
 
 namespace graphene { namespace net { namespace detail {
+
+namespace bmi = boost::multi_index;
+class blockchain_tied_message_cache
+{
+private:
+  static const uint32_t cache_duration_in_blocks = GRAPHENE_NET_MESSAGE_CACHE_DURATION_IN_BLOCKS;
+
+  struct message_hash_index{};
+  struct message_contents_hash_index{};
+  struct block_clock_index{};
+  struct message_info
+  {
+    message_hash_type message_hash;
+    message           message_body;
+    uint32_t          block_clock_when_received;
+
+    // for network performance stats
+    message_propagation_data propagation_data;
+    fc::uint160_t     message_contents_hash; // hash of whatever the message contains (if it's a transaction, this is the transaction id, if it's a block, it's the block_id)
+
+    message_info( const message_hash_type& message_hash,
+                  const message&           message_body,
+                  uint32_t                 block_clock_when_received,
+                  const message_propagation_data& propagation_data,
+                  fc::uint160_t            message_contents_hash ) :
+      message_hash( message_hash ),
+      message_body( message_body ),
+      block_clock_when_received( block_clock_when_received ),
+      propagation_data( propagation_data ),
+      message_contents_hash( message_contents_hash )
+    {}
+  };
+  typedef boost::multi_index_container
+    < message_info,
+        bmi::indexed_by< bmi::ordered_unique< bmi::tag<message_hash_index>,
+                                              bmi::member<message_info, message_hash_type, &message_info::message_hash> >,
+                          bmi::ordered_non_unique< bmi::tag<message_contents_hash_index>,
+                                                  bmi::member<message_info, fc::uint160_t, &message_info::message_contents_hash> >,
+                          bmi::ordered_non_unique< bmi::tag<block_clock_index>,
+                                                  bmi::member<message_info, uint32_t, &message_info::block_clock_when_received> > >
+    > message_cache_container;
+
+  message_cache_container _message_cache;
+
+  uint32_t block_clock;
+
+public:
+  blockchain_tied_message_cache() :
+    block_clock( 0 )
+  {}
+  void block_accepted();
+  void cache_message( const message& message_to_cache, const message_hash_type& hash_of_message_to_cache,
+                    const message_propagation_data& propagation_data, const fc::uint160_t& message_content_hash );
+  message get_message( const message_hash_type& hash_of_message_to_lookup );
+  message_propagation_data get_message_propagation_data( const fc::uint160_t& hash_of_message_contents_to_lookup ) const;
+  size_t size() const { return _message_cache.size(); }
+};
+
+// This specifies configuration info for the local node.  It's stored as JSON
+// in the configuration directory (application data directory)
+struct node_configuration
+{
+  node_configuration() : accept_incoming_connections(true), wait_if_endpoint_is_busy(true) {}
+
+  fc::ip::endpoint listen_endpoint;
+  bool accept_incoming_connections;
+  bool wait_if_endpoint_is_busy;
+  /**
+   * Originally, our p2p code just had a 'node-id' that was a random number identifying this node
+   * on the network.  This is now a private key/public key pair, where the public key is used
+   * in place of the old random node-id.  The private part is unused, but might be used in
+   * the future to support some notion of trusted peers.
+   */
+  fc::ecc::private_key private_key;
+};
 
 // when requesting items from peers, we want to prioritize any blocks before
 // transactions, but otherwise request items in the order we heard about them
@@ -386,8 +465,11 @@ class node_impl : public peer_connection_delegate
       void parse_hello_user_data_for_peer( peer_connection* originating_peer, const fc::variant_object& user_data );
 
       void on_message( peer_connection* originating_peer,
-                       const message& received_message ) override;
+          const message& received_message ) override;
 
+      void call_by_message_type( peer_connection* originating_peer,
+          const message& received_message );
+          
       void on_hello_message( peer_connection* originating_peer,
                              const hello_message& hello_message_received );
 
@@ -400,7 +482,7 @@ class node_impl : public peer_connection_delegate
       void on_address_request_message( peer_connection* originating_peer,
                                        const address_request_message& address_request_message_received );
 
-      std::shared_ptr<address_builder> _address_builder;
+      std::shared_ptr<address_builder> _address_builder = nullptr;
 
       void on_address_message( peer_connection* originating_peer,
                                const address_message& address_message_received );

--- a/libraries/net/node_impl.hxx
+++ b/libraries/net/node_impl.hxx
@@ -255,6 +255,9 @@ class node_impl : public peer_connection_delegate
     public:
 #ifdef P2P_IN_DEDICATED_THREAD
       std::shared_ptr<fc::thread> _thread;
+      // should only be used for testing
+      std::shared_ptr<fc::thread> get_thread() { return _thread; }
+    public:
 #endif // P2P_IN_DEDICATED_THREAD
       std::unique_ptr<statistics_gathering_node_delegate_wrapper> _delegate;
       fc::sha256           _chain_id;

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -40,43 +40,10 @@
 
 #include <fc/crypto/aes.hpp>
 
-#ifdef _WIN32
-   #ifndef _WIN32_WINNT
-      #define _WIN32_WINNT 0x0501
-   #endif
-   #include <winsock2.h>
-   #include <WS2tcpip.h>
-#else
-   #include <sys/socket.h>
-   #include <netinet/ip.h>
-   #include <sys/types.h>
-#endif
-#include <thread>
-
 #include <boost/filesystem/path.hpp>
 
 #define BOOST_TEST_MODULE Test Application
 #include <boost/test/included/unit_test.hpp>
-
-/*****
- * Global Initialization for Windows
- * ( sets up Winsock stuf )
- */
-#ifdef _WIN32
-int sockInit(void)
-{
-   WSADATA wsa_data;
-   return WSAStartup(MAKEWORD(1,1), &wsa_data);
-}
-int sockQuit(void)
-{
-   return WSACleanup();
-}
-#endif
-
-/*********************
- * Helper Methods
- *********************/
 
 #include "../common/genesis_file_util.hpp"
 
@@ -84,32 +51,6 @@ using std::exception;
 using std::cerr;
 
 #define INVOKE(test) ((struct test*)this)->test_method();
-
-//////
-/// @brief attempt to find an available port on localhost
-/// @returns an available port number, or -1 on error
-/////
-int get_available_port()
-{
-   struct sockaddr_in sin;
-   int socket_fd = socket(AF_INET, SOCK_STREAM, 0);
-   if (socket_fd == -1)
-      return -1;
-   sin.sin_family = AF_INET;
-   sin.sin_port = 0;
-   sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-   if (::bind(socket_fd, (struct sockaddr*)&sin, sizeof(struct sockaddr_in)) == -1)
-      return -1;
-   socklen_t len = sizeof(sin);
-   if (getsockname(socket_fd, (struct sockaddr *)&sin, &len) == -1)
-      return -1;
-#ifdef _WIN32
-   closesocket(socket_fd);
-#else
-   close(socket_fd);
-#endif
-   return ntohs(sin.sin_port);
-}
 
 ///////////
 /// @brief Start the application
@@ -129,7 +70,7 @@ std::shared_ptr<graphene::app::application> start_application(fc::temp_directory
 #ifdef _WIN32
    sockInit();
 #endif
-   server_port_number = get_available_port();
+   server_port_number = graphene::app::get_available_port();
    cfg.emplace(
       "rpc-endpoint",
       boost::program_options::variable_value(string("127.0.0.1:" + std::to_string(server_port_number)), false)

--- a/tests/common/genesis_file_util.hpp
+++ b/tests/common/genesis_file_util.hpp
@@ -1,10 +1,64 @@
 #pragma once
 
+#include <graphene/chain/genesis_state.hpp>
+
+#include <boost/filesystem.hpp>
+#include <fc/io/json.hpp>
+
+#ifdef _WIN32
+   #ifndef _WIN32_WINNT
+      #define _WIN32_WINNT 0x0501
+   #endif
+   #include <winsock2.h>
+   #include <WS2tcpip.h>
+int sockInit(void)
+{
+   WSADATA wsa_data;
+   return WSAStartup(MAKEWORD(1,1), &wsa_data);
+}
+int sockQuit(void)
+{
+   return WSACleanup();
+}
+#else
+   #include <sys/socket.h>
+   #include <netinet/ip.h>
+   #include <sys/types.h>
+#endif
+
 /////////
 /// @brief forward declaration, using as a hack to generate a genesis.json file
 /// for testing
 /////////
-namespace graphene { namespace app { namespace detail {
+namespace graphene { namespace app { 
+
+//////
+/// @brief attempt to find an available port on localhost
+/// @returns an available port number, or -1 on error
+/////
+int get_available_port()
+{
+   struct sockaddr_in sin;
+   int socket_fd = socket(AF_INET, SOCK_STREAM, 0);
+   if (socket_fd == -1)
+      return -1;
+   sin.sin_family = AF_INET;
+   sin.sin_port = 0;
+   sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+   if (::bind(socket_fd, (struct sockaddr*)&sin, sizeof(struct sockaddr_in)) == -1)
+      return -1;
+   socklen_t len = sizeof(sin);
+   if (getsockname(socket_fd, (struct sockaddr *)&sin, &len) == -1)
+      return -1;
+#ifdef _WIN32
+   closesocket(socket_fd);
+#else
+   close(socket_fd);
+#endif
+   return ntohs(sin.sin_port);
+}
+
+namespace detail {
    graphene::chain::genesis_state_type create_example_genesis();
 } } } // graphene::app::detail
 

--- a/tests/tests/p2p_node_tests.cpp
+++ b/tests/tests/p2p_node_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Bitshares Foundation, and contributors.
+ * Copyright (c) 2019 Bitshares Foundation, and contributors.
  *
  * The MIT License
  *

--- a/tests/tests/p2p_node_tests.cpp
+++ b/tests/tests/p2p_node_tests.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2017 Bitshares Foundation, and contributors.
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <memory>
+#include <boost/test/unit_test.hpp>
+#include <boost/assign/list_of.hpp>
+
+#include <fc/thread/thread.hpp>
+
+#include <graphene/net/node.hpp>
+#include <graphene/chain/protocol/fee_schedule.hpp>
+
+#include <graphene/net/peer_connection.hpp>
+
+namespace graphene
+{
+namespace net
+{
+namespace detail
+{
+class node_impl : public graphene::net::peer_connection_delegate
+{
+public:
+   void on_message( peer_connection* originating_peer,
+                    const message& received_message );
+   void on_connection_closed(peer_connection* originating_peer);
+   message get_message_for_item(const item_id& item);
+};
+}
+}
+}
+
+class test_node : public graphene::net::node {
+public:
+   test_node(const std::string& name) : node(name) {}
+   void on_message(graphene::net::peer_connection_ptr originating_peer, const graphene::net::message& received_message)
+   {
+      get_thread()->async([&](){ return my->on_message(originating_peer.get(), received_message); }, "thread invoke for method on_message").wait();
+   }
+};
+
+class test_peer : public graphene::net::peer_connection
+{
+public:
+   std::shared_ptr<graphene::net::message> message_received;
+   void send_message(const graphene::net::message& message_to_send, size_t message_send_time_field_offset = (size_t)-1) override
+   {
+      message_received = std::shared_ptr<graphene::net::message>(new graphene::net::message(message_to_send));
+   }
+public:
+   test_peer(graphene::net::peer_connection_delegate* del) : graphene::net::peer_connection(del) {
+      message_received = nullptr;
+   }
+
+};
+
+BOOST_AUTO_TEST_CASE( p2p_disable_peer_advertising )
+{
+   test_node my_node("Hello");
+   graphene::net::detail::node_impl del;
+   std::shared_ptr<test_peer> my_peer(new test_peer{&del});
+   graphene::net::address_request_message address_request_message_received;
+   my_node.on_message(my_peer, address_request_message_received);
+   BOOST_CHECK(my_peer->message_received != nullptr);
+   // now try with "disable_peer_advertising" set
+   my_node.disable_peer_advertising();
+}

--- a/tests/tests/p2p_node_tests.cpp
+++ b/tests/tests/p2p_node_tests.cpp
@@ -175,15 +175,14 @@ public:
    std::shared_ptr<graphene::net::message> message_received;
    void send_message(const graphene::net::message& message_to_send, size_t message_send_time_field_offset = (size_t)-1) override
    {
-      if ( message_to_send.msg_type == graphene::net::core_message_type_enum::address_message_type )
-      {
+      try {
          // make a copy
          graphene::net::address_message m = message_to_send.as<graphene::net::address_message>();
          std::shared_ptr<graphene::net::message> msg_ptr = std::make_shared<graphene::net::message>(m);
          // store it for later
          message_received = msg_ptr;
          return;
-      }
+      } catch (...) {}
       message_received = nullptr;
    }
 public:

--- a/tests/tests/p2p_node_tests.cpp
+++ b/tests/tests/p2p_node_tests.cpp
@@ -175,7 +175,7 @@ public:
    std::shared_ptr<graphene::net::message> message_received;
    void send_message(const graphene::net::message& message_to_send, size_t message_send_time_field_offset = (size_t)-1) override
    {
-      if ( message_to_send.msg_type == graphene::net::address_message_type )
+      if ( message_to_send.msg_type == graphene::net::core_message_type_enum::address_message_type )
       {
          // make a copy
          graphene::net::address_message m = message_to_send.as<graphene::net::address_message>();

--- a/tests/tests/p2p_node_tests.cpp
+++ b/tests/tests/p2p_node_tests.cpp
@@ -175,7 +175,7 @@ public:
    std::shared_ptr<graphene::net::message> message_received;
    void send_message(const graphene::net::message& message_to_send, size_t message_send_time_field_offset = (size_t)-1) override
    {
-      if (message_to_send.msg_type == graphene::net::address_message::type)
+      if ( graphene::net::core_message_type_enum(message_to_send.msg_type) == graphene::net::address_message::type)
       {
          // make a copy
          graphene::net::address_message m = message_to_send.as<graphene::net::address_message>();

--- a/tests/tests/p2p_node_tests.cpp
+++ b/tests/tests/p2p_node_tests.cpp
@@ -38,10 +38,11 @@ namespace net
 {
 namespace detail
 {
+
 class node_impl : public graphene::net::peer_connection_delegate
 {
 public:
-   void on_message( peer_connection* originating_peer,
+   void on_message( graphene::net::peer_connection* originating_peer,
                     const message& received_message );
    void on_connection_closed(peer_connection* originating_peer);
    message get_message_for_item(const item_id& item);
@@ -74,14 +75,28 @@ public:
 
 };
 
+BOOST_AUTO_TEST_SUITE( p2p_node_tests )
+
 BOOST_AUTO_TEST_CASE( p2p_disable_peer_advertising )
 {
+   // set up my node
    test_node my_node("Hello");
    graphene::net::detail::node_impl del;
+   // a fake peer
    std::shared_ptr<test_peer> my_peer(new test_peer{&del});
+
+   // act like my_node received an address_request message from my_peer
    graphene::net::address_request_message address_request_message_received;
-   my_node.on_message(my_peer, address_request_message_received);
-   BOOST_CHECK(my_peer->message_received != nullptr);
+   my_node.on_message( my_peer, address_request_message_received );
+
+   // check the results
+   std::shared_ptr<graphene::net::message> msg = my_peer->message_received;
+   BOOST_CHECK( msg != nullptr);
+   BOOST_CHECK( msg->data.size() == 0 );
    // now try with "disable_peer_advertising" set
    my_node.disable_peer_advertising();
+   BOOST_CHECK( msg != nullptr );
+   BOOST_CHECK( msg->data.size() == 0 );
 }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/tests/p2p_node_tests.cpp
+++ b/tests/tests/p2p_node_tests.cpp
@@ -175,7 +175,7 @@ public:
    std::shared_ptr<graphene::net::message> message_received;
    void send_message(const graphene::net::message& message_to_send, size_t message_send_time_field_offset = (size_t)-1) override
    {
-      if ( graphene::net::core_message_type_enum(message_to_send.msg_type) == graphene::net::address_message::type)
+      if ( message_to_send.msg_type == static_cast<uint32_t>(graphene::net::address_message::type))
       {
          // make a copy
          graphene::net::address_message m = message_to_send.as<graphene::net::address_message>();

--- a/tests/tests/p2p_node_tests.cpp
+++ b/tests/tests/p2p_node_tests.cpp
@@ -22,36 +22,148 @@
  * THE SOFTWARE.
  */
 #include <memory>
+#include <thread>
+#include <iostream>
 #include <boost/test/unit_test.hpp>
 #include <boost/assign/list_of.hpp>
 
 #include <fc/thread/thread.hpp>
+#include <fc/asio.hpp>
 
 #include <graphene/net/node.hpp>
 #include <graphene/chain/protocol/fee_schedule.hpp>
 
 #include <graphene/net/peer_connection.hpp>
+#include "../../libraries/net/node_impl.hxx"
 
-namespace graphene { namespace net  { namespace detail {
+#include "../common/genesis_file_util.hpp"
 
-class node_impl : public graphene::net::peer_connection_delegate
+/***
+ * A peer connection delegate
+ */
+class test_delegate : public graphene::net::peer_connection_delegate
 {
-public:
-   void on_message( graphene::net::peer_connection* originating_peer,
-                    const message& received_message );
-   void on_connection_closed(peer_connection* originating_peer);
-   message get_message_for_item(const item_id& item);
+   public:
+   test_delegate()
+   {
+   }
+   void on_message(graphene::net::peer_connection* originating_peer, 
+         const graphene::net::message& received_message)
+   {
+      elog("on_message was called with ${msg}", ("msg",received_message));
+      try {
+         graphene::net::address_request_message m = received_message.as<graphene::net::address_request_message>();
+         std::shared_ptr<graphene::net::message> m_ptr = std::make_shared<graphene::net::message>( m );
+         last_message = m_ptr;
+      } catch (...)
+      {
+      }
+   }
+   void on_connection_closed(graphene::net::peer_connection* originating_peer) override {}
+   graphene::net::message get_message_for_item(const graphene::net::item_id& item) override
+   { 
+      return graphene::net::message(); 
+   }
+   std::shared_ptr<graphene::net::message> last_message = nullptr;
 };
 
-} } } // namespace graphene::net::detail
-
-class test_node : public graphene::net::node {
+class test_node : public graphene::net::node, public graphene::net::node_delegate
+{
 public:
-   test_node(const std::string& name) : node(name) {}
+   test_node(const std::string& name, const fc::path& config_dir, int port, int seed_port = -1) : node(name)
+   {
+      node_name = name;
+   }
+   ~test_node() 
+   {
+      close();
+   }
+
    void on_message(graphene::net::peer_connection_ptr originating_peer, const graphene::net::message& received_message)
    {
-      get_thread()->async([&](){ return my->on_message(originating_peer.get(), received_message); }, "thread invoke for method on_message").wait();
+      elog("${name} on_message was called", ("name", node_name));
+      my->call_by_message_type( originating_peer.get(), received_message );
    }
+
+   graphene::net::peer_connection_ptr create_peer_connection(graphene::net::peer_connection_delegate* delegate)
+   {
+      graphene::net::peer_connection_ptr ret_val = graphene::net::peer_connection::make_shared(delegate);
+      try {
+         //this->my->_active_connections.insert( ret_val );
+      } catch (...)
+      {
+         // TODO: The above always throws. Skipping this step...
+      }
+      return ret_val;
+   }
+
+   /****
+    * Implementation methods of node_delegate
+    */
+   bool has_item( const graphene::net::item_id& id ) { return false; }
+   bool handle_block( const graphene::net::block_message& blk_msg, bool sync_mode, 
+         std::vector<fc::uint160_t>& contained_transaction_message_ids )
+      { return false; }
+   void handle_transaction( const graphene::net::trx_message& trx_msg )
+   {
+      elog("${name} was asked to handle a transaction", ("name", node_name));
+   }
+   void handle_message( const graphene::net::message& message_to_process ) 
+   {
+      elog("${name} received a message", ("name",node_name));
+   }
+   std::vector<graphene::net::item_hash_t> get_block_ids(
+         const std::vector<graphene::net::item_hash_t>& blockchain_synopsis,
+         uint32_t& remaining_item_count, uint32_t limit = 2000) 
+      { return std::vector<graphene::net::item_hash_t>(); }
+   graphene::net::message get_item( const graphene::net::item_id& id )
+   {
+      elog("${name} get_item was called", ("name",node_name));
+      return graphene::net::message(); 
+   }
+   graphene::net::chain_id_type get_chain_id()const 
+   {
+      elog("${name} get_chain_id was called", ("name",node_name));
+      return graphene::net::chain_id_type(); 
+   }
+   std::vector<graphene::net::item_hash_t> get_blockchain_synopsis(
+         const graphene::net::item_hash_t& reference_point, 
+         uint32_t number_of_blocks_after_reference_point)
+      { return std::vector<graphene::net::item_hash_t>(); }
+   void sync_status( uint32_t item_type, uint32_t item_count ) {}
+   void connection_count_changed( uint32_t c ) 
+   {
+      elog("${name} connection_count_change was called", ("name",node_name));
+   }
+   uint32_t get_block_number(const graphene::net::item_hash_t& block_id) 
+   { 
+      elog("${name} get_block_number was called", ("name",node_name));
+      return 0; 
+   }
+   fc::time_point_sec get_block_time(const graphene::net::item_hash_t& block_id)
+   { 
+      elog("${name} get_block_time was called", ("name",node_name));
+      return fc::time_point_sec(); 
+   }
+   graphene::net::item_hash_t get_head_block_id() const 
+   {
+      elog("${name} get_head_block_id was called", ("name",node_name));
+      return graphene::net::item_hash_t(); 
+   }
+   uint32_t estimate_last_known_fork_from_git_revision_timestamp(uint32_t unix_timestamp) const
+      { return 0; }
+   void error_encountered(const std::string& message, const fc::oexception& error)
+   {
+      elog("${name} error_encountered was called. Message: ${msg}", ("name",node_name)("msg", message));
+   }
+   uint8_t get_current_block_interval_in_seconds() const
+   { 
+      elog("${name} get_current_block_interval_in_seconds was called", ("name",node_name));
+      return 0; 
+   }
+
+   private:
+   std::string node_name;
 };
 
 class test_peer : public graphene::net::peer_connection
@@ -60,7 +172,16 @@ public:
    std::shared_ptr<graphene::net::message> message_received;
    void send_message(const graphene::net::message& message_to_send, size_t message_send_time_field_offset = (size_t)-1) override
    {
-      message_received = std::make_shared<graphene::net::message>(message_to_send);
+      if (message_to_send.msg_type == graphene::net::address_message::type)
+      {
+         // make a copy
+         graphene::net::address_message m = message_to_send.as<graphene::net::address_message>();
+         std::shared_ptr<graphene::net::message> msg_ptr = std::make_shared<graphene::net::message>(m);
+         // store it for later
+         message_received = msg_ptr;
+         return;
+      }
+      message_received = nullptr;
    }
 public:
    test_peer(graphene::net::peer_connection_delegate* del) : graphene::net::peer_connection(del) {
@@ -83,22 +204,55 @@ void test_address_message( std::shared_ptr<graphene::net::message> msg, std::siz
 
 BOOST_AUTO_TEST_SUITE( p2p_node_tests )
 
+/****
+ * Assure that when disable_peer_advertising is set,
+ * the node does not share its peer list
+ */
 BOOST_AUTO_TEST_CASE( disable_peer_advertising )
 {
-   // set up my node
-   test_node my_node("Hello");
-   my_node.disable_peer_advertising();
+   // create a node
+   int node1_port = graphene::app::get_available_port();
+   fc::temp_directory node1_dir;
+   test_node node1("Node1", node1_dir.path(), node1_port);
+   node1.disable_peer_advertising();
 
-   // a fake peer
-   graphene::net::detail::node_impl del;
-   std::shared_ptr<test_peer> my_peer(new test_peer{&del});
+   // create a peer_delegate to receive the response
+   test_delegate peer2_delegate{};
 
-   // act like my_node received an address_request message from my_peer
-   graphene::net::address_request_message address_request_message_received;
-   my_node.on_message( my_peer, address_request_message_received );
+   // get something in their list of connections
+   graphene::net::peer_connection_ptr node2_conn_ptr = node1.create_peer_connection( &peer2_delegate );
+
+   // verify that they do not share it with others
+   std::shared_ptr<test_peer> peer3_ptr = std::make_shared<test_peer>(&peer2_delegate);
+   graphene::net::address_request_message req;
+   node1.on_message( peer3_ptr, req );
 
    // check the results
-   std::shared_ptr<graphene::net::message> msg = my_peer->message_received;
+   std::shared_ptr<graphene::net::message> msg = peer3_ptr->message_received;
+   test_address_message(msg, 0);
+}
+
+BOOST_AUTO_TEST_CASE( set_nothing_advertise_algorithm )
+{
+   // create a node
+   int node1_port = graphene::app::get_available_port();
+   fc::temp_directory node1_dir;
+   test_node node1("Node1", node1_dir.path(), node1_port);
+   node1.set_advertise_algorithm( "nothing" );
+
+   // create a peer_delegate to receive the response
+   test_delegate peer2_delegate{};
+
+   // get something in their list of connections
+   graphene::net::peer_connection_ptr node2_conn_ptr = node1.create_peer_connection( &peer2_delegate );
+
+   // verify that they do not share it with others
+   std::shared_ptr<test_peer> peer3_ptr = std::make_shared<test_peer>(&peer2_delegate);
+   graphene::net::address_request_message req;
+   node1.on_message( peer3_ptr, req );
+
+   // check the results
+   std::shared_ptr<graphene::net::message> msg = peer3_ptr->message_received;
    test_address_message(msg, 0);
 }
 
@@ -106,9 +260,11 @@ BOOST_AUTO_TEST_CASE( advertise_list )
 {
    std::vector<std::string> advert_list = { "127.0.0.1:8090"};
    // set up my node
-   test_node my_node("Hello");
+   int my_node_port = graphene::app::get_available_port();
+   fc::temp_directory my_node_dir;
+   test_node my_node("Hello", my_node_dir.path(), my_node_port);
    my_node.set_advertise_algorithm( "list", advert_list );
-   graphene::net::detail::node_impl del;
+   test_delegate del{};
    // a fake peer
    std::shared_ptr<test_peer> my_peer(new test_peer{&del});
 

--- a/tests/tests/p2p_node_tests.cpp
+++ b/tests/tests/p2p_node_tests.cpp
@@ -175,7 +175,7 @@ public:
    std::shared_ptr<graphene::net::message> message_received;
    void send_message(const graphene::net::message& message_to_send, size_t message_send_time_field_offset = (size_t)-1) override
    {
-      if ( message_to_send.msg_type == static_cast<uint32_t>(graphene::net::address_message::type))
+      if ( static_cast<uint32_t>(message_to_send.msg_type) == graphene::net::address_message::type )
       {
          // make a copy
          graphene::net::address_message m = message_to_send.as<graphene::net::address_message>();

--- a/tests/tests/p2p_node_tests.cpp
+++ b/tests/tests/p2p_node_tests.cpp
@@ -31,7 +31,7 @@
 #include <fc/asio.hpp>
 
 #include <graphene/net/node.hpp>
-#include <graphene/chain/protocol/fee_schedule.hpp>
+#include <graphene/protocol/fee_schedule.hpp>
 
 #include <graphene/net/peer_connection.hpp>
 #define P2P_IN_DEDICATED_THREAD 1

--- a/tests/tests/p2p_node_tests.cpp
+++ b/tests/tests/p2p_node_tests.cpp
@@ -175,7 +175,7 @@ public:
    std::shared_ptr<graphene::net::message> message_received;
    void send_message(const graphene::net::message& message_to_send, size_t message_send_time_field_offset = (size_t)-1) override
    {
-      if ( static_cast<uint32_t>(message_to_send.msg_type) == graphene::net::address_message::type )
+      if ( message_to_send.msg_type == graphene::net::address_message_type )
       {
          // make a copy
          graphene::net::address_message m = message_to_send.as<graphene::net::address_message>();


### PR DESCRIPTION
This PR for Issue #659 adds 2 command line options to witness_node:
1. The parameter ``accept-incoming-connections`` will allow peers to request a connection to your node (default is true). Set to false, your node will not listen for incoming connections.
2. The parameter ``disable-peer-advertising`` will respond to a request for your list of peers with an empty list.

The "accept-incoming-connections" is an existing field in the node configuration file, now accessible from the command line.

The "disable-peer-advertising" is an existing field, now accessible from the command line. NOTE: This could be used as an attack vector, so you may not want to use this. A better option is to provide an option to randomize the returned list of nodes.

Outstanding tasks:
- [x] Add tests to verify these parameters work as designed
- [x] Randomize results returned when nodes ask for list of nodes