### PR TITLE
Change default max-ops-per-account value to 100

### DIFF
--- a/programs/witness_node/main.cpp
+++ b/programs/witness_node/main.cpp
@@ -140,7 +140,7 @@ static void create_new_config_file( const fc::path& config_ini_path, const fc::p
        if( name == "partial-operations" )
           return new_option_description( name, bpo::value<bool>()->default_value(true), o->description() );
        if( name == "max-ops-per-account" )
-          return new_option_description( name, bpo::value<int>()->default_value(1000), o->description() );
+          return new_option_description( name, bpo::value<int>()->default_value(100), o->description() );
        return o;
    };
    deduplicator dedup(modify_option_defaults);


### PR DESCRIPTION
As of writing, a node with default config (max-ops-per-account=1000) need around 22GB of RAM.

With this change (max-ops-per-account=100), a node with default config will use around 10GB of RAM.

Since reference wallet only shows latest 100 entries, this change won't make a difference.