### PR TITLE
Add tests to asset_object::amount_to_string

### DIFF
--- a/libraries/chain/asset_object.cpp
+++ b/libraries/chain/asset_object.cpp
@@ -145,7 +145,7 @@ asset asset_object::amount_from_string(string amount_string) const
    return amount(satoshis);
    } FC_CAPTURE_AND_RETHROW( (amount_string) ) }
 
-string asset_object::amount_to_string(share_type amount) const
+string asset_object::amount_to_string(const share_type& amount) const
 {
    share_type scaled_precision = asset::scaled_precision( precision );
 

--- a/libraries/chain/asset_object.cpp
+++ b/libraries/chain/asset_object.cpp
@@ -149,8 +149,15 @@ string asset_object::amount_to_string(share_type amount) const
 {
    share_type scaled_precision = asset::scaled_precision( precision );
 
-   string result = fc::to_string(amount.value / scaled_precision.value);
-   auto decimals = amount.value % scaled_precision.value;
+   share_type amt_copy = amount;
+   string result = "";
+   if ( amount.value < 0 )
+   {
+      amt_copy = amount * -1;
+      result = "-";
+   }
+   result += fc::to_string(amt_copy.value / scaled_precision.value);
+   auto decimals = amt_copy.value % scaled_precision.value;
    if( decimals )
       result += "." + fc::to_string(scaled_precision.value + decimals).erase(0,1);
    return result;

--- a/libraries/chain/include/graphene/chain/asset_object.hpp
+++ b/libraries/chain/include/graphene/chain/asset_object.hpp
@@ -103,7 +103,7 @@ namespace graphene { namespace chain {
          /// The string may have a decimal and/or a negative sign.
          asset amount_from_string(string amount_string)const;
          /// Convert an asset to a textual representation, i.e. "123.45"
-         string amount_to_string(share_type amount)const;
+         string amount_to_string(const share_type& amount)const;
          /// Convert an asset to a textual representation, i.e. "123.45"
          string amount_to_string(const asset& amount)const
          { FC_ASSERT(amount.asset_id == id); return amount_to_string(amount.amount); }

--- a/tests/tests/asset_tests.cpp
+++ b/tests/tests/asset_tests.cpp
@@ -56,21 +56,19 @@ BOOST_AUTO_TEST_CASE( asset_to_from_string )
    {
       negative_results[i] = "-" + positive_results[i];
    }
-   graphene::chain::share_type amt_result[19];
-   amt_result[0] = 12345;
-   graphene::chain::asset_object obj1;
+   graphene::chain::asset_object test_obj;
    graphene::chain::share_type amt12345 = 12345;
    BOOST_TEST_MESSAGE( "Testing positive numbers" );
    for (int i = 0; i < 19; i++)
    {
-      obj1.precision = i;
-      BOOST_CHECK_EQUAL(positive_results[i], obj1.amount_to_string(amt12345));
+      test_obj.precision = i;
+      BOOST_CHECK_EQUAL(positive_results[i], test_obj.amount_to_string(amt12345));
    }
    BOOST_TEST_MESSAGE( "Testing negative numbers" );
    for (int i = 0; i < 19; i++)
    {
-      obj1.precision = i;
-      BOOST_CHECK_EQUAL(negative_results[i], obj1.amount_to_string(amt12345 * -1));
+      test_obj.precision = i;
+      BOOST_CHECK_EQUAL(negative_results[i], test_obj.amount_to_string(amt12345 * -1));
    }
 }
 

--- a/tests/tests/asset_tests.cpp
+++ b/tests/tests/asset_tests.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2018 Bitshares Foundation, and contributors.
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <boost/test/unit_test.hpp>
+#include <string>
+#include <cmath>
+#include <graphene/chain/asset_object.hpp>
+
+BOOST_AUTO_TEST_SUITE(asset_tests)
+
+BOOST_AUTO_TEST_CASE( asset_to_from_string )
+{
+   std::string positive_results[19];
+   positive_results[0]  = "12345";
+   positive_results[1]  = "1234.5";
+   positive_results[2]  = "123.45";
+   positive_results[3]  = "12.345";
+   positive_results[4]  = "1.2345";
+   positive_results[5]  = "0.12345";
+   positive_results[6]  = "0.012345";
+   positive_results[7]  = "0.0012345";
+   positive_results[8]  = "0.00012345";
+   positive_results[9]  = "0.000012345";
+   positive_results[10] = "0.0000012345";
+   positive_results[11] = "0.00000012345";
+   positive_results[12] = "0.000000012345";
+   positive_results[13] = "0.0000000012345";
+   positive_results[14] = "0.00000000012345";
+   positive_results[15] = "0.000000000012345";
+   positive_results[16] = "0.0000000000012345";
+   positive_results[17] = "0.00000000000012345";
+   positive_results[18] = "0.000000000000012345";
+   std::string negative_results[19];
+   for(int i = 0; i < 19; ++i)
+   {
+      negative_results[i] = "-" + positive_results[i];
+   }
+   graphene::chain::share_type amt_result[19];
+   amt_result[0] = 12345;
+   graphene::chain::asset_object obj1;
+   graphene::chain::share_type amt12345 = 12345;
+   BOOST_TEST_MESSAGE( "Testing positive numbers" );
+   for (int i = 0; i < 19; i++)
+   {
+      obj1.precision = i;
+      BOOST_CHECK_EQUAL(positive_results[i], obj1.amount_to_string(amt12345));
+   }
+   BOOST_TEST_MESSAGE( "Testing negative numbers" );
+   for (int i = 0; i < 19; i++)
+   {
+      obj1.precision = i;
+      BOOST_CHECK_EQUAL(negative_results[i], obj1.amount_to_string(amt12345 * -1));
+   }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This tests the asset_object::amount_to_string.

This is related to PR https://github.com/bitshares/bitshares-core/pull/1012. Current results seem strange for negative numbers (i.e. I believe it should be 1234.5 but the results are 123.5).