### PR TITLE
set default quote asset_id to 1.3.1

### DIFF
--- a/libraries/chain/include/graphene/chain/protocol/asset_ops.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/asset_ops.hpp
@@ -54,7 +54,7 @@ namespace graphene { namespace chain {
       /// order to accept the fee. If this asset's fee pool is funded, the chain will automatically deposite fees
       /// in this asset to its accumulated fees, and withdraw from the fee pool the same amount as converted at
       /// the core exchange rate.
-      price core_exchange_rate;
+      price core_exchange_rate = price(asset(), asset(0, asset_id_type(1)));
 
       /// A set of accounts which maintain whitelists to consult for this asset. If whitelist_authorities
       /// is non-empty, then only accounts in whitelist_authorities are allowed to hold, use, or transfer the asset.


### PR DESCRIPTION
In current help message of create_asset, printed in gethelp, gives an
example of option with quote asset_id of "1.3.0". This asset id is
not a valid one, since the code requires the id to be "1.3.1" on
creating a new asset.

This change set the default quote asset_id to "1.3.1", so that the
gethelp message would give a valid option example.