### PR TITLE
Issue1013, New API: get transaction hex without `signatures` field

### DIFF
--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -138,6 +138,8 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
 
       // Authority / validation
       std::string get_transaction_hex(const signed_transaction& trx)const;
+      std::string get_transaction_hex_without_sig(const signed_transaction& trx)const;
+
       set<public_key_type> get_required_signatures( const signed_transaction& trx, const flat_set<public_key_type>& available_keys )const;
       set<public_key_type> get_potential_signatures( const signed_transaction& trx )const;
       set<address> get_potential_address_signatures( const signed_transaction& trx )const;
@@ -1825,6 +1827,18 @@ std::string database_api::get_transaction_hex(const signed_transaction& trx)cons
 std::string database_api_impl::get_transaction_hex(const signed_transaction& trx)const
 {
    return fc::to_hex(fc::raw::pack(trx));
+}
+
+std::string database_api::get_transaction_hex_without_sig(
+   const signed_transaction &trx) const
+{
+   return my->get_transaction_hex_without_sig(trx);
+}
+
+std::string database_api_impl::get_transaction_hex_without_sig(
+   const signed_transaction &trx) const
+{
+   return fc::to_hex(fc::raw::pack(static_cast<transaction>(trx)));
 }
 
 set<public_key_type> database_api::get_required_signatures( const signed_transaction& trx, const flat_set<public_key_type>& available_keys )const

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -598,8 +598,7 @@ class database_api
 
       /// @brief Get a hexdump of the serialized binary form of a
       /// signatures-stripped transaction
-      std::string
-      get_transaction_hex_without_sig(const signed_transaction &trx) const;
+      std::string get_transaction_hex_without_sig( const signed_transaction &trx ) const;
 
       /**
        *  This API will take a partially signed transaction and a set of public keys that the owner has the ability to sign for

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -596,6 +596,11 @@ class database_api
       /// @brief Get a hexdump of the serialized binary form of a transaction
       std::string get_transaction_hex(const signed_transaction& trx)const;
 
+      /// @brief Get a hexdump of the serialized binary form of a
+      /// signatures-stripped transaction
+      std::string
+      get_transaction_hex_without_sig(const signed_transaction &trx) const;
+
       /**
        *  This API will take a partially signed transaction and a set of public keys that the owner has the ability to sign for
        *  and return the minimal subset of public keys that should add signatures to the transaction.
@@ -770,6 +775,7 @@ FC_API(graphene::app::database_api,
 
    // Authority / validation
    (get_transaction_hex)
+   (get_transaction_hex_without_sig)
    (get_required_signatures)
    (get_potential_signatures)
    (get_potential_address_signatures)

--- a/tests/tests/database_api_tests.cpp
+++ b/tests/tests/database_api_tests.cpp
@@ -702,11 +702,19 @@ BOOST_AUTO_TEST_CASE( get_transaction_hex )
    trx.operations.push_back(make_account("testaccount", test_public));
    trx.validate();
 
-   std::string hex_str = fc::to_hex(fc::raw::pack(trx));
+   // case1: not signed, get hex
+   std::string hex_str = fc::to_hex( fc::raw::pack( trx ) );
 
-   BOOST_CHECK(db_api.get_transaction_hex(trx) == hex_str);
-   BOOST_CHECK(db_api.get_transaction_hex_without_sig(trx) + "00" == hex_str);
+   BOOST_CHECK( db_api.get_transaction_hex( trx ) == hex_str );
+   BOOST_CHECK( db_api.get_transaction_hex_without_sig( trx ) + "00" == hex_str );
 
+   // case2: signed, get hex
+   sign( trx, test_private_key );
+   hex_str = fc::to_hex( fc::raw::pack( trx ) );
+
+   BOOST_CHECK( db_api.get_transaction_hex( trx ) == hex_str );
+   BOOST_CHECK( db_api.get_transaction_hex_without_sig( trx ) +
+                   fc::to_hex( fc::raw::pack( trx.signatures ) ) == hex_str );
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/tests/database_api_tests.cpp
+++ b/tests/tests/database_api_tests.cpp
@@ -28,6 +28,7 @@
 
 #include <fc/crypto/digest.hpp>
 
+#include <fc/crypto/hex.hpp>
 #include "../common/database_fixture.hpp"
 
 using namespace graphene::chain;
@@ -689,6 +690,22 @@ BOOST_AUTO_TEST_CASE( lookup_vote_ids )
    votes.push_back( worker.vote_for );
 
    const auto results = db_api.lookup_vote_ids( votes );
+
+} FC_LOG_AND_RETHROW() }
+
+BOOST_AUTO_TEST_CASE( get_transaction_hex )
+{ try {
+   graphene::app::database_api db_api(db);
+   auto test_private_key = generate_private_key("testaccount");
+   public_key_type test_public = test_private_key.get_public_key();
+
+   trx.operations.push_back(make_account("testaccount", test_public));
+   trx.validate();
+
+   std::string hex_str = fc::to_hex(fc::raw::pack(trx));
+
+   BOOST_CHECK(db_api.get_transaction_hex(trx) == hex_str);
+   BOOST_CHECK(db_api.get_transaction_hex_without_sig(trx) + "00" == hex_str);
 
 } FC_LOG_AND_RETHROW() }
 


### PR DESCRIPTION
fix #1013 