### PR TITLE
Issue #878 permit configuration of io threads

### DIFF
--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -935,6 +935,7 @@ void application::set_program_options(boost::program_options::options_descriptio
          ("dbg-init-key", bpo::value<string>(), "Block signing key to use for init witnesses, overrides genesis file")
          ("api-access", bpo::value<boost::filesystem::path>(), "JSON file specifying API permissions")
          ("plugins", bpo::value<string>(), "Space-separated list of plugins to activate")
+         ("io-threads", bpo::value<int16_t>()->implicit_value(0), "Number of IO threads")
          // TODO uncomment this when GUI is ready
          //("enable-subscribe-to-all", bpo::value<bool>()->implicit_value(false),
          // "Whether allow API clients to subscribe to universal object creation and removal events")

--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -40,6 +40,7 @@
 
 #include <fc/smart_ref_impl.hpp>
 
+#include <fc/asio.hpp>
 #include <fc/io/fstream.hpp>
 #include <fc/rpc/api_connection.hpp>
 #include <fc/rpc/websocket_api.hpp>
@@ -935,7 +936,7 @@ void application::set_program_options(boost::program_options::options_descriptio
          ("dbg-init-key", bpo::value<string>(), "Block signing key to use for init witnesses, overrides genesis file")
          ("api-access", bpo::value<boost::filesystem::path>(), "JSON file specifying API permissions")
          ("plugins", bpo::value<string>(), "Space-separated list of plugins to activate")
-         ("io-threads", bpo::value<int16_t>()->implicit_value(0), "Number of IO threads")
+         ("io-threads", bpo::value<uint16_t>()->implicit_value(0), "Number of IO threads")
          // TODO uncomment this when GUI is ready
          //("enable-subscribe-to-all", bpo::value<bool>()->implicit_value(false),
          // "Whether allow API clients to subscribe to universal object creation and removal events")
@@ -984,6 +985,12 @@ void application::initialize(const fc::path& data_dir, const boost::program_opti
       fc::json::save_to_file(genesis_state, genesis_out);
 
       std::exit(EXIT_SUCCESS);
+   }
+
+   if ( options.count("io-threads") )
+   {
+      const uint16_t num_threads = options["io-threads"].as<uint16_t>();
+      fc::asio::default_io_service_scope::set_num_threads(num_threads);
    }
 
    std::vector<string> wanted;

--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -936,7 +936,7 @@ void application::set_program_options(boost::program_options::options_descriptio
          ("dbg-init-key", bpo::value<string>(), "Block signing key to use for init witnesses, overrides genesis file")
          ("api-access", bpo::value<boost::filesystem::path>(), "JSON file specifying API permissions")
          ("plugins", bpo::value<string>(), "Space-separated list of plugins to activate")
-         ("io-threads", bpo::value<uint16_t>()->implicit_value(0), "Number of IO threads")
+         ("io-threads", bpo::value<uint16_t>()->implicit_value(0), "Number of IO threads, default to 0 for auto-configuration")
          // TODO uncomment this when GUI is ready
          //("enable-subscribe-to-all", bpo::value<bool>()->implicit_value(false),
          // "Whether allow API clients to subscribe to universal object creation and removal events")

--- a/libraries/plugins/delayed_node/delayed_node_plugin.cpp
+++ b/libraries/plugins/delayed_node/delayed_node_plugin.cpp
@@ -49,7 +49,7 @@ struct delayed_node_plugin_impl {
 }
 
 delayed_node_plugin::delayed_node_plugin()
-   : my(new detail::delayed_node_plugin_impl)
+   : my(nullptr)
 {}
 
 delayed_node_plugin::~delayed_node_plugin()
@@ -75,6 +75,7 @@ void delayed_node_plugin::connect()
 void delayed_node_plugin::plugin_initialize(const boost::program_options::variables_map& options)
 {
    FC_ASSERT(options.count("trusted-node") > 0);
+   my = std::unique_ptr<detail::delayed_node_plugin_impl>{ new detail::delayed_node_plugin_impl() };
    my->remote_endpoint = "ws://" + options.at("trusted-node").as<std::string>();
 }
 

--- a/programs/witness_node/main.cpp
+++ b/programs/witness_node/main.cpp
@@ -192,6 +192,16 @@ int main(int argc, char** argv) {
 
       bpo::variables_map options;
 
+      auto witness_plug = node->register_plugin<witness_plugin::witness_plugin>();
+      auto debug_witness_plug = node->register_plugin<debug_witness_plugin::debug_witness_plugin>();
+      auto history_plug = node->register_plugin<account_history::account_history_plugin>();
+      auto elasticsearch_plug = node->register_plugin<elasticsearch::elasticsearch_plugin>();
+      auto market_history_plug = node->register_plugin<market_history::market_history_plugin>();
+      auto delayed_plug = node->register_plugin<delayed_node::delayed_node_plugin>();
+      auto snapshot_plug = node->register_plugin<snapshot_plugin::snapshot_plugin>();
+      auto es_objects_plug = node->register_plugin<es_objects::es_objects_plugin>();
+      auto grouped_orders_plug = node->register_plugin<grouped_orders::grouped_orders_plugin>();
+
       try
       {
          bpo::options_description cli, cfg;
@@ -241,16 +251,6 @@ int main(int argc, char** argv) {
          if ( fc::asio::default_io_service_scope::set_default_num_threads(num_threads) != 0 )
             FC_THROW("Attempt to set number of IO threads after thread pool started.");
       }
-
-      auto witness_plug = node->register_plugin<witness_plugin::witness_plugin>();
-      auto debug_witness_plug = node->register_plugin<debug_witness_plugin::debug_witness_plugin>();
-      auto history_plug = node->register_plugin<account_history::account_history_plugin>();
-      auto elasticsearch_plug = node->register_plugin<elasticsearch::elasticsearch_plugin>();
-      auto market_history_plug = node->register_plugin<market_history::market_history_plugin>();
-      auto delayed_plug = node->register_plugin<delayed_node::delayed_node_plugin>();
-      auto snapshot_plug = node->register_plugin<snapshot_plugin::snapshot_plugin>();
-      auto es_objects_plug = node->register_plugin<es_objects::es_objects_plugin>();
-      auto grouped_orders_plug = node->register_plugin<grouped_orders::grouped_orders_plugin>();
 
       bpo::notify(options);
       node->initialize(data_dir, options);

--- a/programs/witness_node/main.cpp
+++ b/programs/witness_node/main.cpp
@@ -40,6 +40,7 @@
 #include <fc/log/file_appender.hpp>
 #include <fc/log/logger.hpp>
 #include <fc/log/logger_config.hpp>
+#include <fc/asio.hpp>
 
 #include <boost/filesystem.hpp>
 
@@ -191,16 +192,6 @@ int main(int argc, char** argv) {
 
       bpo::variables_map options;
 
-      auto witness_plug = node->register_plugin<witness_plugin::witness_plugin>();
-      auto debug_witness_plug = node->register_plugin<debug_witness_plugin::debug_witness_plugin>();
-      auto history_plug = node->register_plugin<account_history::account_history_plugin>();
-      auto elasticsearch_plug = node->register_plugin<elasticsearch::elasticsearch_plugin>();
-      auto market_history_plug = node->register_plugin<market_history::market_history_plugin>();
-      auto delayed_plug = node->register_plugin<delayed_node::delayed_node_plugin>();
-      auto snapshot_plug = node->register_plugin<snapshot_plugin::snapshot_plugin>();
-      auto es_objects_plug = node->register_plugin<es_objects::es_objects_plugin>();
-      auto grouped_orders_plug = node->register_plugin<grouped_orders::grouped_orders_plugin>();
-
       try
       {
          bpo::options_description cli, cfg;
@@ -243,6 +234,23 @@ int main(int argc, char** argv) {
       if( !fc::exists(config_ini_path) )
          create_new_config_file( config_ini_path, data_dir, cfg_options );
       load_config_file( config_ini_path, cfg_options, options );
+
+      if ( options.count("io-threads") )
+      {
+         const int16_t num_threads = options["io-threads"].as<int16_t>();
+         if ( fc::asio::default_io_service_scope::set_default_num_threads(num_threads) != 0 )
+            FC_THROW("Attempt to set number of IO threads after thread pool started.");
+      }
+
+      auto witness_plug = node->register_plugin<witness_plugin::witness_plugin>();
+      auto debug_witness_plug = node->register_plugin<debug_witness_plugin::debug_witness_plugin>();
+      auto history_plug = node->register_plugin<account_history::account_history_plugin>();
+      auto elasticsearch_plug = node->register_plugin<elasticsearch::elasticsearch_plugin>();
+      auto market_history_plug = node->register_plugin<market_history::market_history_plugin>();
+      auto delayed_plug = node->register_plugin<delayed_node::delayed_node_plugin>();
+      auto snapshot_plug = node->register_plugin<snapshot_plugin::snapshot_plugin>();
+      auto es_objects_plug = node->register_plugin<es_objects::es_objects_plugin>();
+      auto grouped_orders_plug = node->register_plugin<grouped_orders::grouped_orders_plugin>();
 
       bpo::notify(options);
       node->initialize(data_dir, options);

--- a/programs/witness_node/main.cpp
+++ b/programs/witness_node/main.cpp
@@ -40,7 +40,6 @@
 #include <fc/log/file_appender.hpp>
 #include <fc/log/logger.hpp>
 #include <fc/log/logger_config.hpp>
-#include <fc/asio.hpp>
 
 #include <boost/filesystem.hpp>
 
@@ -244,13 +243,6 @@ int main(int argc, char** argv) {
       if( !fc::exists(config_ini_path) )
          create_new_config_file( config_ini_path, data_dir, cfg_options );
       load_config_file( config_ini_path, cfg_options, options );
-
-      if ( options.count("io-threads") )
-      {
-         const int16_t num_threads = options["io-threads"].as<int16_t>();
-         if ( fc::asio::default_io_service_scope::set_default_num_threads(num_threads) != 0 )
-            FC_THROW("Attempt to set number of IO threads after thread pool started.");
-      }
 
       bpo::notify(options);
       node->initialize(data_dir, options);


### PR DESCRIPTION
Issue #878 

This PR implements a configuration parameter (config.ini or command line) that allows for control of the number of IO threads.

It works in conjunction with changes in bitshares-fc (https://github.com/bitshares/bitshares-fc/pull/47) that permits changes to the default number of io threads, and also attempts a better guess of how many io threads should be created.