### PR TITLE
Fixes to make Docker containers shutdown properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,5 +67,8 @@ ADD docker/default_config.ini /etc/bitshares/config.ini
 ADD docker/bitsharesentry.sh /usr/local/bin/bitsharesentry.sh
 RUN chmod a+x /usr/local/bin/bitsharesentry.sh
 
+# Make Docker send SIGINT instead of SIGTERM to the daemon
+STOPSIGNAL SIGINT
+
 # default execute entry
 CMD ["/usr/local/bin/bitsharesentry.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,4 +68,4 @@ ADD docker/bitsharesentry.sh /usr/local/bin/bitsharesentry.sh
 RUN chmod a+x /usr/local/bin/bitsharesentry.sh
 
 # default execute entry
-CMD /usr/local/bin/bitsharesentry.sh
+CMD ["/usr/local/bin/bitsharesentry.sh"]


### PR DESCRIPTION
Making a dockerized daemon receive SIGTERM could be very tricky:
firstly, CMD should not use the "shell form", otherwise a "sh -c" process will possess the PID 1 therefore no one can receive the SIGTERM sent from "docker stop";
second, the bitsharesentry.sh should call $BITSHARESD with exec, i.e. let the daemon take the same PID (i.e. 1). Or in another way, a "trap SIGTERM" trick may be employed to make sure the SIGTERM is forwarded to the actual daemon process.

The second patch is optional. I personally encountered segfaults while sending SIGTERM to witness, however SIGINT works well ever.

See also: https://hynek.me/articles/docker-signals/