### PR TITLE
Short-cut long sequences of missed blocks

### DIFF
--- a/libraries/chain/db_block.cpp
+++ b/libraries/chain/db_block.cpp
@@ -521,7 +521,7 @@ void database::_apply_block( const signed_block& next_block )
       ++_current_trx_in_block;
    }
 
-   const uint32_t missed = count_missed_blocks( next_block );
+   const uint32_t missed = update_witness_missed_blocks( next_block );
    update_global_dynamic_data( next_block, missed );
    update_signing_witness(signing_witness, next_block);
    update_last_irreversible_block();

--- a/libraries/chain/db_block.cpp
+++ b/libraries/chain/db_block.cpp
@@ -521,7 +521,8 @@ void database::_apply_block( const signed_block& next_block )
       ++_current_trx_in_block;
    }
 
-   update_global_dynamic_data(next_block);
+   const uint32_t missed = count_missed_blocks( next_block );
+   update_global_dynamic_data( next_block, missed );
    update_signing_witness(signing_witness, next_block);
    update_last_irreversible_block();
 

--- a/libraries/chain/db_update.cpp
+++ b/libraries/chain/db_update.cpp
@@ -49,7 +49,7 @@ void database::update_global_dynamic_data( const signed_block& b, const uint32_t
    modify( _dgp, [&b,this,missed_blocks]( dynamic_global_property_object& dgp ){
       if( BOOST_UNLIKELY( b.block_num() == 1 ) )
          dgp.recently_missed_count = 0;
-         else if( _checkpoints.size() && _checkpoints.rbegin()->first >= b.block_num() )
+      else if( _checkpoints.size() && _checkpoints.rbegin()->first >= b.block_num() )
          dgp.recently_missed_count = 0;
       else if( missed_blocks )
          dgp.recently_missed_count += GRAPHENE_RECENTLY_MISSED_COUNT_INCREMENT*missed_blocks;

--- a/libraries/chain/db_update.cpp
+++ b/libraries/chain/db_update.cpp
@@ -47,9 +47,10 @@ void database::update_global_dynamic_data( const signed_block& b, const uint32_t
 
    // dynamic global properties updating
    modify( _dgp, [&b,this,missed_blocks]( dynamic_global_property_object& dgp ){
-      if( BOOST_UNLIKELY( b.block_num() == 1 ) )
+      const uint32_t block_num = b.block_num();
+      if( BOOST_UNLIKELY( block_num == 1 ) )
          dgp.recently_missed_count = 0;
-      else if( _checkpoints.size() && _checkpoints.rbegin()->first >= b.block_num() )
+      else if( _checkpoints.size() && _checkpoints.rbegin()->first >= block_num )
          dgp.recently_missed_count = 0;
       else if( missed_blocks )
          dgp.recently_missed_count += GRAPHENE_RECENTLY_MISSED_COUNT_INCREMENT*missed_blocks;
@@ -58,7 +59,7 @@ void database::update_global_dynamic_data( const signed_block& b, const uint32_t
       else if( dgp.recently_missed_count > 0 )
          dgp.recently_missed_count--;
 
-      dgp.head_block_number = b.block_num();
+      dgp.head_block_number = block_num;
       dgp.head_block_id = b.id();
       dgp.time = b.timestamp;
       dgp.current_witness = b.witness;

--- a/libraries/chain/db_witness_schedule.cpp
+++ b/libraries/chain/db_witness_schedule.cpp
@@ -77,6 +77,22 @@ uint32_t database::get_slot_at_time(fc::time_point_sec when)const
    return (when - first_slot_time).to_seconds() / block_interval() + 1;
 }
 
+uint32_t database::count_missed_blocks( const signed_block& b )
+{
+   uint32_t missed_blocks = get_slot_at_time( b.timestamp );
+   FC_ASSERT( missed_blocks != 0, "Trying to push double-produced block onto current block?!" );
+   missed_blocks--;
+   const auto& witnesses = witness_schedule_id_type()(*this).current_shuffled_witnesses;
+   if( missed_blocks < witnesses.size() )
+      for( uint32_t i = 0; i < missed_blocks; ++i ) {
+         const auto& witness_missed = get_scheduled_witness( i+1 )(*this);
+         modify( witness_missed, []( witness_object& w ) {
+            w.total_missed++;
+         });
+      }
+   return missed_blocks;
+}
+
 uint32_t database::witness_participation_rate()const
 {
    const dynamic_global_property_object& dpo = get_dynamic_global_properties();

--- a/libraries/chain/db_witness_schedule.cpp
+++ b/libraries/chain/db_witness_schedule.cpp
@@ -77,7 +77,7 @@ uint32_t database::get_slot_at_time(fc::time_point_sec when)const
    return (when - first_slot_time).to_seconds() / block_interval() + 1;
 }
 
-uint32_t database::count_missed_blocks( const signed_block& b )
+uint32_t database::update_witness_missed_blocks( const signed_block& b )
 {
    uint32_t missed_blocks = get_slot_at_time( b.timestamp );
    FC_ASSERT( missed_blocks != 0, "Trying to push double-produced block onto current block?!" );

--- a/libraries/chain/include/graphene/chain/database.hpp
+++ b/libraries/chain/include/graphene/chain/database.hpp
@@ -443,8 +443,12 @@ namespace graphene { namespace chain {
          const witness_object& _validate_block_header( const signed_block& next_block )const;
          void create_block_summary(const signed_block& next_block);
 
+         //////////////////// db_witness_schedule.cpp ////////////////////
+
+         uint32_t count_missed_blocks( const signed_block& b );
+
          //////////////////// db_update.cpp ////////////////////
-         void update_global_dynamic_data( const signed_block& b );
+         void update_global_dynamic_data( const signed_block& b, const uint32_t missed_blocks );
          void update_signing_witness(const witness_object& signing_witness, const signed_block& new_block);
          void update_last_irreversible_block();
          void clear_expired_transactions();

--- a/libraries/chain/include/graphene/chain/database.hpp
+++ b/libraries/chain/include/graphene/chain/database.hpp
@@ -445,7 +445,7 @@ namespace graphene { namespace chain {
 
          //////////////////// db_witness_schedule.cpp ////////////////////
 
-         uint32_t count_missed_blocks( const signed_block& b );
+         uint32_t update_witness_missed_blocks( const signed_block& b );
 
          //////////////////// db_update.cpp ////////////////////
          void update_global_dynamic_data( const signed_block& b, const uint32_t missed_blocks );


### PR DESCRIPTION
Fix #1086 

Fixes database::update_global_dynamic_data to speed up counting missed blocks.
(This also fixes a minor issue with counting - the previous algorithm would skip missed blocks for the witness who signed the first block after the gap.)

TODO:
* [x] unit test for missed blocks
