### PR TITLE
optionally provide server information to api clients (Issue #626)

### DIFF
--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -29,6 +29,7 @@
 #include <graphene/app/impacted.hpp>
 #include <graphene/chain/database.hpp>
 #include <graphene/chain/get_config.hpp>
+#include <graphene/chain/config.hpp>
 #include <graphene/utilities/key_conversion.hpp>
 #include <graphene/chain/protocol/fee_schedule.hpp>
 #include <graphene/chain/confidential_object.hpp>
@@ -282,6 +283,11 @@ namespace graphene { namespace app {
     {
        FC_ASSERT(_debug_api);
        return *_debug_api;
+    }
+
+    fc::mutable_variant_object login_api::get_server_information()
+    {
+       return this->_app.get_server_information();
     }
 
     vector<order_history_object> history_api::get_fill_order_history( asset_id_type a, asset_id_type b, uint32_t limit  )const

--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -943,6 +943,8 @@ void application::set_program_options(boost::program_options::options_descriptio
          ("api-access", bpo::value<boost::filesystem::path>(), "JSON file specifying API permissions")
          ("plugins", bpo::value<string>(), "Space-separated list of plugins to activate")
          ("io-threads", bpo::value<uint16_t>()->implicit_value(0), "Number of IO threads, default to 0 for auto-configuration")
+         ("share-version-info", bpo::value<bool>()->implicit_value(false), "Share version information with API clients")
+         ("share-plugin-info", bpo::value<bool>()->implicit_value(false), "Share plugin information with API clients")
          // TODO uncomment this when GUI is ready
          //("enable-subscribe-to-all", bpo::value<bool>()->implicit_value(false),
          // "Whether allow API clients to subscribe to universal object creation and removal events")
@@ -1100,8 +1102,10 @@ std::vector<std::string> graphene::app::application::get_active_plugin_names()
 fc::mutable_variant_object graphene::app::application::get_server_information()
 {
    fc::mutable_variant_object ret_val;
+   const boost::program_options::variables_map& options = *(my->_options);
+
    // check parameters to see what we should return
-   if ( my->_options->count("share-plugin-info") )
+   if ( options.count("share-plugin-info") && options["share-plugin-info"].as<bool>() )
    {
       // get plugins and version
       std::vector<std::string> plugin_names = get_active_plugin_names();
@@ -1132,7 +1136,7 @@ fc::mutable_variant_object graphene::app::application::get_server_information()
       }
     }
 
-   if ( my->_options->count( "share-version-info" ) )
+   if ( options.count( "share-version-info" ) && options["share-version-info"].as<bool>() )
    {
       ret_val["server_version"] = graphene::utilities::git_revision_description;
       ret_val["server_sha_version"] = graphene::utilities::git_revision_sha;

--- a/libraries/app/include/graphene/app/api.hpp
+++ b/libraries/app/include/graphene/app/api.hpp
@@ -426,6 +426,12 @@ namespace graphene { namespace app {
 
          /// @brief Called to enable an API, not reflected.
          void enable_api( const string& api_name );
+
+         /***
+          * @brief retrieve server information
+          */
+         fc::mutable_variant_object get_server_information();
+
       private:
 
          application& _app;
@@ -513,4 +519,5 @@ FC_API(graphene::app::login_api,
        (asset)
        (orders)
        (debug)
+       (get_server_information)
      )

--- a/libraries/app/include/graphene/app/application.hpp
+++ b/libraries/app/include/graphene/app/application.hpp
@@ -98,8 +98,13 @@ namespace graphene { namespace app {
          boost::signals2::signal<void()> syncing_finished;
 
          const application_options& get_options();
+         fc::mutable_variant_object get_server_information();
 
       private:
+         /**
+          * @brief retrieve the names of the active plugins
+          */
+         std::vector<std::string> get_active_plugin_names();
          void enable_plugin( const string& name );
          void add_available_plugin( std::shared_ptr<abstract_plugin> p );
          std::shared_ptr<detail::application_impl> my;

--- a/libraries/app/include/graphene/app/plugin.hpp
+++ b/libraries/app/include/graphene/app/plugin.hpp
@@ -88,6 +88,8 @@ class abstract_plugin
          boost::program_options::options_description& command_line_options,
          boost::program_options::options_description& config_file_options
          ) = 0;
+
+      virtual boost::program_options::variables_map plugin_get_program_options() = 0;
 };
 
 /**
@@ -110,6 +112,11 @@ class plugin : public abstract_plugin
          boost::program_options::options_description& command_line_options,
          boost::program_options::options_description& config_file_options
          ) override;
+     virtual boost::program_options::variables_map plugin_get_program_options() override
+     {
+        boost::program_options::variables_map map;
+        return map;
+     }
 
       chain::database& database() { return *app().chain_database(); }
       application& app()const { assert(_app); return *_app; }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 file(GLOB UNIT_TESTS "tests/*.cpp")
 add_executable( chain_test ${COMMON_SOURCES} ${UNIT_TESTS} )
-target_link_libraries( chain_test graphene_chain graphene_app graphene_account_history graphene_egenesis_none fc graphene_wallet ${PLATFORM_SPECIFIC_LIBS} )
+target_link_libraries( chain_test graphene_chain graphene_app graphene_account_history graphene_egenesis_none fc graphene_wallet graphene_witness ${PLATFORM_SPECIFIC_LIBS} )
 if(MSVC)
   set_source_files_properties( tests/serialization_tests.cpp PROPERTIES COMPILE_FLAGS "/bigobj" )
 endif(MSVC)

--- a/tests/tests/login_api_tests.cpp
+++ b/tests/tests/login_api_tests.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2018 Bitshares Foundation, and contributors.
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <boost/test/unit_test.hpp>
+#include <boost/filesystem/path.hpp>
+
+#include <graphene/app/api.hpp>
+#include <graphene/utilities/tempdir.hpp>
+#include <graphene/account_history/account_history_plugin.hpp>
+#include <graphene/market_history/market_history_plugin.hpp>
+#include <graphene/witness/witness.hpp>
+
+#include "../common/genesis_file_util.hpp"
+
+#include <fc/crypto/digest.hpp>
+#include <iostream>
+
+BOOST_AUTO_TEST_SUITE( login_api_tests )
+
+BOOST_AUTO_TEST_CASE(get_parameters_default) {
+
+   BOOST_TEST_MESSAGE( "get_parameters_default" );
+
+   fc::temp_directory app_dir( graphene::utilities::temp_directory_path() );
+
+   graphene::app::application app1;
+   app1.register_plugin< graphene::account_history::account_history_plugin>();
+   app1.register_plugin< graphene::market_history::market_history_plugin >();
+   app1.register_plugin< graphene::witness_plugin::witness_plugin >();
+   app1.register_plugin< graphene::grouped_orders::grouped_orders_plugin>();
+   app1.startup_plugins();
+   boost::program_options::variables_map cfg;
+   cfg.emplace("p2p-endpoint", boost::program_options::variable_value(std::string("127.0.0.1:3939"), false));
+   cfg.emplace("genesis-json", boost::program_options::variable_value(create_genesis_file(app_dir), false));
+   cfg.emplace("seed-nodes", boost::program_options::variable_value(std::string("[]"), false));
+   app1.initialize(app_dir.path(), cfg);
+   BOOST_TEST_MESSAGE( "Starting app and waiting 500 ms" );
+   app1.startup();
+   fc::usleep(fc::milliseconds(500));
+
+   graphene::app::login_api login_api(app1);
+
+   fc::mutable_variant_object server_info = login_api.get_server_information();
+   BOOST_CHECK( server_info.size() == 0ul );
+
+}
+
+BOOST_AUTO_TEST_CASE(get_parameters_basic) {
+
+   BOOST_TEST_MESSAGE( "get_parameters_basic" );
+
+   fc::temp_directory app_dir( graphene::utilities::temp_directory_path() );
+
+   graphene::app::application app1;
+   app1.register_plugin< graphene::account_history::account_history_plugin>();
+   app1.register_plugin< graphene::market_history::market_history_plugin >();
+   app1.register_plugin< graphene::witness_plugin::witness_plugin >();
+   app1.register_plugin< graphene::grouped_orders::grouped_orders_plugin>();
+   app1.startup_plugins();
+   boost::program_options::variables_map cfg;
+   cfg.emplace("p2p-endpoint", boost::program_options::variable_value(std::string("127.0.0.1:3939"), false));
+   cfg.emplace("genesis-json", boost::program_options::variable_value(create_genesis_file(app_dir), false));
+   cfg.emplace("seed-nodes", boost::program_options::variable_value(std::string("[]"), false));
+   cfg.emplace("share-version-info", boost::program_options::variable_value(std::string("true"), false));
+   app1.initialize(app_dir.path(), cfg);
+   BOOST_TEST_MESSAGE( "Starting app and waiting 500 ms" );
+   app1.startup();
+   fc::usleep(fc::milliseconds(500));
+
+   graphene::app::login_api login_api(app1);
+
+   fc::mutable_variant_object server_info = login_api.get_server_information();
+   BOOST_CHECK( server_info.size() != 0ul );
+   std::string result = fc::json::to_pretty_string( server_info );
+   std::cout << result << std::endl;
+
+}
+
+BOOST_AUTO_TEST_CASE(get_parameters_plugins) {
+
+   BOOST_TEST_MESSAGE( "get_parameters_plugins" );
+
+   fc::temp_directory app_dir( graphene::utilities::temp_directory_path() );
+
+   graphene::app::application app1;
+   app1.register_plugin< graphene::account_history::account_history_plugin>();
+   app1.register_plugin< graphene::market_history::market_history_plugin >();
+   app1.register_plugin< graphene::witness_plugin::witness_plugin >();
+   app1.register_plugin< graphene::grouped_orders::grouped_orders_plugin>();
+   app1.startup_plugins();
+   boost::program_options::variables_map cfg;
+   cfg.emplace("p2p-endpoint", boost::program_options::variable_value(std::string("127.0.0.1:3939"), false));
+   cfg.emplace("genesis-json", boost::program_options::variable_value(create_genesis_file(app_dir), false));
+   cfg.emplace("seed-nodes", boost::program_options::variable_value(std::string("[]"), false));
+   cfg.emplace("share-plugin-info", boost::program_options::variable_value(std::string("true"), false));
+   app1.initialize(app_dir.path(), cfg);
+   BOOST_TEST_MESSAGE( "Starting app and waiting 500 ms" );
+   app1.startup();
+   fc::usleep(fc::milliseconds(500));
+
+   graphene::app::login_api login_api(app1);
+
+   fc::mutable_variant_object server_info = login_api.get_server_information();
+   BOOST_CHECK( server_info.size() != 0ul );
+   std::string result = fc::json::to_pretty_string( server_info );
+   std::cout << result << std::endl;
+
+}
+
+BOOST_AUTO_TEST_CASE(get_parameters_all) {
+
+   BOOST_TEST_MESSAGE( "get_parameters_all" );
+
+   fc::temp_directory app_dir( graphene::utilities::temp_directory_path() );
+
+   graphene::app::application app1;
+   app1.register_plugin< graphene::account_history::account_history_plugin>();
+   app1.register_plugin< graphene::market_history::market_history_plugin >();
+   app1.register_plugin< graphene::witness_plugin::witness_plugin >();
+   app1.register_plugin< graphene::grouped_orders::grouped_orders_plugin>();
+   app1.startup_plugins();
+   boost::program_options::variables_map cfg;
+   cfg.emplace("p2p-endpoint", boost::program_options::variable_value(std::string("127.0.0.1:3939"), false));
+   cfg.emplace("genesis-json", boost::program_options::variable_value(create_genesis_file(app_dir), false));
+   cfg.emplace("seed-nodes", boost::program_options::variable_value(std::string("[]"), false));
+   cfg.emplace("share-plugin-info", boost::program_options::variable_value(std::string("true"), false));
+   cfg.emplace("share-version-info", boost::program_options::variable_value(std::string("true"), false));
+   app1.initialize(app_dir.path(), cfg);
+   BOOST_TEST_MESSAGE( "Starting app and waiting 500 ms" );
+   app1.startup();
+   fc::usleep(fc::milliseconds(500));
+
+   graphene::app::login_api login_api(app1);
+
+   fc::mutable_variant_object server_info = login_api.get_server_information();
+   BOOST_CHECK( server_info.size() != 0ul );
+   std::string result = fc::json::to_pretty_string( server_info );
+   std::cout << result << std::endl;
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/tests/login_api_tests.cpp
+++ b/tests/tests/login_api_tests.cpp
@@ -66,6 +66,36 @@ BOOST_AUTO_TEST_CASE(get_parameters_default) {
 
 }
 
+BOOST_AUTO_TEST_CASE(get_parameters_false) {
+
+   BOOST_TEST_MESSAGE( "get_parameters_false" );
+
+   fc::temp_directory app_dir( graphene::utilities::temp_directory_path() );
+
+   graphene::app::application app1;
+   app1.register_plugin< graphene::account_history::account_history_plugin>();
+   app1.register_plugin< graphene::market_history::market_history_plugin >();
+   app1.register_plugin< graphene::witness_plugin::witness_plugin >();
+   app1.register_plugin< graphene::grouped_orders::grouped_orders_plugin>();
+   app1.startup_plugins();
+   boost::program_options::variables_map cfg;
+   cfg.emplace("p2p-endpoint", boost::program_options::variable_value(std::string("127.0.0.1:3939"), false));
+   cfg.emplace("genesis-json", boost::program_options::variable_value(create_genesis_file(app_dir), false));
+   cfg.emplace("seed-nodes", boost::program_options::variable_value(std::string("[]"), false));
+   cfg.emplace("share-plugin-info", boost::program_options::variable_value(false, false));
+   cfg.emplace("share-version-info", boost::program_options::variable_value(false, false));
+   app1.initialize(app_dir.path(), cfg);
+   BOOST_TEST_MESSAGE( "Starting app and waiting 500 ms" );
+   app1.startup();
+   fc::usleep(fc::milliseconds(500));
+
+   graphene::app::login_api login_api(app1);
+
+   fc::mutable_variant_object server_info = login_api.get_server_information();
+   BOOST_CHECK( server_info.size() == 0ul );
+
+}
+
 BOOST_AUTO_TEST_CASE(get_parameters_basic) {
 
    BOOST_TEST_MESSAGE( "get_parameters_basic" );
@@ -82,7 +112,7 @@ BOOST_AUTO_TEST_CASE(get_parameters_basic) {
    cfg.emplace("p2p-endpoint", boost::program_options::variable_value(std::string("127.0.0.1:3939"), false));
    cfg.emplace("genesis-json", boost::program_options::variable_value(create_genesis_file(app_dir), false));
    cfg.emplace("seed-nodes", boost::program_options::variable_value(std::string("[]"), false));
-   cfg.emplace("share-version-info", boost::program_options::variable_value(std::string("true"), false));
+   cfg.emplace("share-version-info", boost::program_options::variable_value(true, false));
    app1.initialize(app_dir.path(), cfg);
    BOOST_TEST_MESSAGE( "Starting app and waiting 500 ms" );
    app1.startup();
@@ -113,7 +143,7 @@ BOOST_AUTO_TEST_CASE(get_parameters_plugins) {
    cfg.emplace("p2p-endpoint", boost::program_options::variable_value(std::string("127.0.0.1:3939"), false));
    cfg.emplace("genesis-json", boost::program_options::variable_value(create_genesis_file(app_dir), false));
    cfg.emplace("seed-nodes", boost::program_options::variable_value(std::string("[]"), false));
-   cfg.emplace("share-plugin-info", boost::program_options::variable_value(std::string("true"), false));
+   cfg.emplace("share-plugin-info", boost::program_options::variable_value(true, false));
    app1.initialize(app_dir.path(), cfg);
    BOOST_TEST_MESSAGE( "Starting app and waiting 500 ms" );
    app1.startup();
@@ -144,8 +174,8 @@ BOOST_AUTO_TEST_CASE(get_parameters_all) {
    cfg.emplace("p2p-endpoint", boost::program_options::variable_value(std::string("127.0.0.1:3939"), false));
    cfg.emplace("genesis-json", boost::program_options::variable_value(create_genesis_file(app_dir), false));
    cfg.emplace("seed-nodes", boost::program_options::variable_value(std::string("[]"), false));
-   cfg.emplace("share-plugin-info", boost::program_options::variable_value(std::string("true"), false));
-   cfg.emplace("share-version-info", boost::program_options::variable_value(std::string("true"), false));
+   cfg.emplace("share-plugin-info", boost::program_options::variable_value(true, false));
+   cfg.emplace("share-version-info", boost::program_options::variable_value(true, false));
    app1.initialize(app_dir.path(), cfg);
    BOOST_TEST_MESSAGE( "Starting app and waiting 500 ms" );
    app1.startup();


### PR DESCRIPTION
Fixes #626 

This PR provides information to the API client about enabled plugins and server version information.

By default, the login_api::get_server_information() API call will return nothing.

If the witness_node is started with the share-version-info parameter set to true, server version information will be shared. If the share-plugin-info parameter is set to true, plugin information will be shared.

Note: The original pull request bitshares/bitshares-core/pull/668 was implemented slightly differently, and bad merges polluted the PR. I feel this is a cleaner implementation, without the unwanted merge artifacts.