### PR TITLE
Improve adjust_balance performance #1083

### DIFF
--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -531,8 +531,8 @@ namespace graphene { namespace app {
     vector<account_asset_balance> asset_api::get_asset_holders( asset_id_type asset_id, uint32_t start, uint32_t limit ) const {
       FC_ASSERT(limit <= 100);
 
-      const auto& bal_idx = _db.get_index_type< account_balance_index >().indices().get< by_asset_balance >();
-      auto range = bal_idx.equal_range( boost::make_tuple( asset_id ) );
+      const auto& bal_idx = _db.get_index_type< account_balance_index >().indices().get< by_asset >();
+      auto range = bal_idx.equal_range( asset_id );
 
       vector<account_asset_balance> result;
 
@@ -563,8 +563,8 @@ namespace graphene { namespace app {
     // get number of asset holders.
     int asset_api::get_asset_holders_count( asset_id_type asset_id ) const {
 
-      const auto& bal_idx = _db.get_index_type< account_balance_index >().indices().get< by_asset_balance >();
-      auto range = bal_idx.equal_range( boost::make_tuple( asset_id ) );
+      const auto& bal_idx = _db.get_index_type< account_balance_index >().indices().get< by_asset >();
+      auto range = bal_idx.equal_range( asset_id );
 
       int count = boost::distance(range) - 1;
 
@@ -583,8 +583,8 @@ namespace graphene { namespace app {
         asset_id_type asset_id;
         asset_id = dasset_obj.id;
 
-        const auto& bal_idx = _db.get_index_type< account_balance_index >().indices().get< by_asset_balance >();
-        auto range = bal_idx.equal_range( boost::make_tuple( asset_id ) );
+        const auto& bal_idx = _db.get_index_type< account_balance_index >().indices().get< by_asset >();
+        auto range = bal_idx.equal_range( asset_id );
 
         int count = boost::distance(range) - 1;
 

--- a/libraries/chain/account_evaluator.cpp
+++ b/libraries/chain/account_evaluator.cpp
@@ -316,6 +316,8 @@ void_result account_update_evaluator::do_apply( const account_update_operation& 
 
    bool sa_before = acnt->has_special_authority();
 
+   flat_set<asset_id_type> assets_before = acnt->get_top_n_control_assets();
+
    // update account statistics
    if( o.new_options.valid() && o.new_options->is_voting() != acnt->options.is_voting() )
    {
@@ -352,12 +354,26 @@ void_result account_update_evaluator::do_apply( const account_update_operation& 
 
    bool sa_after = acnt->has_special_authority();
 
+   flat_set<asset_id_type> assets_after = acnt->get_top_n_control_assets();
+
+   const auto& special_meta = d.get_special_assets_meta_object();
    if( sa_before && (!sa_after) )
    {
       const auto& sa_idx = d.get_index_type< special_authority_index >().indices().get<by_account>();
       auto sa_it = sa_idx.find( o.account );
       assert( sa_it != sa_idx.end() );
       d.remove( *sa_it );
+      // From next maintenance interval, need to stop updating this account's active/owner.
+      // Here we check if each asset is added earlier in this maintenance interval,
+      //   if yes, remove it from "added"; otherwise, add it to "removed".
+      d.modify( special_meta, [&assets_before](special_assets_meta_object& p) {
+         auto& added = p.special_assets_added_this_interval;
+         for( const asset_id_type a : assets_before )
+         {
+            if( added.erase( a ) == 0 ) // if not in "added"
+               p.special_assets_removed_this_interval.insert( a );
+         }
+      });
    }
    else if( (!sa_before) && sa_after )
    {
@@ -365,6 +381,17 @@ void_result account_update_evaluator::do_apply( const account_update_operation& 
       {
          sa.account = o.account;
       } );
+      // From next maintenance interval, need to update this account's active/owner, so need to get top n asset holders.
+      // Here we check if each asset is removed earlier in this maintenance interval,
+      //   if yes, remove it from "removed"; otherwise, add it to "added".
+      d.modify( special_meta, [&assets_after](special_assets_meta_object& p) {
+         auto& removed = p.special_assets_removed_this_interval;
+         for( const asset_id_type a : assets_after )
+         {
+            if( removed.erase( a ) == 0 ) // if not in "removed"
+               p.special_assets_added_this_interval.insert( a );
+         }
+      });
    }
 
    return void_result();

--- a/libraries/chain/account_object.cpp
+++ b/libraries/chain/account_object.cpp
@@ -29,6 +29,22 @@
 
 namespace graphene { namespace chain {
 
+flat_set<asset_id_type> account_object::get_top_n_control_assets() const
+{
+   flat_set<asset_id_type> result;
+   if( owner_special_authority.which() == special_authority::tag< top_holders_special_authority >::value )
+   {
+      const top_holders_special_authority& tha = owner_special_authority.get< top_holders_special_authority >();
+      result.insert( tha.asset );
+   }
+   if( active_special_authority.which() == special_authority::tag< top_holders_special_authority >::value )
+   {
+      const top_holders_special_authority& tha = active_special_authority.get< top_holders_special_authority >();
+      result.insert( tha.asset );
+   }
+   return result;
+}
+
 share_type cut_fee(share_type a, uint16_t p)
 {
    if( a == 0 || p == 0 )
@@ -40,14 +56,6 @@ share_type cut_fee(share_type a, uint16_t p)
    r *= p;
    r /= GRAPHENE_100_PERCENT;
    return r.to_uint64();
-}
-
-void account_balance_object::adjust_balance(const asset& delta)
-{
-   assert(delta.asset_id == asset_type);
-   balance += delta.amount;
-   if( asset_type == asset_id_type() ) // CORE asset
-      maintenance_flag = true;
 }
 
 void account_statistics_object::process_fees(const account_object& a, database& d) const

--- a/libraries/chain/db_balance.cpp
+++ b/libraries/chain/db_balance.cpp
@@ -26,6 +26,7 @@
 
 #include <graphene/chain/account_object.hpp>
 #include <graphene/chain/asset_object.hpp>
+#include <graphene/chain/special_authority_object.hpp>
 #include <graphene/chain/vesting_balance_object.hpp>
 #include <graphene/chain/witness_object.hpp>
 
@@ -52,29 +53,51 @@ string database::to_pretty_string( const asset& a )const
 
 void database::adjust_balance(account_id_type account, asset delta )
 { try {
+
    if( delta.amount == 0 )
       return;
 
-   auto& index = get_index_type<account_balance_index>().indices().get<by_account_asset>();
+   const auto& special_assets = get_special_assets_meta_object().special_assets;
+   bool maint_flag = ( delta.asset_id == asset_id_type() // CORE asset
+                       || special_assets.find( delta.asset_id ) != special_assets.end() ); // special asset
+
+   const auto& index = get_index_type<account_balance_index>().indices().get<by_account_asset>();
    auto itr = index.find(boost::make_tuple(account, delta.asset_id));
+
    if(itr == index.end())
    {
-      FC_ASSERT( delta.amount > 0, "Insufficient Balance: ${a}'s balance of ${b} is less than required ${r}", 
+      FC_ASSERT( delta.amount > 0,
+                 "Insufficient Balance: ${a}'s balance of ${b} is less than required ${r}",
                  ("a",account(*this).name)
                  ("b",to_pretty_string(asset(0,delta.asset_id)))
                  ("r",to_pretty_string(-delta)));
-      create<account_balance_object>([account,&delta](account_balance_object& b) {
+
+      create<account_balance_object>([account,&delta,maint_flag](account_balance_object& b)
+      {
          b.owner = account;
          b.asset_type = delta.asset_id;
-         b.balance = delta.amount.value;
-         if( b.asset_type == asset_id_type() ) // CORE asset
+         b.balance = delta.amount;
+         if( maint_flag )
             b.maintenance_flag = true;
       });
-   } else {
+   }
+   else
+   {
       if( delta.amount < 0 )
-         FC_ASSERT( itr->get_balance() >= -delta, "Insufficient Balance: ${a}'s balance of ${b} is less than required ${r}", ("a",account(*this).name)("b",to_pretty_string(itr->get_balance()))("r",to_pretty_string(-delta)));
-      modify(*itr, [delta](account_balance_object& b) {
-         b.adjust_balance(delta);
+      {
+         FC_ASSERT( itr->balance >= -delta.amount,
+                    "Insufficient Balance: ${a}'s balance of ${b} is less than required ${r}",
+                    ("a",account(*this).name)
+                    ("b",to_pretty_string(itr->get_balance()))
+                    ("r",to_pretty_string(-delta))
+                  );
+      }
+
+      modify(*itr, [delta,maint_flag](account_balance_object& b)
+      {
+         b.balance += delta.amount;
+         if( maint_flag )
+            b.maintenance_flag = true;
       });
    }
 

--- a/libraries/chain/db_getter.cpp
+++ b/libraries/chain/db_getter.cpp
@@ -105,4 +105,9 @@ const account_statistics_object& database::get_account_stats_by_owner( account_i
    return *itr;
 }
 
+const special_assets_meta_object& database::get_special_assets_meta_object()const
+{
+   return get( special_assets_meta_id_type() );
+}
+
 } }

--- a/libraries/chain/db_init.cpp
+++ b/libraries/chain/db_init.cpp
@@ -206,9 +206,11 @@ void database::initialize_indexes()
    //Implementation object indexes
    add_index< primary_index<transaction_index                             > >();
    add_index< primary_index<account_balance_index                         > >();
+   add_index< primary_index<account_special_balance_index                 > >();
    add_index< primary_index<asset_bitasset_data_index                     > >();
    add_index< primary_index<simple_index<global_property_object          >> >();
    add_index< primary_index<simple_index<dynamic_global_property_object  >> >();
+   add_index< primary_index<simple_index<special_assets_meta_object      >> >();
    add_index< primary_index<account_stats_index                           > >();
    add_index< primary_index<simple_index<asset_dynamic_data_object       >> >();
    add_index< primary_index<simple_index<block_summary_object            >> >();
@@ -548,6 +550,10 @@ void database::init_genesis(const genesis_state_type& genesis_state)
          a.bitasset_data_id = bitasset_data_id;
       });
    }
+
+   // Create special assets meta object
+   create<special_assets_meta_object>([&](special_assets_meta_object& p) {
+   });
 
    // Create initial balances
    share_type total_allocation;

--- a/libraries/chain/db_notify.cpp
+++ b/libraries/chain/db_notify.cpp
@@ -355,11 +355,13 @@ void get_relevant_accounts( const object* obj, flat_set<account_id_type>& accoun
               break;
              case impl_dynamic_global_property_object_type:
               break;
-             case impl_reserved0_object_type:
+             case impl_special_assets_meta_object_type:
               break;
              case impl_asset_dynamic_data_type:
               break;
              case impl_asset_bitasset_data_type:
+              break;
+             case impl_account_special_balance_object_type:
               break;
              case impl_account_balance_object_type:{
               const auto& aobj = dynamic_cast<const account_balance_object*>(obj);

--- a/libraries/chain/include/graphene/chain/account_object.hpp
+++ b/libraries/chain/include/graphene/chain/account_object.hpp
@@ -130,7 +130,6 @@ namespace graphene { namespace chain {
          bool              maintenance_flag = false; ///< Whether need to process this balance object in maintenance interval
 
          asset get_balance()const { return asset(balance, asset_type); }
-         void  adjust_balance(const asset& delta);
    };
 
 
@@ -241,6 +240,9 @@ namespace graphene { namespace chain {
          static const uint8_t top_n_control_owner  = 1;
          static const uint8_t top_n_control_active = 2;
 
+         /// Return the related assets if the account has top_holders_special_authority set.
+         flat_set<asset_id_type> get_top_n_control_assets() const;
+
          /**
           * This is a set of assets which the account is allowed to have.
           * This is utilized to restrict buyback accounts to the assets that trade in their markets.
@@ -334,7 +336,7 @@ namespace graphene { namespace chain {
    };
 
    struct by_account_asset;
-   struct by_asset_balance;
+   struct by_asset;
    struct by_maintenance_flag;
    /**
     * @ingroup object_index
@@ -352,18 +354,8 @@ namespace graphene { namespace chain {
                member<account_balance_object, asset_id_type, &account_balance_object::asset_type>
             >
          >,
-         ordered_unique< tag<by_asset_balance>,
-            composite_key<
-               account_balance_object,
-               member<account_balance_object, asset_id_type, &account_balance_object::asset_type>,
-               member<account_balance_object, share_type, &account_balance_object::balance>,
-               member<account_balance_object, account_id_type, &account_balance_object::owner>
-            >,
-            composite_key_compare<
-               std::less< asset_id_type >,
-               std::greater< share_type >,
-               std::less< account_id_type >
-            >
+         ordered_non_unique< tag<by_asset>,
+               member<account_balance_object, asset_id_type, &account_balance_object::asset_type>
          >
       >
    > account_balance_object_multi_index_type;

--- a/libraries/chain/include/graphene/chain/database.hpp
+++ b/libraries/chain/include/graphene/chain/database.hpp
@@ -258,6 +258,7 @@ namespace graphene { namespace chain {
          const node_property_object&            get_node_properties()const;
          const fee_schedule&                    current_fee_schedule()const;
          const account_statistics_object&       get_account_stats_by_owner( account_id_type owner )const;
+         const special_assets_meta_object&      get_special_assets_meta_object()const;
 
          time_point_sec   head_block_time()const;
          uint32_t         head_block_num()const;
@@ -473,6 +474,9 @@ namespace graphene { namespace chain {
 
          template<class Type>
          void perform_account_maintenance( Type tally_helper );
+
+         void perform_balance_maintenance();
+         void perform_special_assets_maintenance();
          ///@}
          ///@}
 

--- a/libraries/chain/include/graphene/chain/protocol/types.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/types.hpp
@@ -148,7 +148,7 @@ namespace graphene { namespace chain {
    {
       impl_global_property_object_type,
       impl_dynamic_global_property_object_type,
-      impl_reserved0_object_type,      // formerly index_meta_object_type, TODO: delete me
+      impl_special_assets_meta_object_type,
       impl_asset_dynamic_data_type,
       impl_asset_bitasset_data_type,
       impl_account_balance_object_type,
@@ -163,7 +163,8 @@ namespace graphene { namespace chain {
       impl_special_authority_object_type,
       impl_buyback_object_type,
       impl_fba_accumulator_object_type,
-      impl_collateral_bid_object_type
+      impl_collateral_bid_object_type,
+      impl_account_special_balance_object_type
    };
 
    //typedef fc::unsigned_int            object_id_type;
@@ -202,6 +203,7 @@ namespace graphene { namespace chain {
    // implementation types
    class global_property_object;
    class dynamic_global_property_object;
+   class special_assets_meta_object;
    class asset_dynamic_data_object;
    class asset_bitasset_data_object;
    class account_balance_object;
@@ -216,9 +218,11 @@ namespace graphene { namespace chain {
    class buyback_object;
    class fba_accumulator_object;
    class collateral_bid_object;
+   class account_special_balance_object;
 
    typedef object_id< implementation_ids, impl_global_property_object_type,  global_property_object>                    global_property_id_type;
    typedef object_id< implementation_ids, impl_dynamic_global_property_object_type,  dynamic_global_property_object>    dynamic_global_property_id_type;
+   typedef object_id< implementation_ids, impl_special_assets_meta_object_type,  special_assets_meta_object>            special_assets_meta_id_type;
    typedef object_id< implementation_ids, impl_asset_dynamic_data_type,      asset_dynamic_data_object>                 asset_dynamic_data_id_type;
    typedef object_id< implementation_ids, impl_asset_bitasset_data_type,     asset_bitasset_data_object>                asset_bitasset_data_id_type;
    typedef object_id< implementation_ids, impl_account_balance_object_type,  account_balance_object>                    account_balance_id_type;
@@ -237,6 +241,7 @@ namespace graphene { namespace chain {
    typedef object_id< implementation_ids, impl_buyback_object_type, buyback_object >                                    buyback_id_type;
    typedef object_id< implementation_ids, impl_fba_accumulator_object_type, fba_accumulator_object >                    fba_accumulator_id_type;
    typedef object_id< implementation_ids, impl_collateral_bid_object_type, collateral_bid_object >                      collateral_bid_id_type;
+   typedef object_id< implementation_ids, impl_account_special_balance_object_type,  account_special_balance_object>    account_special_balance_id_type;
 
    typedef fc::array<char, GRAPHENE_MAX_ASSET_SYMBOL_LENGTH>    symbol_type;
    typedef fc::ripemd160                                        block_id_type;
@@ -352,7 +357,7 @@ FC_REFLECT_ENUM( graphene::chain::object_type,
 FC_REFLECT_ENUM( graphene::chain::impl_object_type,
                  (impl_global_property_object_type)
                  (impl_dynamic_global_property_object_type)
-                 (impl_reserved0_object_type)
+                 (impl_special_assets_meta_object_type)
                  (impl_asset_dynamic_data_type)
                  (impl_asset_bitasset_data_type)
                  (impl_account_balance_object_type)
@@ -368,6 +373,7 @@ FC_REFLECT_ENUM( graphene::chain::impl_object_type,
                  (impl_buyback_object_type)
                  (impl_fba_accumulator_object_type)
                  (impl_collateral_bid_object_type)
+                 (impl_account_special_balance_object_type)
                )
 
 FC_REFLECT_TYPENAME( graphene::chain::share_type )
@@ -388,6 +394,7 @@ FC_REFLECT_TYPENAME( graphene::chain::worker_id_type )
 FC_REFLECT_TYPENAME( graphene::chain::balance_id_type )
 FC_REFLECT_TYPENAME( graphene::chain::global_property_id_type )
 FC_REFLECT_TYPENAME( graphene::chain::dynamic_global_property_id_type )
+FC_REFLECT_TYPENAME( graphene::chain::special_assets_meta_id_type )
 FC_REFLECT_TYPENAME( graphene::chain::asset_dynamic_data_id_type )
 FC_REFLECT_TYPENAME( graphene::chain::asset_bitasset_data_id_type )
 FC_REFLECT_TYPENAME( graphene::chain::account_balance_id_type )
@@ -400,6 +407,7 @@ FC_REFLECT_TYPENAME( graphene::chain::special_authority_id_type )
 FC_REFLECT_TYPENAME( graphene::chain::buyback_id_type )
 FC_REFLECT_TYPENAME( graphene::chain::fba_accumulator_id_type )
 FC_REFLECT_TYPENAME( graphene::chain::collateral_bid_id_type )
+FC_REFLECT_TYPENAME( graphene::chain::account_special_balance_id_type )
 
 FC_REFLECT( graphene::chain::void_t, )
 

--- a/libraries/chain/include/graphene/chain/special_authority_object.hpp
+++ b/libraries/chain/include/graphene/chain/special_authority_object.hpp
@@ -61,10 +61,113 @@ typedef multi_index_container<
 
 typedef generic_index< special_authority_object, special_authority_multi_index_type > special_authority_index;
 
+
+/**
+ * account_special_balance_object only exists to help with a specific indexing problem.
+ * We want to be able to maintain top n holders of special assets, which are specified
+ * by accounts with a special_authority.
+ * However, as of writing, accounts which have a special_authority are very rare.
+ * So rather than indexing account_balance_object by the asset_type and balance fields
+ * (requiring additional bookkeeping for every balance), we instead maintain a
+ * account_special_balance_object which is a copy of account_balance_object but only
+ * for those special assets (requiring additional bookkeeping only for assets which
+ * specified by accounts with special_authority).
+ *
+ * Note: although special_authority is rarely used in the system as of writing, it's
+ *       possible that it will become popular at some time point in the future,
+ *       then we need to re-visit this implementation.
+ *
+ * This class is an implementation detail.
+ */
+
+class account_special_balance_object : public abstract_object<account_special_balance_object>
+{
+   public:
+      static const uint8_t space_id = implementation_ids;
+      static const uint8_t type_id  = impl_account_special_balance_object_type;
+
+      account_id_type   owner;
+      asset_id_type     asset_type;
+      share_type        balance;
+
+      asset get_balance()const { return asset(balance, asset_type); }
+};
+
+struct by_account_asset;
+struct by_asset_balance;
+
+typedef multi_index_container<
+   account_special_balance_object,
+   indexed_by<
+      ordered_unique< tag<by_id>, member< object, object_id_type, &object::id > >,
+      ordered_unique< tag<by_account_asset>,
+         composite_key<
+            account_special_balance_object,
+            member<account_special_balance_object, account_id_type, &account_special_balance_object::owner>,
+            member<account_special_balance_object, asset_id_type, &account_special_balance_object::asset_type>
+         >
+      >,
+      ordered_unique< tag<by_asset_balance>,
+         composite_key<
+            account_special_balance_object,
+            member<account_special_balance_object, asset_id_type, &account_special_balance_object::asset_type>,
+            member<account_special_balance_object, share_type, &account_special_balance_object::balance>,
+            member<account_special_balance_object, account_id_type, &account_special_balance_object::owner>
+         >,
+         composite_key_compare<
+            std::less< asset_id_type >,
+            std::greater< share_type >,
+            std::less< account_id_type >
+         >
+      >
+   >
+> account_special_balance_object_multi_index_type;
+
+typedef generic_index<account_special_balance_object, account_special_balance_object_multi_index_type>
+           account_special_balance_index;
+
+
+/**
+ * @brief Special assets meta object
+ * @ingroup object
+ * @ingroup implementation
+ *
+ * Meta object that stores info related to all special assets which are specified
+ * by accounts with a special_authority.
+ *
+ * Note: as of writing, there are very few special assets.
+ *       If quantity of special assets become large, it would be better to
+ *       redesign this object.
+ *
+ * This is an implementation detail.
+ */
+class special_assets_meta_object : public abstract_object<special_assets_meta_object>
+{
+   public:
+      static const uint8_t space_id = implementation_ids;
+      static const uint8_t type_id  = impl_special_assets_meta_object_type;
+
+      flat_set<asset_id_type> special_assets;
+      flat_set<asset_id_type> special_assets_added_this_interval;
+      flat_set<asset_id_type> special_assets_removed_this_interval;
+};
+
 } } // graphene::chain
 
 FC_REFLECT_DERIVED(
    graphene::chain::special_authority_object,
    (graphene::db::object),
    (account)
+)
+
+FC_REFLECT_DERIVED(
+   graphene::chain::account_special_balance_object, (graphene::db::object),
+   (owner)(asset_type)(balance)
+)
+
+FC_REFLECT_DERIVED(
+   graphene::chain::special_assets_meta_object, (graphene::db::object),
+   (special_assets)
+   (special_assets_added_this_interval)
+   (special_assets_removed_this_interval)
 )


### PR DESCRIPTION
PR for #1083.

With this patch, total replay time for `27,000,000` blocks reduced by `1 - 5063/5633 ~= 10%.` More data is here: https://github.com/bitshares/bitshares-core/issues/1083#issuecomment-399992509

Note: `asset_api::get_asset_holders(...)` and `asset_api::get_all_asset_holders()` will return unordered results after this change.