### PR TITLE
Cherry pick docs change from master to develop

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Bitshares-Core"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "2.0.180425"
+PROJECT_NUMBER         = "2.0.180612"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Bitshares-Core"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "2.0.180202"
+PROJECT_NUMBER         = "2.0.180425"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ To build after all dependencies are installed:
 
 **NOTE:** BitShares requires an [OpenSSL](https://www.openssl.org/) version in the 1.0.x series. OpenSSL 1.1.0 and newer are NOT supported. If your system OpenSSL version is newer, then you will need to manually provide an older version of OpenSSL and specify it to CMake using `-DOPENSSL_INCLUDE_DIR`, `-DOPENSSL_SSL_LIBRARY`, and `-DOPENSSL_CRYPTO_LIBRARY`.
 
-**NOTE:** BitShares requires a [Boost](http://www.boost.org/) version in the range [1.57, 1.63]. Versions earlier than
-1.57 or newer than 1.63 are NOT supported. If your system Boost version is newer, then you will need to manually build
+**NOTE:** BitShares requires a [Boost](http://www.boost.org/) version in the range [1.57, 1.65]. Versions earlier than
+1.57 or newer than 1.65 are NOT supported. If your system Boost version is newer, then you will need to manually build
 an older version of Boost and specify it to CMake using `DBOOST_ROOT`.
 
 After building, the witness node can be launched with:


### PR DESCRIPTION
Notes:
* there was a conflict on project description in `Doxyfile`, I resolved it by using the one in `develop` branch (`"BitShares blockchain implementation and command-line interface software"`)

  * if it's OK, it's best to update `master` branch (the description there is now `"The underlying software running the BitShares Blockchain"`) to avoid conflict when merging to `master` in the future.

* I didn't cherry-pick issue templates from master

Any idea?