### PR TITLE
support account names or ids in all api calls

### DIFF
--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -318,8 +318,9 @@ namespace graphene { namespace app {
        const auto& db = *_app.chain_database();
        FC_ASSERT( limit <= 100 );
        vector<operation_history_object> result;
-       account_id_type account = database_api.get_account_id_from_string(account_id_or_name); // ask this, maybe not safe
+       account_id_type account;
        try {
+          account = database_api.get_account_id_from_string(account_id_or_name);
           const account_transaction_history_object& node = account(db).statistics(db).most_recent_op(db);
           if(start == operation_history_id_type() || start.instance.value > node.operation_id.instance.value)
              start = node.operation_id;
@@ -353,7 +354,10 @@ namespace graphene { namespace app {
        const auto& db = *_app.chain_database();
        FC_ASSERT( limit <= 100 );
        vector<operation_history_object> result;
-       const account_id_type account = database_api.get_account_id_from_string(account_id_or_name); // ask this, maybe not safe
+       account_id_type account;
+       try {
+          account = database_api.get_account_id_from_string(account_id_or_name);
+       } catch(...) { return result; }
        const auto& stats = account(db).statistics(db);
        if( stats.most_recent_op == account_transaction_history_id_type() ) return result;
        const account_transaction_history_object* node = &stats.most_recent_op(db);
@@ -389,7 +393,10 @@ namespace graphene { namespace app {
        const auto& db = *_app.chain_database();
        FC_ASSERT(limit <= 100);
        vector<operation_history_object> result;
-       const account_id_type account = database_api.get_account_id_from_string(account_id_or_name); // ask this, maybe not safe
+       account_id_type account;
+       try {
+          account = database_api.get_account_id_from_string(account_id_or_name);
+       } catch(...) { return result; }
        const auto& stats = account(db).statistics(db);
        if( start == 0 )
           start = stats.total_ops;

--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -318,8 +318,7 @@ namespace graphene { namespace app {
        const auto& db = *_app.chain_database();
        FC_ASSERT( limit <= 100 );
        vector<operation_history_object> result;
-       fc::api<graphene::app::database_api> database_api;
-       account_id_type account = database_api->get_account_id_from_string(account_id_or_name); // ask this, maybe not safe
+       account_id_type account = database_api.get_account_id_from_string(account_id_or_name); // ask this, maybe not safe
        try {
           const account_transaction_history_object& node = account(db).statistics(db).most_recent_op(db);
           if(start == operation_history_id_type() || start.instance.value > node.operation_id.instance.value)
@@ -354,8 +353,7 @@ namespace graphene { namespace app {
        const auto& db = *_app.chain_database();
        FC_ASSERT( limit <= 100 );
        vector<operation_history_object> result;
-       fc::api<graphene::app::database_api> database_api;
-       const account_id_type account = database_api->get_account_id_from_string(account_id_or_name); // ask this, maybe not safe
+       const account_id_type account = database_api.get_account_id_from_string(account_id_or_name); // ask this, maybe not safe
        const auto& stats = account(db).statistics(db);
        if( stats.most_recent_op == account_transaction_history_id_type() ) return result;
        const account_transaction_history_object* node = &stats.most_recent_op(db);
@@ -391,8 +389,7 @@ namespace graphene { namespace app {
        const auto& db = *_app.chain_database();
        FC_ASSERT(limit <= 100);
        vector<operation_history_object> result;
-       fc::api<graphene::app::database_api> database_api;
-       const account_id_type account = database_api->get_account_id_from_string(account_id_or_name); // ask this, maybe not safe
+       const account_id_type account = database_api.get_account_id_from_string(account_id_or_name); // ask this, maybe not safe
        const auto& stats = account(db).statistics(db);
        if( start == 0 )
           start = stats.total_ops;

--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -309,7 +309,7 @@ namespace graphene { namespace app {
        return result;
     }
 
-    vector<operation_history_object> history_api::get_account_history( account_id_type account,
+    vector<operation_history_object> history_api::get_account_history( const std::string account_id_or_name,
                                                                        operation_history_id_type stop,
                                                                        unsigned limit,
                                                                        operation_history_id_type start ) const
@@ -318,6 +318,8 @@ namespace graphene { namespace app {
        const auto& db = *_app.chain_database();
        FC_ASSERT( limit <= 100 );
        vector<operation_history_object> result;
+       fc::api<graphene::app::database_api> database_api;
+       account_id_type account = database_api->get_account_id_from_string(account_id_or_name); // ask this, maybe not safe
        try {
           const account_transaction_history_object& node = account(db).statistics(db).most_recent_op(db);
           if(start == operation_history_id_type() || start.instance.value > node.operation_id.instance.value)
@@ -342,7 +344,7 @@ namespace graphene { namespace app {
        return result;
     }
 
-    vector<operation_history_object> history_api::get_account_history_operations( account_id_type account,
+    vector<operation_history_object> history_api::get_account_history_operations( const std::string account_id_or_name,
                                                                        int operation_id,
                                                                        operation_history_id_type start,
                                                                        operation_history_id_type stop,
@@ -352,6 +354,8 @@ namespace graphene { namespace app {
        const auto& db = *_app.chain_database();
        FC_ASSERT( limit <= 100 );
        vector<operation_history_object> result;
+       fc::api<graphene::app::database_api> database_api;
+       const account_id_type account = database_api->get_account_id_from_string(account_id_or_name); // ask this, maybe not safe
        const auto& stats = account(db).statistics(db);
        if( stats.most_recent_op == account_transaction_history_id_type() ) return result;
        const account_transaction_history_object* node = &stats.most_recent_op(db);
@@ -378,7 +382,7 @@ namespace graphene { namespace app {
     }
 
 
-    vector<operation_history_object> history_api::get_relative_account_history( account_id_type account,
+    vector<operation_history_object> history_api::get_relative_account_history( const std::string account_id_or_name,
                                                                                 uint32_t stop,
                                                                                 unsigned limit,
                                                                                 uint32_t start) const
@@ -387,12 +391,13 @@ namespace graphene { namespace app {
        const auto& db = *_app.chain_database();
        FC_ASSERT(limit <= 100);
        vector<operation_history_object> result;
+       fc::api<graphene::app::database_api> database_api;
+       const account_id_type account = database_api->get_account_id_from_string(account_id_or_name); // ask this, maybe not safe
        const auto& stats = account(db).statistics(db);
        if( start == 0 )
           start = stats.total_ops;
        else
           start = min( stats.total_ops, start );
-
 
        if( start >= stop && start > stats.removed_ops && limit > 0 )
        {
@@ -419,12 +424,12 @@ namespace graphene { namespace app {
        return hist->tracked_buckets();
     }
 
-    history_operation_detail history_api::get_account_history_by_operations(account_id_type account, vector<uint16_t> operation_types, uint32_t start, unsigned limit)
+    history_operation_detail history_api::get_account_history_by_operations(const std::string account_id_or_name, vector<uint16_t> operation_types, uint32_t start, unsigned limit)
     {
-        FC_ASSERT(limit <= 100);
-        history_operation_detail result;
-        vector<operation_history_object> objs = get_relative_account_history(account, start, limit, limit + start - 1);
-        std::for_each(objs.begin(), objs.end(), [&](const operation_history_object &o) {
+       FC_ASSERT(limit <= 100);
+       history_operation_detail result;
+       vector<operation_history_object> objs = get_relative_account_history(account_id_or_name, start, limit, limit + start - 1);
+       std::for_each(objs.begin(), objs.end(), [&](const operation_history_object &o) {
                     if (operation_types.empty() || find(operation_types.begin(), operation_types.end(), o.op.which()) != operation_types.end()) {
                         result.operation_history_objs.push_back(o);
                      }

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -84,7 +84,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       vector<optional<account_object>> get_accounts(const vector<std::string>& account_names_or_ids)const;
       std::map<string,full_account> get_full_accounts( const vector<string>& names_or_ids, bool subscribe );
       optional<account_object> get_account_by_name( string name )const;
-      vector<account_id_type> get_account_references( account_id_type account_id )const;
+      vector<account_id_type> get_account_references( std::string account_id_or_name )const;
       vector<optional<account_object>> lookup_account_names(const vector<string>& account_names)const;
       map<string,account_id_type> lookup_accounts(const string& lower_bound_name, uint32_t limit)const;
       uint64_t get_account_count()const;
@@ -758,16 +758,17 @@ optional<account_object> database_api_impl::get_account_by_name( string name )co
    return optional<account_object>();
 }
 
-vector<account_id_type> database_api::get_account_references( account_id_type account_id )const
+vector<account_id_type> database_api::get_account_references( std::string account_id_or_name )const
 {
-   return my->get_account_references( account_id );
+   return my->get_account_references( account_id_or_name );
 }
 
-vector<account_id_type> database_api_impl::get_account_references( account_id_type account_id )const
+vector<account_id_type> database_api_impl::get_account_references( std::string account_id_or_name )const
 {
    const auto& idx = _db.get_index_type<account_index>();
    const auto& aidx = dynamic_cast<const primary_index<account_index>&>(idx);
    const auto& refs = aidx.get_secondary_index<graphene::chain::account_member_index>();
+   const account_id_type account_id = get_account_from_string(account_id_or_name)->id;
    auto itr = refs.account_to_account_memberships.find(account_id);
    vector<account_id_type> result;
 

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -105,7 +105,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       vector<limit_order_object>         get_limit_orders(asset_id_type a, asset_id_type b, uint32_t limit)const;
       vector<call_order_object>          get_call_orders(asset_id_type a, uint32_t limit)const;
       vector<force_settlement_object>    get_settle_orders(asset_id_type a, uint32_t limit)const;
-      vector<call_order_object>          get_margin_positions( const account_id_type& id )const;
+      vector<call_order_object>          get_margin_positions( const std::string account_id_or_name )const;
       vector<collateral_bid_object>      get_collateral_bids(const asset_id_type asset, uint32_t limit, uint32_t start)const;
       void subscribe_to_market(std::function<void(const variant&)> callback, asset_id_type a, asset_id_type b);
       void unsubscribe_from_market(asset_id_type a, asset_id_type b);
@@ -1107,17 +1107,18 @@ vector<force_settlement_object> database_api_impl::get_settle_orders(asset_id_ty
    return result;
 }
 
-vector<call_order_object> database_api::get_margin_positions( const account_id_type& id )const
+vector<call_order_object> database_api::get_margin_positions( const std::string account_id_or_name )const
 {
-   return my->get_margin_positions( id );
+   return my->get_margin_positions( account_id_or_name );
 }
 
-vector<call_order_object> database_api_impl::get_margin_positions( const account_id_type& id )const
+vector<call_order_object> database_api_impl::get_margin_positions( const std::string account_id_or_name )const
 {
    try
    {
       const auto& idx = _db.get_index_type<call_order_index>();
       const auto& aidx = idx.indices().get<by_account>();
+      const account_id_type id = get_account_from_string(account_id_or_name)->id; // ask this, maybe not safe
       auto start = aidx.lower_bound( boost::make_tuple( id, asset_id_type(0) ) );
       auto end = aidx.lower_bound( boost::make_tuple( id+1, asset_id_type(0) ) );
       vector<call_order_object> result;
@@ -1127,7 +1128,7 @@ vector<call_order_object> database_api_impl::get_margin_positions( const account
          ++start;
       }
       return result;
-   } FC_CAPTURE_AND_RETHROW( (id) )
+   } FC_CAPTURE_AND_RETHROW( (account_id_or_name) )
 }
 
 vector<collateral_bid_object> database_api::get_collateral_bids(const asset_id_type asset, uint32_t limit, uint32_t start)const

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -81,7 +81,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       bool is_public_key_registered(string public_key) const;
 
       // Accounts
-      vector<optional<account_object>> get_accounts(const vector<account_id_type>& account_ids)const;
+      vector<optional<account_object>> get_accounts(const vector<std::string>& account_names_or_ids)const;
       std::map<string,full_account> get_full_accounts( const vector<string>& names_or_ids, bool subscribe );
       optional<account_object> get_account_by_name( string name )const;
       vector<account_id_type> get_account_references( account_id_type account_id )const;
@@ -622,16 +622,19 @@ bool database_api_impl::is_public_key_registered(string public_key) const
 //                                                                  //
 //////////////////////////////////////////////////////////////////////
 
-vector<optional<account_object>> database_api::get_accounts(const vector<account_id_type>& account_ids)const
+vector<optional<account_object>> database_api::get_accounts(const vector<std::string>& account_names_or_ids)const
 {
-   return my->get_accounts( account_ids );
+   return my->get_accounts( account_names_or_ids );
 }
 
-vector<optional<account_object>> database_api_impl::get_accounts(const vector<account_id_type>& account_ids)const
+vector<optional<account_object>> database_api_impl::get_accounts(const vector<std::string>& account_names_or_ids)const
 {
-   vector<optional<account_object>> result; result.reserve(account_ids.size());
-   std::transform(account_ids.begin(), account_ids.end(), std::back_inserter(result),
-                  [this](account_id_type id) -> optional<account_object> {
+   vector<optional<account_object>> result; result.reserve(account_names_or_ids.size());
+   std::transform(account_names_or_ids.begin(), account_names_or_ids.end(), std::back_inserter(result),
+                  [this](std::string id_or_name) -> optional<account_object> {
+
+      const account_object* account = get_account_from_string(id_or_name);
+      account_id_type id = account->id;
       if(auto o = _db.find(id))
       {
          subscribe_to_item( id );

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -124,7 +124,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
 
       // Committee members
       vector<optional<committee_member_object>> get_committee_members(const vector<committee_member_id_type>& committee_member_ids)const;
-      fc::optional<committee_member_object> get_committee_member_by_account(account_id_type account)const;
+      fc::optional<committee_member_object> get_committee_member_by_account(const std::string account_id_or_name)const;
       map<string, committee_member_id_type> lookup_committee_member_accounts(const string& lower_bound_name, uint32_t limit)const;
       uint64_t get_committee_count()const;
 
@@ -1653,14 +1653,15 @@ vector<optional<committee_member_object>> database_api_impl::get_committee_membe
    return result;
 }
 
-fc::optional<committee_member_object> database_api::get_committee_member_by_account(account_id_type account)const
+fc::optional<committee_member_object> database_api::get_committee_member_by_account(const std::string account_id_or_name)const
 {
-   return my->get_committee_member_by_account( account );
+   return my->get_committee_member_by_account( account_id_or_name );
 }
 
-fc::optional<committee_member_object> database_api_impl::get_committee_member_by_account(account_id_type account) const
+fc::optional<committee_member_object> database_api_impl::get_committee_member_by_account(const std::string account_id_or_name) const
 {
    const auto& idx = _db.get_index_type<committee_member_index>().indices().get<by_account>();
+   const account_id_type account = get_account_from_string(account_id_or_name)->id; // ask this, maybe not safe
    auto itr = idx.find(account);
    if( itr != idx.end() )
       return *itr;

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -153,8 +153,8 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       vector<blinded_balance_object> get_blinded_balances( const flat_set<commitment_type>& commitments )const;
 
       // Withdrawals
-      vector<withdraw_permission_object> get_withdraw_permissions_by_giver(account_id_type account, withdraw_permission_id_type start, uint32_t limit)const;
-      vector<withdraw_permission_object> get_withdraw_permissions_by_recipient(account_id_type account, withdraw_permission_id_type start, uint32_t limit)const;
+      vector<withdraw_permission_object> get_withdraw_permissions_by_giver(const std::string account_id_or_name, withdraw_permission_id_type start, uint32_t limit)const;
+      vector<withdraw_permission_object> get_withdraw_permissions_by_recipient(const std::string account_id_or_name, withdraw_permission_id_type start, uint32_t limit)const;
 
    //private:
       static string price_to_string( const price& _price, const asset_object& _base, const asset_object& _quote );
@@ -2119,18 +2119,19 @@ vector<blinded_balance_object> database_api_impl::get_blinded_balances( const fl
 //                                                                  //
 //////////////////////////////////////////////////////////////////////
 
-vector<withdraw_permission_object> database_api::get_withdraw_permissions_by_giver(account_id_type account, withdraw_permission_id_type start, uint32_t limit)const
+vector<withdraw_permission_object> database_api::get_withdraw_permissions_by_giver(const std::string account_id_or_name, withdraw_permission_id_type start, uint32_t limit)const
 {
-   return my->get_withdraw_permissions_by_giver( account, start, limit );
+   return my->get_withdraw_permissions_by_giver( account_id_or_name, start, limit );
 }
 
-vector<withdraw_permission_object> database_api_impl::get_withdraw_permissions_by_giver(account_id_type account, withdraw_permission_id_type start, uint32_t limit)const
+vector<withdraw_permission_object> database_api_impl::get_withdraw_permissions_by_giver(const std::string account_id_or_name, withdraw_permission_id_type start, uint32_t limit)const
 {
    FC_ASSERT( limit <= 101 );
    vector<withdraw_permission_object> result;
 
    const auto& withdraw_idx = _db.get_index_type<withdraw_permission_index>().indices().get<by_from>();
    auto withdraw_index_end = withdraw_idx.end();
+   const account_id_type account = get_account_from_string(account_id_or_name)->id; // ask this, maybe not safe
    auto withdraw_itr = withdraw_idx.lower_bound(boost::make_tuple(account, start));
    while(withdraw_itr != withdraw_index_end && withdraw_itr->withdraw_from_account == account && result.size() < limit)
    {
@@ -2140,18 +2141,19 @@ vector<withdraw_permission_object> database_api_impl::get_withdraw_permissions_b
    return result;
 }
 
-vector<withdraw_permission_object> database_api::get_withdraw_permissions_by_recipient(account_id_type account, withdraw_permission_id_type start, uint32_t limit)const
+vector<withdraw_permission_object> database_api::get_withdraw_permissions_by_recipient(const std::string account_id_or_name, withdraw_permission_id_type start, uint32_t limit)const
 {
-   return my->get_withdraw_permissions_by_recipient( account, start, limit );
+   return my->get_withdraw_permissions_by_recipient( account_id_or_name, start, limit );
 }
 
-vector<withdraw_permission_object> database_api_impl::get_withdraw_permissions_by_recipient(account_id_type account, withdraw_permission_id_type start, uint32_t limit)const
+vector<withdraw_permission_object> database_api_impl::get_withdraw_permissions_by_recipient(const std::string account_id_or_name, withdraw_permission_id_type start, uint32_t limit)const
 {
    FC_ASSERT( limit <= 101 );
    vector<withdraw_permission_object> result;
 
    const auto& withdraw_idx = _db.get_index_type<withdraw_permission_index>().indices().get<by_authorized>();
    auto withdraw_index_end = withdraw_idx.end();
+   const account_id_type account = get_account_from_string(account_id_or_name)->id; // ask this, maybe not safe
    auto withdraw_itr = withdraw_idx.lower_bound(boost::make_tuple(account, start));
    while(withdraw_itr != withdraw_index_end && withdraw_itr->authorized_account == account && result.size() < limit)
    {

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -90,7 +90,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       uint64_t get_account_count()const;
 
       // Balances
-      vector<asset> get_account_balances(const std::string& account_name_or_id, const flat_set<asset_id_type>& assets);
+      vector<asset> get_account_balances(const std::string& account_name_or_id, const flat_set<asset_id_type>& assets)const;
       vector<asset> get_named_account_balances(const std::string& name, const flat_set<asset_id_type>& assets)const;
       vector<balance_object> get_balance_objects( const vector<address>& addrs )const;
       vector<asset> get_vested_balances( const vector<balance_id_type>& objs )const;
@@ -142,7 +142,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       set<public_key_type> get_potential_signatures( const signed_transaction& trx )const;
       set<address> get_potential_address_signatures( const signed_transaction& trx )const;
       bool verify_authority( const signed_transaction& trx )const;
-      bool verify_account_authority( const string& account_name_or_id, const flat_set<public_key_type>& signers );
+      bool verify_account_authority( const string& account_name_or_id, const flat_set<public_key_type>& signers )const;
       processed_transaction validate_transaction( const signed_transaction& trx )const;
       vector< fc::variant > get_required_fees( const vector<operation>& ops, asset_id_type id )const;
 
@@ -198,7 +198,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
          return tmp;
       }
 
-      const account_object* get_account_from_string( const std::string& name_or_id  )
+      const account_object* get_account_from_string( const std::string& name_or_id  ) const
       {
          // TODO cache the result to avoid repeatly fetching from db
          FC_ASSERT( name_or_id.size() > 0);
@@ -833,12 +833,12 @@ uint64_t database_api_impl::get_account_count()const
 //                                                                  //
 //////////////////////////////////////////////////////////////////////
 
-vector<asset> database_api::get_account_balances(const std::string& account_name_or_id, const flat_set<asset_id_type>& assets)
+vector<asset> database_api::get_account_balances(const std::string& account_name_or_id, const flat_set<asset_id_type>& assets)const
 {
    return my->get_account_balances( account_name_or_id, assets );
 }
 
-vector<asset> database_api_impl::get_account_balances(const std::string& account_name_or_id, const flat_set<asset_id_type>& assets)
+vector<asset> database_api_impl::get_account_balances(const std::string& account_name_or_id, const flat_set<asset_id_type>& assets)const
 {
    const account_object* account = get_account_from_string(account_name_or_id);
    account_id_type acnt = account->id;
@@ -1938,12 +1938,12 @@ bool database_api_impl::verify_authority( const signed_transaction& trx )const
    return true;
 }
 
-bool database_api::verify_account_authority( const string& account_name_or_id, const flat_set<public_key_type>& signers )
+bool database_api::verify_account_authority( const string& account_name_or_id, const flat_set<public_key_type>& signers )const
 {
    return my->verify_account_authority( account_name_or_id, signers );
 }
 
-bool database_api_impl::verify_account_authority( const string& account_name_or_id, const flat_set<public_key_type>& keys )
+bool database_api_impl::verify_account_authority( const string& account_name_or_id, const flat_set<public_key_type>& keys )const
 {
    const account_object* account = get_account_from_string(account_name_or_id);
 

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -774,7 +774,7 @@ vector<account_id_type> database_api_impl::get_account_references( const std::st
    const auto& idx = _db.get_index_type<account_index>();
    const auto& aidx = dynamic_cast<const primary_index<account_index>&>(idx);
    const auto& refs = aidx.get_secondary_index<graphene::chain::account_member_index>();
-   const account_id_type account_id = get_account_from_string(account_id_or_name)->id; // ask this, maybe not safe
+   const account_id_type account_id = get_account_from_string(account_id_or_name)->id;
    auto itr = refs.account_to_account_memberships.find(account_id);
    vector<account_id_type> result;
 
@@ -943,7 +943,7 @@ vector<vesting_balance_object> database_api_impl::get_vesting_balances( const st
 {
    try
    {
-      const account_id_type account_id = get_account_from_string(account_id_or_name)->id; // ask this, maybe not safe
+      const account_id_type account_id = get_account_from_string(account_id_or_name)->id;
       vector<vesting_balance_object> result;
       auto vesting_range = _db.get_index_type<vesting_balance_index>().indices().get<by_account>().equal_range(account_id);
       std::for_each(vesting_range.first, vesting_range.second,
@@ -1124,7 +1124,7 @@ vector<call_order_object> database_api_impl::get_margin_positions( const std::st
    {
       const auto& idx = _db.get_index_type<call_order_index>();
       const auto& aidx = idx.indices().get<by_account>();
-      const account_id_type id = get_account_from_string(account_id_or_name)->id; // ask this, maybe not safe
+      const account_id_type id = get_account_from_string(account_id_or_name)->id;
       auto start = aidx.lower_bound( boost::make_tuple( id, asset_id_type(0) ) );
       auto end = aidx.lower_bound( boost::make_tuple( id+1, asset_id_type(0) ) );
       vector<call_order_object> result;
@@ -1591,7 +1591,7 @@ fc::optional<witness_object> database_api::get_witness_by_account(const std::str
 fc::optional<witness_object> database_api_impl::get_witness_by_account(const std::string account_id_or_name) const
 {
    const auto& idx = _db.get_index_type<witness_index>().indices().get<by_account>();
-   const account_id_type account = get_account_from_string(account_id_or_name)->id; // ask this, maybe not safe
+   const account_id_type account = get_account_from_string(account_id_or_name)->id;
    auto itr = idx.find(account);
    if( itr != idx.end() )
       return *itr;
@@ -1667,7 +1667,7 @@ fc::optional<committee_member_object> database_api::get_committee_member_by_acco
 fc::optional<committee_member_object> database_api_impl::get_committee_member_by_account(const std::string account_id_or_name) const
 {
    const auto& idx = _db.get_index_type<committee_member_index>().indices().get<by_account>();
-   const account_id_type account = get_account_from_string(account_id_or_name)->id; // ask this, maybe not safe
+   const account_id_type account = get_account_from_string(account_id_or_name)->id;
    auto itr = idx.find(account);
    if( itr != idx.end() )
       return *itr;
@@ -1745,7 +1745,7 @@ vector<optional<worker_object>> database_api_impl::get_workers_by_account(const 
    vector<optional<worker_object>> result;
    const auto& workers_idx = _db.get_index_type<worker_index>().indices().get<by_account>();
 
-   const account_id_type account = get_account_from_string(account_id_or_name)->id; // ask this, maybe not safe
+   const account_id_type account = get_account_from_string(account_id_or_name)->id;
    for( const auto& w : workers_idx )
     {
         if( w.worker_account == account )
@@ -2080,7 +2080,7 @@ vector<proposal_object> database_api_impl::get_proposed_transactions( const std:
 {
    const auto& idx = _db.get_index_type<proposal_index>();
    vector<proposal_object> result;
-   const account_id_type id = get_account_from_string(account_id_or_name)->id; // ask this, maybe not safe
+   const account_id_type id = get_account_from_string(account_id_or_name)->id;
 
    idx.inspect_all_objects( [&](const object& obj){
            const proposal_object& p = static_cast<const proposal_object&>(obj);
@@ -2137,7 +2137,7 @@ vector<withdraw_permission_object> database_api_impl::get_withdraw_permissions_b
 
    const auto& withdraw_idx = _db.get_index_type<withdraw_permission_index>().indices().get<by_from>();
    auto withdraw_index_end = withdraw_idx.end();
-   const account_id_type account = get_account_from_string(account_id_or_name)->id; // ask this, maybe not safe
+   const account_id_type account = get_account_from_string(account_id_or_name)->id;
    auto withdraw_itr = withdraw_idx.lower_bound(boost::make_tuple(account, start));
    while(withdraw_itr != withdraw_index_end && withdraw_itr->withdraw_from_account == account && result.size() < limit)
    {
@@ -2159,7 +2159,7 @@ vector<withdraw_permission_object> database_api_impl::get_withdraw_permissions_b
 
    const auto& withdraw_idx = _db.get_index_type<withdraw_permission_index>().indices().get<by_authorized>();
    auto withdraw_index_end = withdraw_idx.end();
-   const account_id_type account = get_account_from_string(account_id_or_name)->id; // ask this, maybe not safe
+   const account_id_type account = get_account_from_string(account_id_or_name)->id;
    auto withdraw_itr = withdraw_idx.lower_bound(boost::make_tuple(account, start));
    while(withdraw_itr != withdraw_index_end && withdraw_itr->authorized_account == account && result.size() < limit)
    {

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -81,6 +81,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       bool is_public_key_registered(string public_key) const;
 
       // Accounts
+      account_id_type get_account_id_from_string(const std::string& name_or_id)const;
       vector<optional<account_object>> get_accounts(const vector<std::string>& account_names_or_ids)const;
       std::map<string,full_account> get_full_accounts( const vector<string>& names_or_ids, bool subscribe );
       optional<account_object> get_account_by_name( string name )const;
@@ -198,7 +199,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
          return tmp;
       }
 
-      const account_object* get_account_from_string( const std::string& name_or_id  ) const
+      const account_object* get_account_from_string( const std::string& name_or_id ) const
       {
          // TODO cache the result to avoid repeatly fetching from db
          FC_ASSERT( name_or_id.size() > 0);
@@ -621,6 +622,11 @@ bool database_api_impl::is_public_key_registered(string public_key) const
 // Accounts                                                         //
 //                                                                  //
 //////////////////////////////////////////////////////////////////////
+
+account_id_type database_api::get_account_id_from_string(const std::string& name_or_id)const
+{
+   return my->get_account_from_string( name_or_id )->id; // safe?
+}
 
 vector<optional<account_object>> database_api::get_accounts(const vector<std::string>& account_names_or_ids)const
 {

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -118,7 +118,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
 
       // Witnesses
       vector<optional<witness_object>> get_witnesses(const vector<witness_id_type>& witness_ids)const;
-      fc::optional<witness_object> get_witness_by_account(account_id_type account)const;
+      fc::optional<witness_object> get_witness_by_account(const std::string account_id_or_name)const;
       map<string, witness_id_type> lookup_witness_accounts(const string& lower_bound_name, uint32_t limit)const;
       uint64_t get_witness_count()const;
 
@@ -1577,14 +1577,15 @@ vector<optional<witness_object>> database_api_impl::get_witnesses(const vector<w
    return result;
 }
 
-fc::optional<witness_object> database_api::get_witness_by_account(account_id_type account)const
+fc::optional<witness_object> database_api::get_witness_by_account(const std::string account_id_or_name)const
 {
-   return my->get_witness_by_account( account );
+   return my->get_witness_by_account( account_id_or_name );
 }
 
-fc::optional<witness_object> database_api_impl::get_witness_by_account(account_id_type account) const
+fc::optional<witness_object> database_api_impl::get_witness_by_account(const std::string account_id_or_name) const
 {
    const auto& idx = _db.get_index_type<witness_index>().indices().get<by_account>();
+   const account_id_type account = get_account_from_string(account_id_or_name)->id; // ask this, maybe not safe
    auto itr = idx.find(account);
    if( itr != idx.end() )
       return *itr;

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -130,7 +130,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
 
       // Workers
       vector<worker_object> get_all_workers()const;
-      vector<optional<worker_object>> get_workers_by_account(account_id_type account)const;
+      vector<optional<worker_object>> get_workers_by_account(const std::string account_id_or_name)const;
       uint64_t get_worker_count()const;
 
       // Votes
@@ -1729,17 +1729,18 @@ vector<worker_object> database_api_impl::get_all_workers()const
     return result;
 }
 
-vector<optional<worker_object>> database_api::get_workers_by_account(account_id_type account)const
+vector<optional<worker_object>> database_api::get_workers_by_account(const std::string account_id_or_name)const
 {
-    return my->get_workers_by_account( account );
+    return my->get_workers_by_account( account_id_or_name );
 }
 
-vector<optional<worker_object>> database_api_impl::get_workers_by_account(account_id_type account)const
+vector<optional<worker_object>> database_api_impl::get_workers_by_account(const std::string account_id_or_name)const
 {
-    vector<optional<worker_object>> result;
-    const auto& workers_idx = _db.get_index_type<worker_index>().indices().get<by_account>();
+   vector<optional<worker_object>> result;
+   const auto& workers_idx = _db.get_index_type<worker_index>().indices().get<by_account>();
 
-    for( const auto& w : workers_idx )
+   const account_id_type account = get_account_from_string(account_id_or_name)->id; // ask this, maybe not safe
+   for( const auto& w : workers_idx )
     {
         if( w.worker_account == account )
             result.push_back( w );

--- a/libraries/app/include/graphene/app/api.hpp
+++ b/libraries/app/include/graphene/app/api.hpp
@@ -120,40 +120,40 @@ namespace graphene { namespace app {
 
          /**
           * @brief Get operations relevant to the specificed account
-          * @param account The account whose history should be queried
+          * @param account_id_or_name The account ID or name whose history should be queried
           * @param stop ID of the earliest operation to retrieve
           * @param limit Maximum number of operations to retrieve (must not exceed 100)
           * @param start ID of the most recent operation to retrieve
           * @return A list of operations performed by account, ordered from most recent to oldest.
           */
-         vector<operation_history_object> get_account_history(account_id_type account,
+         vector<operation_history_object> get_account_history(const std::string account_id_or_name,
                                                               operation_history_id_type stop = operation_history_id_type(),
                                                               unsigned limit = 100,
                                                               operation_history_id_type start = operation_history_id_type())const;
 
          /**
           * @brief Get operations relevant to the specified account filtering by operation type
-          * @param account The account whose history should be queried
+          * @param account_id_or_name The account ID or name whose history should be queried
           * @param operation_types The IDs of the operation we want to get operations in the account( 0 = transfer , 1 = limit order create, ...)
           * @param start the sequence number where to start looping back throw the history
           * @param limit the max number of entries to return (from start number)
           * @return history_operation_detail
           */
-          history_operation_detail get_account_history_by_operations(account_id_type account,
+          history_operation_detail get_account_history_by_operations(const std::string account_id_or_name,
                                                                      vector<uint16_t> operation_types,
                                                                      uint32_t start,
                                                                      unsigned limit);
 
          /**
           * @brief Get only asked operations relevant to the specified account
-          * @param account The account whose history should be queried
+          * @param account_id_or_name The account ID or name whose history should be queried
           * @param operation_id The ID of the operation we want to get operations in the account( 0 = transfer , 1 = limit order create, ...)
           * @param stop ID of the earliest operation to retrieve
           * @param limit Maximum number of operations to retrieve (must not exceed 100)
           * @param start ID of the most recent operation to retrieve
           * @return A list of operations performed by account, ordered from most recent to oldest.
           */
-         vector<operation_history_object> get_account_history_operations(account_id_type account,
+         vector<operation_history_object> get_account_history_operations(const std::string account_id_or_name,
                                                                          int operation_id,
                                                                          operation_history_id_type start = operation_history_id_type(),
                                                                          operation_history_id_type stop = operation_history_id_type(),
@@ -163,7 +163,7 @@ namespace graphene { namespace app {
           * @breif Get operations relevant to the specified account referenced
           * by an event numbering specific to the account. The current number of operations
           * for the account can be found in the account statistics (or use 0 for start).
-          * @param account The account whose history should be queried
+          * @param account_id_or_name The account ID or name whose history should be queried
           * @param stop Sequence number of earliest operation. 0 is default and will
           * query 'limit' number of operations.
           * @param limit Maximum number of operations to retrieve (must not exceed 100)
@@ -171,7 +171,7 @@ namespace graphene { namespace app {
           * 0 is default, which will start querying from the most recent operation.
           * @return A list of operations performed by account, ordered from most recent to oldest.
           */
-         vector<operation_history_object> get_relative_account_history( account_id_type account,
+         vector<operation_history_object> get_relative_account_history( const std::string account_id_or_name,
                                                                         uint32_t stop = 0,
                                                                         unsigned limit = 100,
                                                                         uint32_t start = 0) const;

--- a/libraries/app/include/graphene/app/api.hpp
+++ b/libraries/app/include/graphene/app/api.hpp
@@ -116,9 +116,10 @@ namespace graphene { namespace app {
    class history_api
    {
       public:
-         history_api(application& app):_app(app){}
+         history_api(application& app)
+               :_app(app), database_api( std::ref(*app.chain_database()), &(app.get_options())) {}
 
-         /**
+      /**
           * @brief Get operations relevant to the specificed account
           * @param account_id_or_name The account ID or name whose history should be queried
           * @param stop ID of the earliest operation to retrieve
@@ -182,6 +183,7 @@ namespace graphene { namespace app {
          flat_set<uint32_t> get_market_history_buckets()const;
       private:
            application& _app;
+           graphene::app::database_api database_api;
    };
 
    /**

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -531,10 +531,10 @@ class database_api
 
       /**
        * @brief Get the committee_member owned by a given account
-       * @param account The ID of the account whose committee_member should be retrieved
+       * @param account The ID or name of the account whose committee_member should be retrieved
        * @return The committee_member object, or null if the account does not have a committee_member
        */
-      fc::optional<committee_member_object> get_committee_member_by_account(account_id_type account)const;
+      fc::optional<committee_member_object> get_committee_member_by_account(const std::string account_id_or_name)const;
 
       /**
        * @brief Get names and IDs for registered committee_members

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -259,6 +259,14 @@ class database_api
       // Accounts //
       //////////////
 
+     /**
+      * @brief Get account object from a name or ID
+      * @param account_name_or_id ID or name of the accounts
+      * @return Account ID
+      *
+      */
+      account_id_type get_account_id_from_string(const std::string& name_or_id) const;
+
       /**
        * @brief Get a list of accounts by ID
        * @param account_names_or_ids IDs or names of the accounts to retrieve
@@ -713,6 +721,7 @@ FC_API(graphene::app::database_api,
    (is_public_key_registered)
 
    // Accounts
+   (get_account_id_from_string)
    (get_accounts)
    (get_full_accounts)
    (get_account_by_name)

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -286,7 +286,7 @@ class database_api
       /**
        *  @return all accounts that referr to the key or account id in their owner or active authorities.
        */
-      vector<account_id_type> get_account_references( std::string account_id_or_name )const;
+      vector<account_id_type> get_account_references( const std::string account_id_or_name )const;
 
       /**
        * @brief Get a list of accounts by name
@@ -325,7 +325,7 @@ class database_api
 
       vector<asset> get_vested_balances( const vector<balance_id_type>& objs )const;
 
-      vector<vesting_balance_object> get_vesting_balances( std::string account_id_or_name )const;
+      vector<vesting_balance_object> get_vesting_balances( const std::string account_id_or_name )const;
 
       /**
        * @brief Get the total number of accounts registered with the blockchain
@@ -638,7 +638,7 @@ class database_api
       /**
        *  @return the set of proposed transactions relevant to the specified account id.
        */
-      vector<proposal_object> get_proposed_transactions( account_id_type id )const;
+      vector<proposal_object> get_proposed_transactions( const std::string account_id_or_name )const;
 
       //////////////////////
       // Blinded balances //

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -311,11 +311,11 @@ class database_api
 
       /**
        * @brief Get an account's balances in various assets
-       * @param name_or_id ID or name of the account to get balances for
+       * @param account_name_or_id ID or name of the account to get balances for
        * @param assets IDs of the assets to get balances of; if empty, get all assets account has a balance in
        * @return Balances of the account
        */
-      vector<asset> get_account_balances(const std::string& get_account_balances, const flat_set<asset_id_type>& assets)const;
+      vector<asset> get_account_balances(const std::string& account_name_or_id, const flat_set<asset_id_type>& assets)const;
 
       /// Semantically equivalent to @ref get_account_balances, but takes a name instead of an ID.
       vector<asset> get_named_account_balances(const std::string& name, const flat_set<asset_id_type>& assets)const;

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -261,12 +261,12 @@ class database_api
 
       /**
        * @brief Get a list of accounts by ID
-       * @param account_ids IDs of the accounts to retrieve
+       * @param account_names_or_ids IDs or names of the accounts to retrieve
        * @return The accounts corresponding to the provided IDs
        *
        * This function has semantics identical to @ref get_objects
        */
-      vector<optional<account_object>> get_accounts(const vector<account_id_type>& account_ids)const;
+      vector<optional<account_object>> get_accounts(const vector<std::string>& account_names_or_ids)const;
 
       /**
        * @brief Fetch all objects relevant to the specified accounts and subscribe to updates

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -286,7 +286,7 @@ class database_api
       /**
        *  @return all accounts that referr to the key or account id in their owner or active authorities.
        */
-      vector<account_id_type> get_account_references( account_id_type account_id )const;
+      vector<account_id_type> get_account_references( std::string account_id_or_name )const;
 
       /**
        * @brief Get a list of accounts by name

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -401,9 +401,9 @@ class database_api
       vector<collateral_bid_object> get_collateral_bids(const asset_id_type asset, uint32_t limit, uint32_t start)const;
 
       /**
-       *  @return all open margin positions for a given account id.
+       *  @return all open margin positions for a given account id or name.
        */
-      vector<call_order_object> get_margin_positions( const account_id_type& id )const;
+      vector<call_order_object> get_margin_positions( const std::string account_id_or_name )const;
 
       /**
        * @brief Request notification when the active orders in the market between two assets changes

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -563,10 +563,10 @@ class database_api
 
       /**
        * @brief Get the workers owned by a given account
-       * @param account The ID of the account whose worker should be retrieved
+       * @param account_id_or_name The ID or name of the account whose worker should be retrieved
        * @return The worker object, or null if the account does not have a worker
        */
-      vector<optional<worker_object>> get_workers_by_account(account_id_type account)const;
+      vector<optional<worker_object>> get_workers_by_account(const std::string account_id_or_name)const;
 
       /**
        * @brief Get the total number of workers registered with the blockchain

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -315,7 +315,7 @@ class database_api
        * @param assets IDs of the assets to get balances of; if empty, get all assets account has a balance in
        * @return Balances of the account
        */
-      vector<asset> get_account_balances(const std::string& get_account_balances, const flat_set<asset_id_type>& assets);
+      vector<asset> get_account_balances(const std::string& get_account_balances, const flat_set<asset_id_type>& assets)const;
 
       /// Semantically equivalent to @ref get_account_balances, but takes a name instead of an ID.
       vector<asset> get_named_account_balances(const std::string& name, const flat_set<asset_id_type>& assets)const;
@@ -618,7 +618,7 @@ class database_api
       /**
        * @return true if the signers have enough authority to authorize an account
        */
-      bool           verify_account_authority( const string& account_name_or_id, const flat_set<public_key_type>& signers );
+      bool           verify_account_authority( const string& account_name_or_id, const flat_set<public_key_type>& signers )const;
 
       /**
        *  Validates a transaction against the current state without broadcasting it on the network.

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -655,21 +655,21 @@ class database_api
 
       /**
        *  @brief Get non expired withdraw permission objects for a giver(ex:recurring customer)
-       *  @param account Account to get objects from
+       *  @param account Account ID or name to get objects from
        *  @param start Withdraw permission objects(1.12.X) before this ID will be skipped in results. Pagination purposes.
        *  @param limit Maximum number of objects to retrieve
        *  @return Withdraw permission objects for the account
        */
-      vector<withdraw_permission_object> get_withdraw_permissions_by_giver(account_id_type account, withdraw_permission_id_type start, uint32_t limit)const;
+      vector<withdraw_permission_object> get_withdraw_permissions_by_giver(const std::string account_id_or_name, withdraw_permission_id_type start, uint32_t limit)const;
 
       /**
        *  @brief Get non expired withdraw permission objects for a recipient(ex:service provider)
-       *  @param account Account to get objects from
+       *  @param account Account ID or name to get objects from
        *  @param start Withdraw permission objects(1.12.X) before this ID will be skipped in results. Pagination purposes.
        *  @param limit Maximum number of objects to retrieve
        *  @return Withdraw permission objects for the account
        */
-      vector<withdraw_permission_object> get_withdraw_permissions_by_recipient(account_id_type account, withdraw_permission_id_type start, uint32_t limit)const;
+      vector<withdraw_permission_object> get_withdraw_permissions_by_recipient(const std::string account_id_or_name, withdraw_permission_id_type start, uint32_t limit)const;
 
    private:
       std::shared_ptr< database_api_impl > my;

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -311,11 +311,11 @@ class database_api
 
       /**
        * @brief Get an account's balances in various assets
-       * @param id ID of the account to get balances for
+       * @param name_or_id ID or name of the account to get balances for
        * @param assets IDs of the assets to get balances of; if empty, get all assets account has a balance in
        * @return Balances of the account
        */
-      vector<asset> get_account_balances(account_id_type id, const flat_set<asset_id_type>& assets)const;
+      vector<asset> get_account_balances(const std::string& get_account_balances, const flat_set<asset_id_type>& assets);
 
       /// Semantically equivalent to @ref get_account_balances, but takes a name instead of an ID.
       vector<asset> get_named_account_balances(const std::string& name, const flat_set<asset_id_type>& assets)const;
@@ -618,7 +618,7 @@ class database_api
       /**
        * @return true if the signers have enough authority to authorize an account
        */
-      bool           verify_account_authority( const string& name_or_id, const flat_set<public_key_type>& signers )const;
+      bool           verify_account_authority( const string& account_name_or_id, const flat_set<public_key_type>& signers );
 
       /**
        *  Validates a transaction against the current state without broadcasting it on the network.

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -498,10 +498,10 @@ class database_api
 
       /**
        * @brief Get the witness owned by a given account
-       * @param account The ID of the account whose witness should be retrieved
+       * @param account_id_or_name The ID of the account whose witness should be retrieved
        * @return The witness object, or null if the account does not have a witness
        */
-      fc::optional<witness_object> get_witness_by_account(account_id_type account)const;
+      fc::optional<witness_object> get_witness_by_account(const std::string account_id_or_name)const;
 
       /**
        * @brief Get names and IDs for registered witnesses

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -325,7 +325,7 @@ class database_api
 
       vector<asset> get_vested_balances( const vector<balance_id_type>& objs )const;
 
-      vector<vesting_balance_object> get_vesting_balances( account_id_type account_id )const;
+      vector<vesting_balance_object> get_vesting_balances( std::string account_id_or_name )const;
 
       /**
        * @brief Get the total number of accounts registered with the blockchain

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -569,9 +569,18 @@ public:
    {
       return _remote_db->get_dynamic_global_properties();
    }
+   std::string account_id_to_string(account_id_type id) const
+   {
+      std::string account_id = fc::to_string(id.space_id)
+                               + "." + fc::to_string(id.type_id)
+                               + "." + fc::to_string(id.instance.value);
+      return account_id;
+   }
    account_object get_account(account_id_type id) const
    {
-      auto rec = _remote_db->get_accounts({id}).front();
+      std::string account_id = account_id_to_string(id);
+
+      auto rec = _remote_db->get_accounts({account_id}).front();
       FC_ASSERT(rec);
       return *rec;
    }
@@ -713,7 +722,7 @@ public:
             ("chain_id", _chain_id) );
 
       size_t account_pagination = 100;
-      vector< account_id_type > account_ids_to_send;
+      vector< std::string > account_ids_to_send;
       size_t n = _wallet.my_accounts.size();
       account_ids_to_send.reserve( std::min( account_pagination, n ) );
       auto it = _wallet.my_accounts.begin();
@@ -728,7 +737,8 @@ public:
          {
             assert( it != _wallet.my_accounts.end() );
             old_accounts.push_back( *it );
-            account_ids_to_send.push_back( old_accounts.back().id );
+            std::string account_id = account_id_to_string(old_accounts.back().id);
+            account_ids_to_send.push_back( account_id );
             ++it;
          }
          std::vector< optional< account_object > > accounts = _remote_db->get_accounts(account_ids_to_send);

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2816,9 +2816,7 @@ map<string,account_id_type> wallet_api::list_accounts(const string& lowerbound, 
 
 vector<asset> wallet_api::list_account_balances(const string& id)
 {
-   if( auto real_id = detail::maybe_id<account_id_type>(id) )
-      return my->_remote_db->get_account_balances(*real_id, flat_set<asset_id_type>());
-   return my->_remote_db->get_account_balances(get_account(id).id, flat_set<asset_id_type>());
+   return my->_remote_db->get_account_balances(id, flat_set<asset_id_type>());
 }
 
 vector<asset_object> wallet_api::list_assets(const string& lowerbound, uint32_t limit)const

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -336,7 +336,8 @@ private:
          for( const fc::optional<graphene::chain::account_object>& optional_account : owner_account_objects )
             if (optional_account)
             {
-               fc::optional<witness_object> witness_obj = _remote_db->get_witness_by_account(optional_account->id);
+               std::string account_id = account_id_to_string(optional_account->id);
+               fc::optional<witness_object> witness_obj = _remote_db->get_witness_by_account(account_id);
                if (witness_obj)
                   claim_registered_witness(optional_account->name);
             }
@@ -1421,7 +1422,7 @@ public:
             // then maybe it's the owner account
             try
             {
-               account_id_type owner_account_id = get_account_id(owner_account);
+               std::string owner_account_id = account_id_to_string(get_account_id(owner_account));
                fc::optional<witness_object> witness = _remote_db->get_witness_by_account(owner_account_id);
                if (witness)
                   return *witness;
@@ -1487,7 +1488,7 @@ public:
       witness_create_op.block_signing_key = witness_public_key;
       witness_create_op.url = url;
 
-      if (_remote_db->get_witness_by_account(witness_create_op.witness_account))
+      if (_remote_db->get_witness_by_account(account_id_to_string(witness_create_op.witness_account)))
          FC_THROW("Account ${owner_account} is already a witness", ("owner_account", owner_account));
 
       signed_transaction tx;
@@ -1650,7 +1651,7 @@ public:
          result.emplace_back( get_object<vesting_balance_object>(*vbid), now );
          return result;
       }
-         
+
       vector< vesting_balance_object > vbos = _remote_db->get_vesting_balances( account_name );
       if( vbos.size() == 0 )
          return result;
@@ -1733,7 +1734,8 @@ public:
                                         bool broadcast /* = false */)
    { try {
       account_object voting_account_object = get_account(voting_account);
-      account_id_type witness_owner_account_id = get_account_id(witness);
+      std::string witness_owner_account_id = account_id_to_string(get_account_id(witness));
+
       fc::optional<witness_object> witness_obj = _remote_db->get_witness_by_account(witness_owner_account_id);
       if (!witness_obj)
          FC_THROW("Account ${witness} is not registered as a witness", ("witness", witness));

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -1392,7 +1392,7 @@ public:
       committee_member_create_operation committee_member_create_op;
       committee_member_create_op.committee_member_account = get_account_id(owner_account);
       committee_member_create_op.url = url;
-      if (_remote_db->get_committee_member_by_account(committee_member_create_op.committee_member_account))
+      if (_remote_db->get_committee_member_by_account(owner_account))
          FC_THROW("Account ${owner_account} is already a committee_member", ("owner_account", owner_account));
 
       signed_transaction tx;
@@ -1457,8 +1457,7 @@ public:
             // then maybe it's the owner account
             try
             {
-               account_id_type owner_account_id = get_account_id(owner_account);
-               fc::optional<committee_member_object> committee_member = _remote_db->get_committee_member_by_account(owner_account_id);
+               fc::optional<committee_member_object> committee_member = _remote_db->get_committee_member_by_account(owner_account);
                if (committee_member)
                   return *committee_member;
                else
@@ -1700,8 +1699,7 @@ public:
                                         bool broadcast /* = false */)
    { try {
       account_object voting_account_object = get_account(voting_account);
-      account_id_type committee_member_owner_account_id = get_account_id(committee_member);
-      fc::optional<committee_member_object> committee_member_obj = _remote_db->get_committee_member_by_account(committee_member_owner_account_id);
+      fc::optional<committee_member_object> committee_member_obj = _remote_db->get_committee_member_by_account(committee_member);
       if (!committee_member_obj)
          FC_THROW("Account ${committee_member} is not registered as a committee_member", ("committee_member", committee_member));
       if (approve)
@@ -1734,9 +1732,8 @@ public:
                                         bool broadcast /* = false */)
    { try {
       account_object voting_account_object = get_account(voting_account);
-      std::string witness_owner_account_id = account_id_to_string(get_account_id(witness));
 
-      fc::optional<witness_object> witness_obj = _remote_db->get_witness_by_account(witness_owner_account_id);
+      fc::optional<witness_object> witness_obj = _remote_db->get_witness_by_account(voting_account);
       if (!witness_obj)
          FC_THROW("Account ${witness} is not registered as a witness", ("witness", witness));
       if (approve)

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -1650,13 +1650,8 @@ public:
          result.emplace_back( get_object<vesting_balance_object>(*vbid), now );
          return result;
       }
-
-      // try casting to avoid a round-trip if we were given an account ID
-      fc::optional<account_id_type> acct_id = maybe_id<account_id_type>( account_name );
-      if( !acct_id )
-         acct_id = get_account( account_name ).id;
-
-      vector< vesting_balance_object > vbos = _remote_db->get_vesting_balances( *acct_id );
+         
+      vector< vesting_balance_object > vbos = _remote_db->get_vesting_balances( account_name );
       if( vbos.size() == 0 )
          return result;
 

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2831,7 +2831,6 @@ vector<asset_object> wallet_api::list_assets(const string& lowerbound, uint32_t 
 vector<operation_detail> wallet_api::get_account_history(string name, int limit)const
 {
    vector<operation_detail> result;
-   auto account_id = get_account(name).get_id();
 
    while( limit > 0 )
    {
@@ -2843,7 +2842,7 @@ vector<operation_detail> wallet_api::get_account_history(string name, int limit)
       }
 
 
-      vector<operation_history_object> current = my->_remote_hist->get_account_history(account_id, operation_history_id_type(), std::min(100,limit), start);
+      vector<operation_history_object> current = my->_remote_hist->get_account_history(name, operation_history_id_type(), std::min(100,limit), start);
       for( auto& o : current ) {
          std::stringstream ss;
          auto memo = o.op.visit(detail::operation_printer(ss, *my, o.result));
@@ -2872,7 +2871,7 @@ vector<operation_detail> wallet_api::get_relative_account_history(string name, u
 
    while( limit > 0 )
    {
-      vector <operation_history_object> current = my->_remote_hist->get_relative_account_history(account_id, stop, std::min<uint32_t>(100, limit), start);
+      vector <operation_history_object> current = my->_remote_hist->get_relative_account_history(name, stop, std::min<uint32_t>(100, limit), start);
       for (auto &o : current) {
          std::stringstream ss;
          auto memo = o.op.visit(detail::operation_printer(ss, *my, o.result));
@@ -2905,7 +2904,7 @@ account_history_operation_detail wallet_api::get_account_history_by_operations(s
 
     while (limit > 0 && start <= stats.total_ops) {
         uint32_t min_limit = std::min<uint32_t> (100, limit);
-        auto current = my->_remote_hist->get_account_history_by_operations(account_id, operation_types, start, min_limit);
+        auto current = my->_remote_hist->get_account_history_by_operations(name, operation_types, start, min_limit);
         for (auto& obj : current.operation_history_objs) {
             std::stringstream ss;
             auto memo = obj.op.visit(detail::operation_printer(ss, *my, obj.result));

--- a/tests/tests/history_api_tests.cpp
+++ b/tests/tests/history_api_tests.cpp
@@ -102,9 +102,7 @@ BOOST_AUTO_TEST_CASE(get_account_history_additional) {
       BOOST_CHECK_EQUAL(histories.size(), 1);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 0);
 
-
       const account_object& dan = create_account("dan"); // create op 1
-      auto dan_id = dan.id;
 
       create_bitasset("CNY", dan.id); // create op 2
       create_bitasset("BTC", account_id_type()); // create op 3
@@ -374,8 +372,7 @@ BOOST_AUTO_TEST_CASE(get_account_history_additional) {
       BOOST_CHECK_EQUAL(histories.size(), 0);
 
       // create a new account C = alice { 7 }
-      const account_object& alice = create_account("alice");
-      auto alice_id = alice.id;
+      create_account("alice");
 
       generate_block();
 
@@ -411,8 +408,7 @@ BOOST_AUTO_TEST_CASE(track_account) {
       // account_id_type() is not tracked
 
       // account_id_type() creates alice(not tracked account)
-      const account_object& alice = create_account("alice");
-      auto alice_id = alice.id;
+      create_account("alice");
 
       //account_id_type() creates some ops
       create_bitasset("CNY", account_id_type());
@@ -497,8 +493,7 @@ BOOST_AUTO_TEST_CASE(track_account2) {
       create_bitasset("EUR", alice_id);
 
       // account_id_type() creates dan(account not tracked)
-      const account_object& dan = create_account("dan");
-      auto dan_id = dan.id;
+      create_account("dan");
 
       generate_block();
 
@@ -527,11 +522,11 @@ BOOST_AUTO_TEST_CASE(track_account2) {
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 3);
 
       // anything against dan should be {}
-      histories = hist_api.get_account_history("alice", operation_history_id_type(0), 10, operation_history_id_type(0));
+      histories = hist_api.get_account_history("dan", operation_history_id_type(0), 10, operation_history_id_type(0));
       BOOST_CHECK_EQUAL(histories.size(), 0);
-      histories = hist_api.get_account_history("alice", operation_history_id_type(1), 10, operation_history_id_type(0));
+      histories = hist_api.get_account_history("dan", operation_history_id_type(1), 10, operation_history_id_type(0));
       BOOST_CHECK_EQUAL(histories.size(), 0);
-      histories = hist_api.get_account_history("alice", operation_history_id_type(1), 1, operation_history_id_type(2));
+      histories = hist_api.get_account_history("dan", operation_history_id_type(1), 1, operation_history_id_type(2));
       BOOST_CHECK_EQUAL(histories.size(), 0);
 
    } catch (fc::exception &e) {

--- a/tests/tests/history_api_tests.cpp
+++ b/tests/tests/history_api_tests.cpp
@@ -46,6 +46,7 @@ BOOST_AUTO_TEST_CASE(get_account_history) {
       create_account("dan");
       create_account("bob");
 
+
       generate_block();
       fc::usleep(fc::milliseconds(2000));
 
@@ -53,26 +54,26 @@ BOOST_AUTO_TEST_CASE(get_account_history) {
       int account_create_op_id = operation::tag<account_create_operation>::value;
 
       //account_id_type() did 3 ops and includes id0
-      vector<operation_history_object> histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(), 100, operation_history_id_type());
+      vector<operation_history_object> histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 100, operation_history_id_type());
 
       BOOST_CHECK_EQUAL(histories.size(), 3);
       BOOST_CHECK_EQUAL(histories[2].id.instance(), 0);
       BOOST_CHECK_EQUAL(histories[2].op.which(), asset_create_op_id);
 
       // 1 account_create op larger than id1
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(1), 100, operation_history_id_type());
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(1), 100, operation_history_id_type());
       BOOST_CHECK_EQUAL(histories.size(), 1);
       BOOST_CHECK(histories[0].id.instance() != 0);
       BOOST_CHECK_EQUAL(histories[0].op.which(), account_create_op_id);
 
 
       // Limit 2 returns 2 result
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(), 2, operation_history_id_type());
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 2, operation_history_id_type());
       BOOST_CHECK_EQUAL(histories.size(), 2);
       BOOST_CHECK(histories[1].id.instance() != 0);
       BOOST_CHECK_EQUAL(histories[1].op.which(), account_create_op_id);
       // bob has 1 op
-      histories = hist_api.get_account_history(get_account("bob").id, operation_history_id_type(), 100, operation_history_id_type());
+      histories = hist_api.get_account_history("bob", operation_history_id_type(), 100, operation_history_id_type());
       BOOST_CHECK_EQUAL(histories.size(), 1);
       BOOST_CHECK_EQUAL(histories[0].op.which(), account_create_op_id);
 
@@ -91,13 +92,13 @@ BOOST_AUTO_TEST_CASE(get_account_history_additional) {
       // account_id_type() and dan share operation id 1(account create) - share can be also in id 0
 
       // no history at all in the chain
-      vector<operation_history_object> histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(0), 4, operation_history_id_type(0));
+      vector<operation_history_object> histories = hist_api.get_account_history("1.2.0", operation_history_id_type(0), 4, operation_history_id_type(0));
       BOOST_CHECK_EQUAL(histories.size(), 0);
 
       create_bitasset("USD", account_id_type()); // create op 0
       generate_block();
       // what if the account only has one history entry and it is 0?
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(), 4, operation_history_id_type());
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 4, operation_history_id_type());
       BOOST_CHECK_EQUAL(histories.size(), 1);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 0);
 
@@ -114,7 +115,7 @@ BOOST_AUTO_TEST_CASE(get_account_history_additional) {
       generate_block();
 
       // f(A, 0, 4, 9) = { 5, 3, 1, 0 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(), 4, operation_history_id_type(9));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 4, operation_history_id_type(9));
       BOOST_CHECK_EQUAL(histories.size(), 4);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
@@ -122,7 +123,7 @@ BOOST_AUTO_TEST_CASE(get_account_history_additional) {
       BOOST_CHECK_EQUAL(histories[3].id.instance(), 0);
 
       // f(A, 0, 4, 6) = { 5, 3, 1, 0 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(), 4, operation_history_id_type(6));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 4, operation_history_id_type(6));
       BOOST_CHECK_EQUAL(histories.size(), 4);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
@@ -130,7 +131,7 @@ BOOST_AUTO_TEST_CASE(get_account_history_additional) {
       BOOST_CHECK_EQUAL(histories[3].id.instance(), 0);
 
       // f(A, 0, 4, 5) = { 5, 3, 1, 0 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(), 4, operation_history_id_type(5));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 4, operation_history_id_type(5));
       BOOST_CHECK_EQUAL(histories.size(), 4);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
@@ -138,33 +139,33 @@ BOOST_AUTO_TEST_CASE(get_account_history_additional) {
       BOOST_CHECK_EQUAL(histories[3].id.instance(), 0);
 
       // f(A, 0, 4, 4) = { 3, 1, 0 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(), 4, operation_history_id_type(4));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 4, operation_history_id_type(4));
       BOOST_CHECK_EQUAL(histories.size(), 3);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 3);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 1);
       BOOST_CHECK_EQUAL(histories[2].id.instance(), 0);
 
       // f(A, 0, 4, 3) = { 3, 1, 0 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(), 4, operation_history_id_type(3));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 4, operation_history_id_type(3));
       BOOST_CHECK_EQUAL(histories.size(), 3);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 3);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 1);
       BOOST_CHECK_EQUAL(histories[2].id.instance(), 0);
 
       // f(A, 0, 4, 2) = { 1, 0 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(), 4, operation_history_id_type(2));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 4, operation_history_id_type(2));
       BOOST_CHECK_EQUAL(histories.size(), 2);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 1);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 0);
 
       // f(A, 0, 4, 1) = { 1, 0 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(), 4, operation_history_id_type(1));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 4, operation_history_id_type(1));
       BOOST_CHECK_EQUAL(histories.size(), 2);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 1);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 0);
 
       // f(A, 0, 4, 0) = { 5, 3, 1, 0 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(), 4, operation_history_id_type());
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 4, operation_history_id_type());
       BOOST_CHECK_EQUAL(histories.size(), 4);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
@@ -172,103 +173,103 @@ BOOST_AUTO_TEST_CASE(get_account_history_additional) {
       BOOST_CHECK_EQUAL(histories[3].id.instance(), 0);
 
       // f(A, 1, 5, 9) = { 5, 3 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(1), 5, operation_history_id_type(9));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(1), 5, operation_history_id_type(9));
       BOOST_CHECK_EQUAL(histories.size(), 2);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
 
       // f(A, 1, 5, 6) = { 5, 3 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(1), 5, operation_history_id_type(6));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(1), 5, operation_history_id_type(6));
       BOOST_CHECK_EQUAL(histories.size(), 2);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
 
       // f(A, 1, 5, 5) = { 5, 3 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(1), 5, operation_history_id_type(5));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(1), 5, operation_history_id_type(5));
       BOOST_CHECK_EQUAL(histories.size(), 2);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
 
       // f(A, 1, 5, 4) = { 3 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(1), 5, operation_history_id_type(4));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(1), 5, operation_history_id_type(4));
       BOOST_CHECK_EQUAL(histories.size(), 1);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 3);
 
       // f(A, 1, 5, 3) = { 3 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(1), 5, operation_history_id_type(3));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(1), 5, operation_history_id_type(3));
       BOOST_CHECK_EQUAL(histories.size(), 1);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 3);
 
       // f(A, 1, 5, 2) = { }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(1), 5, operation_history_id_type(2));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(1), 5, operation_history_id_type(2));
       BOOST_CHECK_EQUAL(histories.size(), 0);
 
       // f(A, 1, 5, 1) = { }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(1), 5, operation_history_id_type(1));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(1), 5, operation_history_id_type(1));
       BOOST_CHECK_EQUAL(histories.size(), 0);
 
       // f(A, 1, 5, 0) = { 5, 3 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(1), 5, operation_history_id_type(0));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(1), 5, operation_history_id_type(0));
       BOOST_CHECK_EQUAL(histories.size(), 2);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
 
       // f(A, 0, 3, 9) = { 5, 3, 1 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(), 3, operation_history_id_type(9));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 3, operation_history_id_type(9));
       BOOST_CHECK_EQUAL(histories.size(), 3);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
       BOOST_CHECK_EQUAL(histories[2].id.instance(), 1);
 
       // f(A, 0, 3, 6) = { 5, 3, 1 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(), 3, operation_history_id_type(6));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 3, operation_history_id_type(6));
       BOOST_CHECK_EQUAL(histories.size(), 3);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
       BOOST_CHECK_EQUAL(histories[2].id.instance(), 1);
 
       // f(A, 0, 3, 5) = { 5, 3, 1 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(), 3, operation_history_id_type(5));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 3, operation_history_id_type(5));
       BOOST_CHECK_EQUAL(histories.size(), 3);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
       BOOST_CHECK_EQUAL(histories[2].id.instance(), 1);
 
       // f(A, 0, 3, 4) = { 3, 1, 0 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(), 3, operation_history_id_type(4));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 3, operation_history_id_type(4));
       BOOST_CHECK_EQUAL(histories.size(), 3);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 3);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 1);
       BOOST_CHECK_EQUAL(histories[2].id.instance(), 0);
 
       // f(A, 0, 3, 3) = { 3, 1, 0 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(), 3, operation_history_id_type(3));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 3, operation_history_id_type(3));
       BOOST_CHECK_EQUAL(histories.size(), 3);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 3);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 1);
       BOOST_CHECK_EQUAL(histories[2].id.instance(), 0);
 
       // f(A, 0, 3, 2) = { 1, 0 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(), 3, operation_history_id_type(2));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 3, operation_history_id_type(2));
       BOOST_CHECK_EQUAL(histories.size(), 2);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 1);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 0);
 
       // f(A, 0, 3, 1) = { 1, 0 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(), 3, operation_history_id_type(1));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 3, operation_history_id_type(1));
       BOOST_CHECK_EQUAL(histories.size(), 2);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 1);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 0);
 
       // f(A, 0, 3, 0) = { 5, 3, 1 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(), 3, operation_history_id_type());
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 3, operation_history_id_type());
       BOOST_CHECK_EQUAL(histories.size(), 3);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
       BOOST_CHECK_EQUAL(histories[2].id.instance(), 1);
 
       // f(B, 0, 4, 9) = { 6, 4, 2, 1 }
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(), 4, operation_history_id_type(9));
+      histories = hist_api.get_account_history("dan", operation_history_id_type(), 4, operation_history_id_type(9));
       BOOST_CHECK_EQUAL(histories.size(), 4);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 6);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 4);
@@ -276,7 +277,7 @@ BOOST_AUTO_TEST_CASE(get_account_history_additional) {
       BOOST_CHECK_EQUAL(histories[3].id.instance(), 1);
 
       // f(B, 0, 4, 6) = { 6, 4, 2, 1 }
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(), 4, operation_history_id_type(6));
+      histories = hist_api.get_account_history("dan", operation_history_id_type(), 4, operation_history_id_type(6));
       BOOST_CHECK_EQUAL(histories.size(), 4);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 6);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 4);
@@ -284,38 +285,38 @@ BOOST_AUTO_TEST_CASE(get_account_history_additional) {
       BOOST_CHECK_EQUAL(histories[3].id.instance(), 1);
 
       // f(B, 0, 4, 5) = { 4, 2, 1 }
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(), 4, operation_history_id_type(5));
+      histories = hist_api.get_account_history("dan", operation_history_id_type(), 4, operation_history_id_type(5));
       BOOST_CHECK_EQUAL(histories.size(), 3);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 4);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 2);
       BOOST_CHECK_EQUAL(histories[2].id.instance(), 1);
 
       // f(B, 0, 4, 4) = { 4, 2, 1 }
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(), 4, operation_history_id_type(4));
+      histories = hist_api.get_account_history("dan", operation_history_id_type(), 4, operation_history_id_type(4));
       BOOST_CHECK_EQUAL(histories.size(), 3);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 4);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 2);
       BOOST_CHECK_EQUAL(histories[2].id.instance(), 1);
 
       // f(B, 0, 4, 3) = { 2, 1 }
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(), 4, operation_history_id_type(3));
+      histories = hist_api.get_account_history("dan", operation_history_id_type(), 4, operation_history_id_type(3));
       BOOST_CHECK_EQUAL(histories.size(), 2);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 2);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 1);
 
       // f(B, 0, 4, 2) = { 2, 1 }
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(), 4, operation_history_id_type(2));
+      histories = hist_api.get_account_history("dan", operation_history_id_type(), 4, operation_history_id_type(2));
       BOOST_CHECK_EQUAL(histories.size(), 2);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 2);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 1);
 
       // f(B, 0, 4, 1) = { 1 }
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(), 4, operation_history_id_type(1));
+      histories = hist_api.get_account_history("dan", operation_history_id_type(), 4, operation_history_id_type(1));
       BOOST_CHECK_EQUAL(histories.size(), 1);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 1);
 
       // f(B, 0, 4, 0) = { 6, 4, 2, 1 }
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(), 4, operation_history_id_type());
+      histories = hist_api.get_account_history("dan", operation_history_id_type(), 4, operation_history_id_type());
       BOOST_CHECK_EQUAL(histories.size(), 4);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 6);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 4);
@@ -323,53 +324,53 @@ BOOST_AUTO_TEST_CASE(get_account_history_additional) {
       BOOST_CHECK_EQUAL(histories[3].id.instance(), 1);
 
       // f(B, 2, 4, 9) = { 6, 4 }
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(2), 4, operation_history_id_type(9));
+      histories = hist_api.get_account_history("dan", operation_history_id_type(2), 4, operation_history_id_type(9));
       BOOST_CHECK_EQUAL(histories.size(), 2);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 6);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 4);
 
       // f(B, 2, 4, 6) = { 6, 4 }
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(2), 4, operation_history_id_type(6));
+      histories = hist_api.get_account_history("dan", operation_history_id_type(2), 4, operation_history_id_type(6));
       BOOST_CHECK_EQUAL(histories.size(), 2);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 6);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 4);
 
       // f(B, 2, 4, 5) = { 4 }
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(2), 4, operation_history_id_type(5));
+      histories = hist_api.get_account_history("dan", operation_history_id_type(2), 4, operation_history_id_type(5));
       BOOST_CHECK_EQUAL(histories.size(), 1);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 4);
 
       // f(B, 2, 4, 4) = { 4 }
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(2), 4, operation_history_id_type(4));
+      histories = hist_api.get_account_history("dan", operation_history_id_type(2), 4, operation_history_id_type(4));
       BOOST_CHECK_EQUAL(histories.size(), 1);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 4);
 
       // f(B, 2, 4, 3) = { }
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(2), 4, operation_history_id_type(3));
+      histories = hist_api.get_account_history("dan", operation_history_id_type(2), 4, operation_history_id_type(3));
       BOOST_CHECK_EQUAL(histories.size(), 0);
 
       // f(B, 2, 4, 2) = { }
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(2), 4, operation_history_id_type(2));
+      histories = hist_api.get_account_history("dan", operation_history_id_type(2), 4, operation_history_id_type(2));
       BOOST_CHECK_EQUAL(histories.size(), 0);
 
       // f(B, 2, 4, 1) = { }
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(2), 4, operation_history_id_type(1));
+      histories = hist_api.get_account_history("dan", operation_history_id_type(2), 4, operation_history_id_type(1));
       BOOST_CHECK_EQUAL(histories.size(), 0);
 
       // f(B, 2, 4, 0) = { 6, 4 }
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(2), 4, operation_history_id_type(0));
+      histories = hist_api.get_account_history("dan", operation_history_id_type(2), 4, operation_history_id_type(0));
       BOOST_CHECK_EQUAL(histories.size(), 2);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 6);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 4);
 
       // 0 limits
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(0), 0, operation_history_id_type(0));
+      histories = hist_api.get_account_history("dan", operation_history_id_type(0), 0, operation_history_id_type(0));
       BOOST_CHECK_EQUAL(histories.size(), 0);
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(3), 0, operation_history_id_type(9));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(3), 0, operation_history_id_type(9));
       BOOST_CHECK_EQUAL(histories.size(), 0);
 
       // non existent account
-      histories = hist_api.get_account_history(account_id_type(18), operation_history_id_type(0), 4, operation_history_id_type(0));
+      histories = hist_api.get_account_history("1.2.18", operation_history_id_type(0), 4, operation_history_id_type(0));
       BOOST_CHECK_EQUAL(histories.size(), 0);
 
       // create a new account C = alice { 7 }
@@ -379,16 +380,16 @@ BOOST_AUTO_TEST_CASE(get_account_history_additional) {
       generate_block();
 
       // f(C, 0, 4, 10) = { 7 }
-      histories = hist_api.get_account_history(alice_id, operation_history_id_type(0), 4, operation_history_id_type(10));
+      histories = hist_api.get_account_history("alice", operation_history_id_type(0), 4, operation_history_id_type(10));
       BOOST_CHECK_EQUAL(histories.size(), 1);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 7);
 
       // f(C, 8, 4, 10) = { }
-      histories = hist_api.get_account_history(alice_id, operation_history_id_type(8), 4, operation_history_id_type(10));
+      histories = hist_api.get_account_history("alice", operation_history_id_type(8), 4, operation_history_id_type(10));
       BOOST_CHECK_EQUAL(histories.size(), 0);
 
       // f(A, 0, 10, 0) = { 7, 5, 3, 1, 0 }
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(0), 10, operation_history_id_type(0));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(0), 10, operation_history_id_type(0));
       BOOST_CHECK_EQUAL(histories.size(), 5);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 7);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 5);
@@ -427,23 +428,23 @@ BOOST_AUTO_TEST_CASE(track_account) {
       generate_block( ~database::skip_fork_db );
 
       // anything against account_id_type() should be {}
-      vector<operation_history_object> histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(0), 10, operation_history_id_type(0));
+      vector<operation_history_object> histories = hist_api.get_account_history("1.2.0", operation_history_id_type(0), 10, operation_history_id_type(0));
       BOOST_CHECK_EQUAL(histories.size(), 0);
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(1), 10, operation_history_id_type(0));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(1), 10, operation_history_id_type(0));
       BOOST_CHECK_EQUAL(histories.size(), 0);
-      histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(1), 1, operation_history_id_type(2));
+      histories = hist_api.get_account_history("1.2.0", operation_history_id_type(1), 1, operation_history_id_type(2));
       BOOST_CHECK_EQUAL(histories.size(), 0);
 
       // anything against alice should be {}
-      histories = hist_api.get_account_history(alice_id, operation_history_id_type(0), 10, operation_history_id_type(0));
+      histories = hist_api.get_account_history("alice", operation_history_id_type(0), 10, operation_history_id_type(0));
       BOOST_CHECK_EQUAL(histories.size(), 0);
-      histories = hist_api.get_account_history(alice_id, operation_history_id_type(1), 10, operation_history_id_type(0));
+      histories = hist_api.get_account_history("alice", operation_history_id_type(1), 10, operation_history_id_type(0));
       BOOST_CHECK_EQUAL(histories.size(), 0);
-      histories = hist_api.get_account_history(alice_id, operation_history_id_type(1), 1, operation_history_id_type(2));
+      histories = hist_api.get_account_history("alice", operation_history_id_type(1), 1, operation_history_id_type(2));
       BOOST_CHECK_EQUAL(histories.size(), 0);
 
       // dan should have history
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(0), 10, operation_history_id_type(0));
+      histories = hist_api.get_account_history("dan", operation_history_id_type(0), 10, operation_history_id_type(0));
       BOOST_CHECK_EQUAL(histories.size(), 2);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 4);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
@@ -454,7 +455,7 @@ BOOST_AUTO_TEST_CASE(track_account) {
 
       generate_block( ~database::skip_fork_db );
 
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(0), 10, operation_history_id_type(0));
+      histories = hist_api.get_account_history("dan", operation_history_id_type(0), 10, operation_history_id_type(0));
       BOOST_CHECK_EQUAL(histories.size(), 3);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 6);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 4);
@@ -468,7 +469,7 @@ BOOST_AUTO_TEST_CASE(track_account) {
 
       generate_block();
 
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(0), 10, operation_history_id_type(0));
+      histories = hist_api.get_account_history("dan", operation_history_id_type(0), 10, operation_history_id_type(0));
       BOOST_CHECK_EQUAL(histories.size(), 3);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 6);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 4);
@@ -502,7 +503,7 @@ BOOST_AUTO_TEST_CASE(track_account2) {
       generate_block();
 
       // all account_id_type() should have 4 ops {4,2,1,0}
-      vector<operation_history_object> histories = hist_api.get_account_history(account_id_type(), operation_history_id_type(0), 10, operation_history_id_type(0));
+      vector<operation_history_object> histories = hist_api.get_account_history("committee-account", operation_history_id_type(0), 10, operation_history_id_type(0));
       BOOST_CHECK_EQUAL(histories.size(), 4);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 4);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 2);
@@ -510,27 +511,27 @@ BOOST_AUTO_TEST_CASE(track_account2) {
       BOOST_CHECK_EQUAL(histories[3].id.instance(), 0);
 
       // all alice account should have 2 ops {3, 0}
-      histories = hist_api.get_account_history(alice_id, operation_history_id_type(0), 10, operation_history_id_type(0));
+      histories = hist_api.get_account_history("alice", operation_history_id_type(0), 10, operation_history_id_type(0));
       BOOST_CHECK_EQUAL(histories.size(), 2);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 3);
       BOOST_CHECK_EQUAL(histories[1].id.instance(), 0);
 
       // alice first op should be {0}
-      histories = hist_api.get_account_history(alice_id, operation_history_id_type(0), 1, operation_history_id_type(1));
+      histories = hist_api.get_account_history("alice", operation_history_id_type(0), 1, operation_history_id_type(1));
       BOOST_CHECK_EQUAL(histories.size(), 1);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 0);
 
       // alice second op should be {3}
-      histories = hist_api.get_account_history(alice_id, operation_history_id_type(1), 1, operation_history_id_type(0));
+      histories = hist_api.get_account_history("alice", operation_history_id_type(1), 1, operation_history_id_type(0));
       BOOST_CHECK_EQUAL(histories.size(), 1);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 3);
 
       // anything against dan should be {}
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(0), 10, operation_history_id_type(0));
+      histories = hist_api.get_account_history("alice", operation_history_id_type(0), 10, operation_history_id_type(0));
       BOOST_CHECK_EQUAL(histories.size(), 0);
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(1), 10, operation_history_id_type(0));
+      histories = hist_api.get_account_history("alice", operation_history_id_type(1), 10, operation_history_id_type(0));
       BOOST_CHECK_EQUAL(histories.size(), 0);
-      histories = hist_api.get_account_history(dan_id, operation_history_id_type(1), 1, operation_history_id_type(2));
+      histories = hist_api.get_account_history("alice", operation_history_id_type(1), 1, operation_history_id_type(2));
       BOOST_CHECK_EQUAL(histories.size(), 0);
 
    } catch (fc::exception &e) {
@@ -555,27 +556,27 @@ BOOST_AUTO_TEST_CASE(get_account_history_operations) {
       int account_create_op_id = operation::tag<account_create_operation>::value;
 
       //account_id_type() did 1 asset_create op
-      vector<operation_history_object> histories = hist_api.get_account_history_operations(account_id_type(), asset_create_op_id, operation_history_id_type(), operation_history_id_type(), 100);
+      vector<operation_history_object> histories = hist_api.get_account_history_operations("committee-account", asset_create_op_id, operation_history_id_type(), operation_history_id_type(), 100);
       BOOST_CHECK_EQUAL(histories.size(), 1);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 0);
       BOOST_CHECK_EQUAL(histories[0].op.which(), asset_create_op_id);
 
       //account_id_type() did 2 account_create ops
-      histories = hist_api.get_account_history_operations(account_id_type(), account_create_op_id, operation_history_id_type(), operation_history_id_type(), 100);
+      histories = hist_api.get_account_history_operations("committee-account", account_create_op_id, operation_history_id_type(), operation_history_id_type(), 100);
       BOOST_CHECK_EQUAL(histories.size(), 2);
       BOOST_CHECK_EQUAL(histories[0].op.which(), account_create_op_id);
 
       // No asset_create op larger than id1
-      histories = hist_api.get_account_history_operations(account_id_type(), asset_create_op_id, operation_history_id_type(), operation_history_id_type(1), 100);
+      histories = hist_api.get_account_history_operations("committee-account", asset_create_op_id, operation_history_id_type(), operation_history_id_type(1), 100);
       BOOST_CHECK_EQUAL(histories.size(), 0);
 
       // Limit 1 returns 1 result
-      histories = hist_api.get_account_history_operations(account_id_type(), account_create_op_id, operation_history_id_type(),operation_history_id_type(), 1);
+      histories = hist_api.get_account_history_operations("committee-account", account_create_op_id, operation_history_id_type(),operation_history_id_type(), 1);
       BOOST_CHECK_EQUAL(histories.size(), 1);
       BOOST_CHECK_EQUAL(histories[0].op.which(), account_create_op_id);
 
       // alice has 1 op
-      histories = hist_api.get_account_history_operations(get_account("alice").id, account_create_op_id, operation_history_id_type(),operation_history_id_type(), 100);
+      histories = hist_api.get_account_history_operations("alice", account_create_op_id, operation_history_id_type(),operation_history_id_type(), 100);
       BOOST_CHECK_EQUAL(histories.size(), 1);
       BOOST_CHECK_EQUAL(histories[0].op.which(), account_create_op_id);
 


### PR DESCRIPTION
The following is an initial work in https://github.com/bitshares/bitshares-core/issues/969 giving support of account by name to a few selected calls to discuss if it is the right approach or something else will be better.

In this approach, non exposed function `get_account_from_string` is created, the scope is only database_api.cpp file. Code for it is present(and duplicated) in several api calls like `verify_account_authority` or `get_full_accounts`. This duplicated code is what it is added to the new function.

Next, `verify_account_authority` was refactored to use the new created call and also `get_full_accounts`. Please note this 2 calls were already supporting account as a string.

Next, api call `get_account_balances` is changed to support account by name. In this change, the wallet is impacted so had to make changes there too.

There are actually a lot of calls that need to be changed just inside `database_api.cpp`, more in `api.cpp` and some require `wallet.cpp` changes so decided to submit pull now before going further as the approach can be wrong.

I will post a list of all the impacted apis in the issue soon.

Note: There is a similar issue with assets, it should be better to be able to use all api calls by asset_id or name, probably for another issue.
Note 2: A local cache will be a good idea for `get_account_from_string` as it will be called constantly, other suggestions to improve performance of it will be great.