### PR TITLE
MPA -> MPA -> CORE is valid

### DIFF
--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -498,7 +498,7 @@ void_result asset_update_bitasset_evaluator::do_evaluate(const asset_update_bita
          // Check if the new backing asset is itself backed by something. It must be CORE or a UIA
          if ( new_backing_asset.is_market_issued() )
          {
-            const asset_id_type& backing_backing_asset_id = new_backing_asset.bitasset_data(d).options.short_backing_asset;
+            asset_id_type backing_backing_asset_id = new_backing_asset.bitasset_data(d).options.short_backing_asset;
             FC_ASSERT( (backing_backing_asset_id == asset_id_type() || !backing_backing_asset_id(d).is_market_issued()),
                   "A BitAsset cannot be backed by a BitAsset that itself is backed by a BitAsset.");
          }
@@ -570,7 +570,7 @@ void_result asset_update_bitasset_evaluator::do_evaluate(const asset_update_bita
          // Check if the new backing asset is itself backed by something. It must be CORE or a UIA
          if ( new_backing_asset.is_market_issued() )
          {
-            const asset_id_type& backing_backing_asset_id = new_backing_asset.bitasset_data(d).options.short_backing_asset;
+            asset_id_type backing_backing_asset_id = new_backing_asset.bitasset_data(d).options.short_backing_asset;
             if ( backing_backing_asset_id != asset_id_type() && backing_backing_asset_id(d).is_market_issued() )
             {
                wlog( "before hf-922-931, a BitAsset cannot be backed by a BitAsset that itself "

--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -570,16 +570,13 @@ void_result asset_update_bitasset_evaluator::do_evaluate(const asset_update_bita
          // Check if the new backing asset is itself backed by something. It must be CORE or a UIA
          if ( new_backing_asset.is_market_issued() )
          {
-            const asset_object& backing_backing_asset = new_backing_asset.bitasset_data(d).asset_id(d);
-            if ( backing_backing_asset.get_id() != asset_id_type() )
+            const asset_id_type& backing_backing_asset_id = new_backing_asset.bitasset_data(d).options.short_backing_asset;
+            if ( backing_backing_asset_id != asset_id_type() && backing_backing_asset_id(d).is_market_issued() )
             {
-               if ( backing_backing_asset.is_market_issued() )
-               {
-                  wlog( "before hf-922-931, a BitAsset cannot be backed by a BitAsset that itself "
-                        "is backed by a BitAsset. This occurred at block ${b}",
-                        ("b", d.head_block_num() ) );
-               }
-            } // not core
+               wlog( "before hf-922-931, a BitAsset cannot be backed by a BitAsset that itself "
+                     "is backed by a BitAsset. This occurred at block ${b}",
+                     ("b", d.head_block_num() ) );
+            } // not core, not UIA
          } // if market issued
       }
    }

--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -498,9 +498,9 @@ void_result asset_update_bitasset_evaluator::do_evaluate(const asset_update_bita
          // Check if the new backing asset is itself backed by something. It must be CORE or a UIA
          if ( new_backing_asset.is_market_issued() )
          {
-            const asset_object& backing_backing_asset = new_backing_asset.bitasset_data(d).asset_id(d);
-            FC_ASSERT( !backing_backing_asset.is_market_issued(), "A BitAsset cannot be backed by a BitAsset that itself "
-                  "is backed by a BitAsset.");
+            const asset_id_type& backing_backing_asset_id = new_backing_asset.bitasset_data(d).options.short_backing_asset;
+            FC_ASSERT( (backing_backing_asset_id == asset_id_type() || !backing_backing_asset_id(d).is_market_issued()),
+                  "A BitAsset cannot be backed by a BitAsset that itself is backed by a BitAsset.");
          }
       }
       else // prior to HF 922 / 931

--- a/tests/tests/bitasset_tests.cpp
+++ b/tests/tests/bitasset_tests.cpp
@@ -165,9 +165,6 @@ BOOST_AUTO_TEST_CASE( reset_backing_asset_on_witness_asset )
       trx.clear();
    }
 
-   BOOST_TEST_MESSAGE( "Create JMJUIA" );
-   asset_id_type jmj_uia_id = create_user_issued_asset( "JMJUIA" ).id;
-
    BOOST_TEST_MESSAGE("Grab active witnesses");
    auto& global_props = db.get_global_properties();
    std::vector<account_id_type> active_witnesses;
@@ -236,8 +233,8 @@ BOOST_AUTO_TEST_CASE( reset_backing_asset_on_witness_asset )
       BOOST_CHECK_EQUAL(jmj_obj.feeds.size(), 2ul);
    }
    {
-      BOOST_TEST_MESSAGE("After hardfork, change underlying asset of bit_jmj from core to jmj_uia");
-      change_backing_asset(*this, nathan_private_key, bit_jmj_id, jmj_uia_id);
+      BOOST_TEST_MESSAGE("After hardfork, change underlying asset of bit_jmj from core to bit_usd");
+      change_backing_asset(*this, nathan_private_key, bit_jmj_id, bit_usd_id);
 
       BOOST_TEST_MESSAGE("Verify feed producers have been reset");
       const asset_bitasset_data_object& jmj_obj = bit_jmj_id(db).bitasset_data(db);
@@ -246,7 +243,7 @@ BOOST_AUTO_TEST_CASE( reset_backing_asset_on_witness_asset )
    {
       BOOST_TEST_MESSAGE("With underlying bitasset changed from one to another, price feeds should still be publish-able");
       BOOST_TEST_MESSAGE("Re-Adding Witness 1 price feed");
-      publish_feed(active_witnesses[0], jmj_uia_id, 1, bit_jmj_id, 30, core_id);
+      publish_feed(active_witnesses[0], bit_usd_id, 1, bit_jmj_id, 30, core_id);
 
       const asset_bitasset_data_object& bitasset = bit_jmj_id(db).bitasset_data(db);
       BOOST_CHECK_EQUAL(bitasset.current_feed.settlement_price.to_real(), 30);
@@ -310,10 +307,6 @@ BOOST_AUTO_TEST_CASE( reset_backing_asset_on_non_witness_asset )
       generate_block();
       trx.clear();
    }
-
-   BOOST_TEST_MESSAGE( "Create JMJUIA" );
-   asset_id_type jmj_uia_id = create_user_issued_asset( "JMJUIA" ).id;
-
 
    {
       BOOST_TEST_MESSAGE("Verify feed producers are registered for JMJBIT");
@@ -392,8 +385,8 @@ BOOST_AUTO_TEST_CASE( reset_backing_asset_on_non_witness_asset )
       //BOOST_CHECK_EQUAL(jmj_obj.current_feed.settlement_price.to_real(), 300);
    }
    {
-      BOOST_TEST_MESSAGE("After hardfork, change underlying asset of bit_jmj from core to jmj_uia");
-      change_backing_asset(*this, nathan_private_key, bit_jmj_id, jmj_uia_id);
+      BOOST_TEST_MESSAGE("After hardfork, change underlying asset of bit_jmj from core to bit_usd");
+      change_backing_asset(*this, nathan_private_key, bit_jmj_id, bit_usd_id);
 
       BOOST_TEST_MESSAGE("Verify feed producers have been reset");
       const asset_bitasset_data_object& jmj_obj = bit_jmj_id(db).bitasset_data(db);
@@ -406,20 +399,20 @@ BOOST_AUTO_TEST_CASE( reset_backing_asset_on_non_witness_asset )
    {
       BOOST_TEST_MESSAGE("With underlying bitasset changed from one to another, price feeds should still be publish-able");
       BOOST_TEST_MESSAGE("Adding Vikram's price feed");
-      publish_feed(vikram_id, jmj_uia_id, 1, bit_jmj_id, 30, core_id);
+      publish_feed(vikram_id, bit_usd_id, 1, bit_jmj_id, 30, core_id);
 
       const asset_bitasset_data_object& bitasset = bit_jmj_id(db).bitasset_data(db);
       BOOST_CHECK_EQUAL(bitasset.current_feed.settlement_price.to_real(), 30);
       BOOST_CHECK(bitasset.current_feed.maintenance_collateral_ratio == GRAPHENE_DEFAULT_MAINTENANCE_COLLATERAL_RATIO);
 
       BOOST_TEST_MESSAGE("Adding Ben's pricing to JMJBIT");
-      publish_feed(ben_id, jmj_uia_id, 1, bit_jmj_id, 25, core_id);
+      publish_feed(ben_id, bit_usd_id, 1, bit_jmj_id, 25, core_id);
 
       BOOST_CHECK_EQUAL(bitasset.current_feed.settlement_price.to_real(), 30);
       BOOST_CHECK(bitasset.current_feed.maintenance_collateral_ratio == GRAPHENE_DEFAULT_MAINTENANCE_COLLATERAL_RATIO);
 
       BOOST_TEST_MESSAGE("Adding Dan's pricing to JMJBIT");
-      publish_feed(dan_id, jmj_uia_id, 1, bit_jmj_id, 10, core_id);
+      publish_feed(dan_id, bit_usd_id, 1, bit_jmj_id, 10, core_id);
 
       BOOST_CHECK_EQUAL(bitasset.current_feed.settlement_price.to_real(), 25);
       BOOST_CHECK(bitasset.current_feed.maintenance_collateral_ratio == GRAPHENE_DEFAULT_MAINTENANCE_COLLATERAL_RATIO);


### PR DESCRIPTION
This fixes issue #970 
A change made to the asset_evaluator mistakenly asserted when the backing asset's backing asset was market issued. That is normally ok, but not if the market issued asset being examined is CORE.

During development of #922 and #931, some tests were failing, and those tests were modified in a way that hid the problem rather than exposing it. This fix also reverses those test changes. 