### PR TITLE
possible solution for issue 1105: update_last_irreversible_block() performance

### DIFF
--- a/libraries/chain/db_maint.cpp
+++ b/libraries/chain/db_maint.cpp
@@ -273,8 +273,7 @@ void database::update_active_witnesses()
    });
 
    populate_witness(gpo);
-
-
+      
 } FC_CAPTURE_AND_RETHROW() }
 
 void database::populate_witness(const global_property_object& gpo)

--- a/libraries/chain/db_maint.cpp
+++ b/libraries/chain/db_maint.cpp
@@ -272,7 +272,18 @@ void database::update_active_witnesses()
       });
    });
 
+   populate_witness(gpo);
+
+
 } FC_CAPTURE_AND_RETHROW() }
+
+void database::populate_witness(const global_property_object& gpo)
+{
+   wit_objs.clear();
+   wit_objs.reserve(gpo.active_witnesses.size());
+   for (const witness_id_type &wid : gpo.active_witnesses)
+      wit_objs.push_back(&(wid(*this)));
+}
 
 void database::update_active_committee_members()
 { try {

--- a/libraries/chain/db_update.cpp
+++ b/libraries/chain/db_update.cpp
@@ -109,10 +109,8 @@ void database::update_last_irreversible_block()
    const global_property_object& gpo = get_global_properties();
    const dynamic_global_property_object& dpo = get_dynamic_global_properties();
 
-   vector< const witness_object* > wit_objs;
-   wit_objs.reserve( gpo.active_witnesses.size() );
-   for( const witness_id_type& wid : gpo.active_witnesses )
-      wit_objs.push_back( &(wid(*this)) );
+   if(wit_objs.empty())
+      populate_witness(gpo);
 
    static_assert( GRAPHENE_IRREVERSIBLE_THRESHOLD > 0, "irreversible threshold must be nonzero" );
 

--- a/libraries/chain/include/graphene/chain/database.hpp
+++ b/libraries/chain/include/graphene/chain/database.hpp
@@ -460,12 +460,12 @@ namespace graphene { namespace chain {
          void update_withdraw_permissions();
          bool check_for_blackswan( const asset_object& mia, bool enable_black_swan = true );
 
+         ///Steps performed only at maintenance intervals
+         ///@{
+
          // populated in db_main.cpp and used in db_update.cpp
          vector<const witness_object *> wit_objs;
          void populate_witness(const global_property_object& gpo);
-
-         ///Steps performed only at maintenance intervals
-         ///@{
 
          //////////////////// db_maint.cpp ////////////////////
 

--- a/libraries/chain/include/graphene/chain/database.hpp
+++ b/libraries/chain/include/graphene/chain/database.hpp
@@ -460,6 +460,10 @@ namespace graphene { namespace chain {
          void update_withdraw_permissions();
          bool check_for_blackswan( const asset_object& mia, bool enable_black_swan = true );
 
+         // populated in db_main.cpp and used in db_update.cpp
+         vector<const witness_object *> wit_objs;
+         void populate_witness(const global_property_object& gpo);
+
          ///Steps performed only at maintenance intervals
          ///@{
 


### PR DESCRIPTION
https://github.com/bitshares/bitshares-core/issues/1105

The implementation add a vector `wit_objs` in `database.hpp` so it can be used by `db_maint.cpp` and `db_update.cpp`. 

Function `update_last_irreversible_block` at `db_update` will check if the "global" vector is populated and use it. Vector will be empty if chain is just starting and possible other scenarios(like at some sort or replay/resync?). When the vector is empty `update_last_irreversible_block` will do what it currently do, loop throw the active witnesses but using a function(`populate_witness`). 

In the first maint time(and on each), when `update_active_witnesses` is called global vector will be populated by `populate_witness`.

Not sure if it is the best approach.