### PR TITLE
implement update_authorities

### DIFF
--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -1566,6 +1566,29 @@ class wallet_api
       fc::signal<void(bool)> lock_changed;
       std::shared_ptr<detail::wallet_api_impl> my;
       void encrypt_keys();
+
+
+      /** Update account authorities
+       *
+       * @param account_name The account to be updated.
+       * @param owner_auths map with public key or account and weight for instance [["1.2.1",1],["1.2.3",1]]
+       * @param active_auths map with public key or account and weight
+       * @param memo_key string with new memo key
+       * @param broadcast true if you wish to broadcast the transaction
+       * @return the signed version of the transaction
+       */
+      signed_transaction update_authorities( string account_name,
+                                             pair<uint16_t, flat_map<std::string, uint16_t>> owner,
+                                             pair<uint16_t, flat_map<std::string, uint16_t>> active,
+                                             std::string memo_key,
+                                             bool broadcast );
+
+      authority delete_authority(authority auth, std::string key);
+      authority insert_authority(authority auth, std::string key, uint16_t w);
+
+
+
+
 };
 
 } }
@@ -1751,4 +1774,5 @@ FC_API( graphene::wallet::wallet_api,
         (blind_history)
         (receive_blind_transfer)
         (get_order_book)
+        (update_authorities)
       )

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -4442,6 +4442,80 @@ vesting_balance_object_with_info::vesting_balance_object_with_info( const vestin
    allowed_withdraw_time = now;
 }
 
+signed_transaction wallet_api::update_authorities( string account_name,
+                                                   pair<uint16_t, flat_map<std::string, uint16_t>> owner,
+                                                   pair<uint16_t, flat_map<std::string, uint16_t>> active,
+                                                   std::string memo_key,
+                                                   bool broadcast )
+{
+   FC_ASSERT( !is_locked() );
+
+   auto account = get_account(account_name);
+   FC_ASSERT( account_name == account.name, "Account name doesn't match?" );
+
+   authority new_auth_owner;
+   authority new_auth_active;
+   new_auth_owner = account.owner;
+   new_auth_active = account.active;
+
+   account_update_operation op;
+   op.account = account.id;
+
+   // process owner auths
+   new_auth_owner.weight_threshold = weight_type(owner.first);
+   if (owner.second.size() > 0) {
+      for (const auto &auths : owner.second) {
+         if (auths.second == 0) // delete
+            new_auth_owner = delete_authority(new_auth_owner, auths.first);
+         else  // add
+            new_auth_owner = insert_authority(new_auth_owner, auths.first, auths.second);
+      }
+   }
+   op.owner = new_auth_owner;
+
+   // process active auths
+   new_auth_active.weight_threshold = active.first;
+   if (active.second.size() > 0) {
+      for (const auto &auths : active.second) {
+         if (auths.second == 0) // delete
+            new_auth_active = delete_authority(new_auth_active, auths.first);
+         else  // add
+            new_auth_active = insert_authority(new_auth_active, auths.first, auths.second);
+      }
+   }
+   op.active = new_auth_active;
+
+   // process the memo
+   if(memo_key != "") {
+      account_options ao;
+      ao.memo_key = public_key_type(memo_key);
+      op.new_options = ao;
+   }
+
+   signed_transaction tx;
+   tx.operations.push_back(op);
+   auto current_fees = my->_remote_db->get_global_properties().parameters.current_fees;
+   my->set_operation_fees( tx, current_fees );
+   tx.validate();
+
+   return my->sign_transaction( tx, broadcast );
+}
+
+authority wallet_api::delete_authority(authority auth, std::string key)
+{
+   if(is_public_key_registered(key)) auth.key_auths.erase(public_key_type(key));
+   else auth.account_auths.erase(get_account(key).id);
+
+   return auth;
+}
+authority wallet_api::insert_authority(authority auth, std::string key, uint16_t w)
+{
+   if(is_public_key_registered(key)) auth.add_authority(public_key_type(key), weight_type(w));
+   else auth.add_authority(get_account(key).id, weight_type(w));
+
+   return auth;
+}
+
 } } // graphene::wallet
 
 namespace fc {


### PR DESCRIPTION
replacement for https://github.com/bitshares/bitshares-core/pull/270

more discussion at https://github.com/bitshares/bitshares-core/issues/163

needs:
- [ ] protection for cycles. what condition(s) to protect exactly.
- [ ] more tests cases.

i tried different implementations however this format and execution was the in the direction of keeping the function action clear, small and clean.(probably possible to do it smaller). 

adding a key to active.
`update_authorities alpha [] [1, [["BTS6kFiqv1kpMHM2tMAcHArkDNZHCi1SiT2iQ9sC2U4SnVWGM1Y9t", 1]]] "" true`

deleting the key:
`update_authorities alpha [] [1, [["BTS6kFiqv1kpMHM2tMAcHArkDNZHCi1SiT2iQ9sC2U4SnVWGM1Y9t", 0]]] "" true`

add account:

`update_authorities alpha [] [1, [["1.2.0", 0]]] "" true`

etc, more samples in the test cases.