### PR TITLE
Issues #922 and #931 bitasset_update checks

### DIFF
--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -366,7 +366,7 @@ void_result asset_update_bitasset_evaluator::do_evaluate(const asset_update_bita
 
    const asset_object& asset_obj = op.asset_to_update(d);
 
-   FC_ASSERT(asset_obj.is_market_issued(), "Cannot update BitAsset-specific settings on a non-BitAsset.");
+   FC_ASSERT( asset_obj.is_market_issued(), "Cannot update BitAsset-specific settings on a non-BitAsset." );
 
    const asset_bitasset_data_object& current_bitasset_data = asset_obj.bitasset_data(d);
 
@@ -375,10 +375,10 @@ void_result asset_update_bitasset_evaluator::do_evaluate(const asset_update_bita
    // Are we changing the backing asset?
    if( op.new_options.short_backing_asset != current_bitasset_data.options.short_backing_asset )
    {
-      FC_ASSERT(asset_obj.dynamic_asset_data_id(d).current_supply == 0,
-            "Cannot update a bitasset if there is already a current supply.");
+      FC_ASSERT( asset_obj.dynamic_asset_data_id(d).current_supply == 0,
+            "Cannot update a bitasset if there is already a current supply." );
 
-      if (d.get_dynamic_global_properties().next_maintenance_time > HARDFORK_CORE_922_931_TIME)
+      if( d.get_dynamic_global_properties().next_maintenance_time > HARDFORK_CORE_922_931_TIME )
       {
          const asset_object& new_backing_asset = op.new_options.short_backing_asset(d);
 
@@ -394,16 +394,19 @@ void_result asset_update_bitasset_evaluator::do_evaluate(const asset_update_bita
             {
                FC_ASSERT( new_backing_asset.bitasset_data(d).options.short_backing_asset == asset_id_type(),
                      "May not modify a blockchain-controlled market asset to be backed by an asset which is not backed by CORE.");
-            } else
+            }
+            else
+            {
                FC_ASSERT( new_backing_asset.get_id() == asset_id_type(),
                      "May not modify a blockchain-controlled market asset to be backed by an asset which is not market issued asset nor CORE.");
+            }
          }
       }
       else
       {
          // prior to HF 922 / 931
 
-         FC_ASSERT( d.find_object(op.new_options.short_backing_asset) );
+         FC_ASSERT( d.find_object( op.new_options.short_backing_asset ) );
 
          if( asset_obj.issuer == GRAPHENE_COMMITTEE_ACCOUNT )
          {
@@ -414,19 +417,21 @@ void_result asset_update_bitasset_evaluator::do_evaluate(const asset_update_bita
             {
                FC_ASSERT( old_backing_asset.bitasset_data(d).options.short_backing_asset == asset_id_type(),
                      "May not modify a blockchain-controlled market asset to be backed by an asset which is not backed by CORE.");
-            } else
+            }
+            else
+            {
                FC_ASSERT( old_backing_asset.get_id() == asset_id_type(),
                      "May not modify a blockchain-controlled market asset to be backed by an asset which is not market issued asset nor CORE.");
+            }
          }
       }
-
    }
 
    const auto& chain_parameters = d.get_global_properties().parameters;
    FC_ASSERT( op.new_options.feed_lifetime_sec > chain_parameters.block_interval,
          "Feed lifetime must exceed block interval." );
    FC_ASSERT( op.new_options.force_settlement_delay_sec > chain_parameters.block_interval,
-         "Force settlement delay must exceed block interval.");
+         "Force settlement delay must exceed block interval." );
    FC_ASSERT( op.issuer == asset_obj.issuer,
          "Only asset issuer can update bitasset_data of the asset." );
 

