### PR TITLE
Fix test cases: if hf 343 and 890 occur at same maintenance interval

### DIFF
--- a/tests/tests/bitasset_tests.cpp
+++ b/tests/tests/bitasset_tests.cpp
@@ -1036,8 +1036,8 @@ BOOST_AUTO_TEST_CASE( hf_935_test )
          ba_op.issuer = asset_to_update.issuer;
          ba_op.new_options = asset_to_update.bitasset_data(db).options;
          ba_op.new_options.feed_lifetime_sec = HARDFORK_CORE_935_TIME.sec_since_epoch()
-                                             - db.head_block_time().sec_since_epoch()
-                                             + mi * 3;
+                                             + mi * 3 + 86400 * 2
+                                             - db.head_block_time().sec_since_epoch();
          trx.operations.push_back(ba_op);
          PUSH_TX(db, trx, ~0);
          trx.clear();


### PR DESCRIPTION
The test case `hf_935_test` was failing in `testnet-hf-time` branch when bitasset data is updated before hard fork 890:

https://github.com/bitshares/bitshares-core/blob/e9defea081cb00b0d9d5eeb06fc5f869e3c3bdbe/tests/tests/bitasset_tests.cpp#L1071

The reason is explained in the in-code comments:

https://github.com/bitshares/bitshares-core/blob/e9defea081cb00b0d9d5eeb06fc5f869e3c3bdbe/libraries/chain/db_maint.cpp#L933-L935

That said, if hf 343 and 890 occur at same maintenance interval, after median feed got updated by hf 890 code, `check_call_orders` will be called by hf 343 code, thus will finally produce a good result.

This PR fixed the test case.