### PR TITLE
Remove crypto_api from default list of allowed APIs. (issue #1123)

### DIFF
--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -436,7 +436,6 @@ void application_impl::startup()
       wild_access.allowed_apis.push_back( "database_api" );
       wild_access.allowed_apis.push_back( "network_broadcast_api" );
       wild_access.allowed_apis.push_back( "history_api" );
-      wild_access.allowed_apis.push_back( "crypto_api" );
       wild_access.allowed_apis.push_back( "orders_api" );
       _apiaccess.permission_map["*"] = wild_access;
    }


### PR DESCRIPTION
Fix for #1123.