--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -423,17 +423,17 @@ void_result asset_update_bitasset_evaluator::do_evaluate(const asset_update_bita
                // loop through all assets that have this asset as a backing asset
                const auto& idx = db().get_index_type<asset_index>().indices().get<by_type>();
 
-               for( auto child : idx )
+               for( auto itr = idx.lower_bound(true); itr != idx.end(); ++itr )
                {
+                  auto child = *itr;
                   if ( child.is_market_issued()
                         && child.bitasset_data(d).options.short_backing_asset == asset_obj.get_id() )
                   {
                      FC_ASSERT( child.issuer != GRAPHENE_COMMITTEE_ACCOUNT,
-                           "A committee-issued BitAsset would be invalidated by changing this backing asset." );
+                           "A blockchain-controlled market asset would be invalidated by changing this backing asset." );
 
-                     FC_ASSERT( child.issuer != GRAPHENE_COMMITTEE_ACCOUNT &&
-                           new_backing_asset.issuer != GRAPHENE_COMMITTEE_ACCOUNT,
-                           "A user-issued BitAsset would be invalidated by changing this backing asset.");
+                     FC_ASSERT( !new_backing_asset.is_market_issued(),
+                           "A non-blockchain controlled BitAsset would be invalidated by changing this backing asset.");
                   }
                }
             }
