### PR TITLE
When tallying witness/committee member votes, always assign at least 1

### DIFF
--- a/libraries/chain/db_maint.cpp
+++ b/libraries/chain/db_maint.cpp
@@ -224,7 +224,7 @@ void database::update_active_witnesses()
       {
          vote_counter vc;
          for( const witness_object& wit : wits )
-            vc.add( wit.witness_account, _vote_tally_buffer[wit.vote_id] );
+            vc.add( wit.witness_account, std::max(_vote_tally_buffer[wit.vote_id], UINT64_C(1)) );
          vc.finish( a.active );
       }
    } );
@@ -301,7 +301,7 @@ void database::update_active_committee_members()
          {
             vote_counter vc;
             for( const committee_member_object& cm : committee_members )
-               vc.add( cm.committee_member_account, _vote_tally_buffer[cm.vote_id] );
+               vc.add( cm.committee_member_account, std::max(_vote_tally_buffer[cm.vote_id], UINT64_C(1)) );
             vc.finish( a.active );
          }
       } );


### PR DESCRIPTION
This branch is created by @xeroc, cherry-picked from peerplays project.

Actually it's a fix for https://github.com/bitshares/bitshares-core/issues/183 which was labeled "wont fix".

I'm creating this ticket for potential discussion, although IMHO low priority.

Proposed changes:
>When tallying witness/committee member votes, always assign at least
one vote to each witness/committee member for purposes of calculating
their weight in the witness-account or committee-account authority.
This will likely have no effect in a well established blockchain, but
it does occur when a new blockchain is launched for testing without
enough votes to fill all the witness/committee slots.