@@ -497,8 +497,9 @@ void_result asset_update_bitasset_evaluator::do_evaluate(const asset_update_bita
                // loop through all assets that have this asset as a backing asset
                const auto& idx = db().get_index_type<asset_index>().indices().get<by_type>();
 
-               for( auto child : idx )
+               for( auto itr = idx.lower_bound(true); itr != idx.end(); ++itr)
                {
+                  auto child = *itr;
                   if ( child.is_market_issued()
                         && child.bitasset_data(d).options.short_backing_asset == asset_obj.get_id() )
                   {

--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -499,11 +499,8 @@ void_result asset_update_bitasset_evaluator::do_evaluate(const asset_update_bita
          if ( new_backing_asset.is_market_issued() )
          {
             const asset_object& backing_backing_asset = new_backing_asset.bitasset_data(d).asset_id(d);
-            if ( backing_backing_asset.get_id() != asset_id_type() )
-            {
-               FC_ASSERT( !backing_backing_asset.is_market_issued(), "A BitAsset cannot be backed by a BitAsset that itself "
-                     "is backed by a BitAsset.");
-            }
+            FC_ASSERT( !backing_backing_asset.is_market_issued(), "A BitAsset cannot be backed by a BitAsset that itself "
+                  "is backed by a BitAsset.");
          }
       }
       else // prior to HF 922 / 931

--- a/libraries/chain/hardfork.d/CORE_922_931.hf
+++ b/libraries/chain/hardfork.d/CORE_922_931.hf
@@ -1,0 +1,5 @@
+// bitshares-core issue #922 Missing checks when updating an asset's bitasset_data
+// bitshares-core issue #931 Changing backing asset ID runs some checks against the old value instead of the new
+#ifndef HARDFORK_CORE_922_931_TIME
+#define HARDFORK_CORE_922_931_TIME (fc::time_point_sec( 1535625300 ))
+#endif

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -537,7 +537,8 @@ const asset_object& database_fixture::create_user_issued_asset( const string& na
 }
 
 const asset_object& database_fixture::create_user_issued_asset( const string& name, const account_object& issuer, uint16_t flags,
-                                                                const price& core_exchange_rate )
+                                                                const price& core_exchange_rate,
+                                                                asset_id_type backing_asset)
 {
    asset_create_operation creator;
    creator.issuer = issuer.id;
@@ -549,6 +550,11 @@ const asset_object& database_fixture::create_user_issued_asset( const string& na
    creator.common_options.max_supply = GRAPHENE_MAX_SHARE_SUPPLY;
    creator.common_options.flags = flags;
    creator.common_options.issuer_permissions = flags;
+   if (backing_asset != asset_id_type())
+   {
+      creator.bitasset_opts = bitasset_options();
+      creator.bitasset_opts->short_backing_asset = backing_asset;
+   }
    trx.operations.clear();
    trx.operations.push_back(std::move(creator));
    set_expiration( db, trx );

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -459,7 +459,9 @@ const asset_object& database_fixture::create_bitasset(
    const string& name,
    account_id_type issuer /* = GRAPHENE_WITNESS_ACCOUNT */,
    uint16_t market_fee_percent /* = 100 */ /* 1% */,
-   uint16_t flags /* = charge_market_fee */
+   uint16_t flags /* = charge_market_fee */,
+   uint16_t precision /* = GRAPHENE_BLOCKCHAIN_PRECISION_DIGITS */,
+   asset_id_type backing_asset /* = CORE */
    )
 { try {
    asset_create_operation creator;
@@ -467,7 +469,7 @@ const asset_object& database_fixture::create_bitasset(
    creator.fee = asset();
    creator.symbol = name;
    creator.common_options.max_supply = GRAPHENE_MAX_SHARE_SUPPLY;
-   creator.precision = 2;
+   creator.precision = precision;
    creator.common_options.market_fee_percent = market_fee_percent;
    if( issuer == GRAPHENE_WITNESS_ACCOUNT )
       flags |= witness_fed_asset;
@@ -475,6 +477,7 @@ const asset_object& database_fixture::create_bitasset(
    creator.common_options.flags = flags & ~global_settle;
    creator.common_options.core_exchange_rate = price({asset(1,asset_id_type(1)),asset(1)});
    creator.bitasset_opts = bitasset_options();
+   creator.bitasset_opts->short_backing_asset = backing_asset;
    trx.operations.push_back(std::move(creator));
    trx.validate();
    processed_transaction ptx = db.push_transaction(trx, ~0);
@@ -486,7 +489,9 @@ const asset_object& database_fixture::create_prediction_market(
    const string& name,
    account_id_type issuer /* = GRAPHENE_WITNESS_ACCOUNT */,
    uint16_t market_fee_percent /* = 100 */ /* 1% */,
-   uint16_t flags /* = charge_market_fee */
+   uint16_t flags /* = charge_market_fee */,
+   uint16_t precision /* = 2, which seems arbitrary, but historically chosen */,
+   asset_id_type backing_asset /* = CORE */
    )
 { try {
    asset_create_operation creator;
@@ -494,7 +499,7 @@ const asset_object& database_fixture::create_prediction_market(
    creator.fee = asset();
    creator.symbol = name;
    creator.common_options.max_supply = GRAPHENE_MAX_SHARE_SUPPLY;
-   creator.precision = GRAPHENE_BLOCKCHAIN_PRECISION_DIGITS;
+   creator.precision = precision;
    creator.common_options.market_fee_percent = market_fee_percent;
    creator.common_options.issuer_permissions = flags | global_settle;
    creator.common_options.flags = flags & ~global_settle;
@@ -502,6 +507,7 @@ const asset_object& database_fixture::create_prediction_market(
       creator.common_options.flags |= witness_fed_asset;
    creator.common_options.core_exchange_rate = price({asset(1,asset_id_type(1)),asset(1)});
    creator.bitasset_opts = bitasset_options();
+   creator.bitasset_opts->short_backing_asset = backing_asset;
    creator.is_prediction_market = true;
    trx.operations.push_back(std::move(creator));
    trx.validate();
@@ -509,6 +515,7 @@ const asset_object& database_fixture::create_prediction_market(
    trx.operations.clear();
    return db.get<asset_object>(ptx.operation_results[0].get<object_id_type>());
 } FC_CAPTURE_AND_RETHROW( (name)(flags) ) }
+
 
 const asset_object& database_fixture::create_user_issued_asset( const string& name )
 {

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -537,24 +537,18 @@ const asset_object& database_fixture::create_user_issued_asset( const string& na
 }
 
 const asset_object& database_fixture::create_user_issued_asset( const string& name, const account_object& issuer, uint16_t flags,
-                                                                const price& core_exchange_rate,
-                                                                asset_id_type backing_asset)
+                                                                const price& core_exchange_rate, uint16_t precision)
 {
    asset_create_operation creator;
    creator.issuer = issuer.id;
    creator.fee = asset();
    creator.symbol = name;
    creator.common_options.max_supply = 0;
-   creator.precision = 2;
+   creator.precision = precision;
    creator.common_options.core_exchange_rate = core_exchange_rate;
    creator.common_options.max_supply = GRAPHENE_MAX_SHARE_SUPPLY;
    creator.common_options.flags = flags;
    creator.common_options.issuer_permissions = flags;
-   if (backing_asset != asset_id_type())
-   {
-      creator.bitasset_opts = bitasset_options();
-      creator.bitasset_opts->short_backing_asset = backing_asset;
-   }
    trx.operations.clear();
    trx.operations.push_back(std::move(creator));
    set_expiration( db, trx );

--- a/tests/common/database_fixture.hpp
+++ b/tests/common/database_fixture.hpp
@@ -112,14 +112,20 @@ extern uint32_t GRAPHENE_TESTING_GENESIS_TIMESTAMP;
    {                                                              \
       op;                                                         \
       BOOST_FAIL(std::string("Expected an exception with \"") +   \
-         std::string(exc_text) + std::string("\""));              \
+         std::string(exc_text) +                                  \
+         std::string("\" but none thrown"));                      \
    }                                                              \
    catch (fc::exception& ex)                                      \
    {                                                              \
       std::string what = ex.to_string(                            \
             fc::log_level(fc::log_level::all));                   \
-      BOOST_CHECK_MESSAGE(what.find(exc_text)                     \
-            != std::string::npos, what);                          \
+      if (what.find(exc_text) == std::string::npos)               \
+      {                                                           \
+         BOOST_FAIL( std::string("Expected \"") +                 \
+            std::string(exc_text) +                               \
+            std::string("\" but got \"") +                        \
+            std::string(what) );                                  \
+      }                                                           \
    }                                                              \
 }                                                                 \
 

--- a/tests/common/database_fixture.hpp
+++ b/tests/common/database_fixture.hpp
@@ -108,17 +108,18 @@ extern uint32_t GRAPHENE_TESTING_GENESIS_TIMESTAMP;
 
 #define REQUIRE_EXCEPTION_WITH_TEXT(op, exc_text)                 \
 {                                                                 \
-   fc::log_level ll(fc::log_level::all);                          \
    try                                                            \
    {                                                              \
       op;                                                         \
-      BOOST_FAIL(std::string("Expected an exception with ") +     \
-         std::string(exc_text));                                  \
+      BOOST_FAIL(std::string("Expected an exception with \"") +   \
+         std::string(exc_text) + std::string("\""));              \
    }                                                              \
    catch (fc::exception& ex)                                      \
    {                                                              \
-      std::string what = ex.to_string(log_level_all);             \
-      BOOST_CHECK(what.find(exc_text) != std::string::npos);      \
+      std::string what = ex.to_string(                            \
+            fc::log_level(fc::log_level::all));                   \
+      BOOST_CHECK_MESSAGE(what.find(exc_text)                     \
+            != std::string::npos, what);                          \
    }                                                              \
 }                                                                 \
 
@@ -275,7 +276,8 @@ struct database_fixture {
    const asset_object& create_user_issued_asset( const string& name,
                                                  const account_object& issuer,
                                                  uint16_t flags,
-                                                 const price& core_exchange_rate = price(asset(1, asset_id_type(1)), asset(1)) );
+                                                 const price& core_exchange_rate = price(asset(1, asset_id_type(1)), asset(1)),
+                                                 asset_id_type backing_asset = {});
    void issue_uia( const account_object& recipient, asset amount );
    void issue_uia( account_id_type recipient_id, asset amount );
 

--- a/tests/common/database_fixture.hpp
+++ b/tests/common/database_fixture.hpp
@@ -106,6 +106,22 @@ extern uint32_t GRAPHENE_TESTING_GENESIS_TIMESTAMP;
 #define REQUIRE_OP_VALIDATION_FAILURE( op, field, value ) \
    REQUIRE_OP_VALIDATION_FAILURE_2( op, field, value, fc::exception )
 
+#define REQUIRE_EXCEPTION_WITH_TEXT(op, exc_text)                 \
+{                                                                 \
+   fc::log_level ll(fc::log_level::all);                          \
+   try                                                            \
+   {                                                              \
+      op;                                                         \
+      BOOST_FAIL(std::string("Expected an exception with ") +     \
+         std::string(exc_text));                                  \
+   }                                                              \
+   catch (fc::exception& ex)                                      \
+   {                                                              \
+      std::string what = ex.to_string(log_level_all);             \
+      BOOST_CHECK(what.find(exc_text) != std::string::npos);      \
+   }                                                              \
+}                                                                 \
+
 #define REQUIRE_THROW_WITH_VALUE_2(op, field, value, exc_type) \
 { \
    auto bak = op.field; \
@@ -246,11 +262,15 @@ struct database_fixture {
    const asset_object& create_bitasset(const string& name,
                                        account_id_type issuer = GRAPHENE_WITNESS_ACCOUNT,
                                        uint16_t market_fee_percent = 100 /*1%*/,
-                                       uint16_t flags = charge_market_fee);
+                                       uint16_t flags = charge_market_fee,
+                                       uint16_t precision = 2,
+                                       asset_id_type backing_asset = {});
    const asset_object& create_prediction_market(const string& name,
                                        account_id_type issuer = GRAPHENE_WITNESS_ACCOUNT,
                                        uint16_t market_fee_percent = 100 /*1%*/,
-                                       uint16_t flags = charge_market_fee);
+                                       uint16_t flags = charge_market_fee,
+                                       uint16_t precision = GRAPHENE_BLOCKCHAIN_PRECISION_DIGITS,
+                                       asset_id_type backing_asset = {});
    const asset_object& create_user_issued_asset( const string& name );
    const asset_object& create_user_issued_asset( const string& name,
                                                  const account_object& issuer,

--- a/tests/common/database_fixture.hpp
+++ b/tests/common/database_fixture.hpp
@@ -277,7 +277,7 @@ struct database_fixture {
                                                  const account_object& issuer,
                                                  uint16_t flags,
                                                  const price& core_exchange_rate = price(asset(1, asset_id_type(1)), asset(1)),
-                                                 asset_id_type backing_asset = {});
+                                                 uint16_t precision = 2 /* traditional precision for tests */);
    void issue_uia( const account_object& recipient, asset amount );
    void issue_uia( account_id_type recipient_id, asset amount );
 

--- a/tests/tests/bitasset_tests.cpp
+++ b/tests/tests/bitasset_tests.cpp
@@ -572,7 +572,7 @@ BOOST_AUTO_TEST_CASE( bitasset_evaluator_test_before_922_931 )
    const asset_object& bit_usd = create_bitasset("USDBIT", GRAPHENE_COMMITTEE_ACCOUNT);
    asset_id_type bit_usd_id = bit_usd.id;
 
-   BOOST_TEST_MESSAGE( "Create market issued BLAH" );
+   BOOST_TEST_MESSAGE( "Create user issued BLAH" );
    const asset_object& blah = create_user_issued_asset( "BLAH" );
 
    BOOST_TEST_MESSAGE( "Create a bitasset with a precision of 6" );
@@ -755,7 +755,7 @@ BOOST_AUTO_TEST_CASE( bitasset_evaluator_test_after_922_931 )
    const asset_object& bit_usd = create_bitasset("USDBIT", GRAPHENE_COMMITTEE_ACCOUNT);
    asset_id_type bit_usd_id = bit_usd.id;
 
-   BOOST_TEST_MESSAGE( "Create market issued BLAH" );
+   BOOST_TEST_MESSAGE( "Create user issued BLAH" );
    const asset_object& blah = create_user_issued_asset( "BLAH" );
 
    BOOST_TEST_MESSAGE( "Create a bitasset with a precision of 6" );

--- a/tests/tests/bitasset_tests.cpp
+++ b/tests/tests/bitasset_tests.cpp
@@ -685,6 +685,11 @@ BOOST_AUTO_TEST_CASE( bitasset_evaluator_test_before_922_931 )
    BOOST_TEST_MESSAGE( "Switching to a backing asset that is a UIA should work. No error in the log." );
    op.new_options.short_backing_asset = asset_objs.user_issued->get_id();
    BOOST_CHECK( evaluator.evaluate(op) == void_result() );
+   // A -> B -> C, change B to be backed by A (circular backing)
+   BOOST_TEST_MESSAGE( "Check for circular backing. This should generate a warning" );
+   op.new_options.short_backing_asset = asset_objs.bit_child_user_issued->get_id();
+   BOOST_CHECK( evaluator.evaluate(op) == void_result() );
+   op.new_options.short_backing_asset = asset_objs.user_issued->get_id();
    BOOST_TEST_MESSAGE( "Pre hardfork: Adding a committee-issued asset. This should generate another message in the log" );
    // CHILDCOMMITTEE is a committee asset backed by PARENT which is backed by CORE
    // Cannot change PARENT's backing asset from CORE to something else because that will make CHILD be backed by
@@ -696,6 +701,7 @@ BOOST_AUTO_TEST_CASE( bitasset_evaluator_test_before_922_931 )
    op.asset_to_update = asset_objs.bit_usd->get_id();
    op.issuer = asset_objs.bit_usd->issuer;
    op.new_options.short_backing_asset = correct_asset_id;
+
 
    // Feed lifetime must exceed block interval
    BOOST_TEST_MESSAGE( "Feed lifetime less than or equal to block interval" );
@@ -805,6 +811,11 @@ BOOST_AUTO_TEST_CASE( bitasset_evaluator_test_after_922_931 )
    BOOST_TEST_MESSAGE( "Switching to a backing asset that is a UIA should work." );
    op.new_options.short_backing_asset = asset_objs.user_issued->get_id();
    BOOST_CHECK( evaluator.evaluate(op) == void_result() );
+   // A -> B -> C, change B to be backed by A (circular backing)
+   BOOST_TEST_MESSAGE( "Check for circular backing. This should generate an exception" );
+   op.new_options.short_backing_asset = asset_objs.bit_child_user_issued->get_id();
+   REQUIRE_EXCEPTION_WITH_TEXT( evaluator.evaluate(op), "'A' backed by 'B' backed by 'A'" );
+   op.new_options.short_backing_asset = asset_objs.user_issued->get_id();
    BOOST_TEST_MESSAGE( "Creating CHILDCOMMITTEE" );
    // CHILDCOMMITTEE is a committee asset backed by PARENT which is backed by CORE
    // Cannot change PARENT's backing asset from CORE to something else because that will make CHILD be backed by


### PR DESCRIPTION
This PR is for Issues #922 and #931 

#922 Checks for updating bitasset options do not include some of the same checks that are run when a bitasset is created.

#931 A bug exists in the evaluator that was running checks against the old backing asset, instead of the incoming backing asset.

- [x] Add hardfork protection
- [x] Add logging
- [x] Add tests

Update by @abitmore:
- handle more edge cases
  - [x] cycles
    - [x] test case
  - [x] disallow an MPA backed by an MPA backed by an MPA
    - [x] test case
  - [x] committee-owned MPA's need to be always backed by CORE
    - [x] test case
- test cases
  - [x] move common initialization code to a function
  - [x] need test cases for both MPA owned by committee and MPA owned by another account