### PR TITLE
add extension to js_serializer

### DIFF
--- a/libraries/chain/include/graphene/chain/protocol/account.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/account.hpp
@@ -101,7 +101,9 @@ namespace graphene { namespace chain {
       authority       active;
 
       account_options options;
-      extension< ext > extensions;
+
+      typedef extension<ext> extensions_type;
+      extensions_type extensions;
 
       account_id_type fee_payer()const { return registrar; }
       void            validate()const;
@@ -149,7 +151,9 @@ namespace graphene { namespace chain {
 
       /// New account options
       optional<account_options> new_options;
-      extension< ext > extensions;
+
+      typedef extension<ext> extensions_type;
+      extensions_type extensions;
 
       account_id_type fee_payer()const { return account; }
       void       validate()const;
@@ -280,10 +284,15 @@ FC_REFLECT( graphene::chain::account_create_operation,
             (name)(owner)(active)(options)(extensions)
           )
 
+FC_REFLECT_TYPENAME( graphene::chain::account_create_operation::extensions_type )
+
 FC_REFLECT(graphene::chain::account_update_operation::ext, (null_ext)(owner_special_authority)(active_special_authority) )
 FC_REFLECT( graphene::chain::account_update_operation,
             (fee)(account)(owner)(active)(new_options)(extensions)
           )
+
+FC_REFLECT_TYPENAME( graphene::chain::account_update_operation::extensions_type )
+
 
 FC_REFLECT( graphene::chain::account_upgrade_operation,
             (fee)(account_to_upgrade)(upgrade_to_lifetime_member)(extensions) )

--- a/programs/js_operation_serializer/main.cpp
+++ b/programs/js_operation_serializer/main.cpp
@@ -126,6 +126,7 @@ template<> struct js_name<fc::signed_int>      { static std::string name(){ retu
 template<> struct js_name< vote_id_type >      { static std::string name(){ return "vote_id";    } };
 template<> struct js_name< time_point_sec >    { static std::string name(){ return "time_point_sec"; } };
 
+
 template<uint8_t S, uint8_t T, typename O>
 struct js_name<graphene::db::object_id<S,T,O> >
 {
@@ -267,6 +268,8 @@ struct serializer<uint64_t,false>
    static void generate() {}
 };
 template<> struct serializer<vote_id_type,false> { static void init() {} static void generate() {} };
+
+
 #ifdef __APPLE__
 // on mac, size_t is a distinct type from uint64_t or uint32_t and needs a separate specialization
 template<> struct serializer<size_t,false> { static void init() {} static void generate() {} };
@@ -276,6 +279,13 @@ template<> struct serializer<int64_t,true> { static void init() {} static void g
 
 template<typename T>
 struct serializer<fc::optional<T>,false>
+{
+   static void init() { serializer<T>::init(); }
+   static void generate(){}
+};
+
+template<typename T>
+struct serializer<graphene::chain::extension<T>,false>
 {
    static void init() { serializer<T>::init(); }
    static void generate(){}


### PR DESCRIPTION
this pull is a replacement for https://github.com/bitshares/bitshares-core/pull/966 for issue https://github.com/bitshares/bitshares-core/issues/947

here is how it looks now. for `call_order_update`:

```
call_order_update_operation_options = new Serializer(
    "call_order_update_operation_options"
    target_collateral_ratio: optional uint16
)

call_order_update = new Serializer(
    "call_order_update"
    fee: asset
    funding_account: protocol_id_type "account"
    delta_collateral: asset
    delta_debt: asset
    extensions: call_order_update_operation_extensions
)
```

for `account_create`:
```
account_create_operation_ext = new Serializer(
    "account_create_operation_ext"
    null_ext: optional void
    owner_special_authority: optional static_variant [
    no_special_authority
    top_holders_special_authority
]
    active_special_authority: optional static_variant [
    no_special_authority
    top_holders_special_authority
]
    buyback_options: optional buyback_account_options
)

account_create = new Serializer(
    "account_create"
    fee: asset
    registrar: protocol_id_type "account"
    referrer: protocol_id_type "account"
    referrer_percent: uint16
    name: string
    owner: authority
    active: authority
    options: account_options
    extensions: account_create_operation_extensions
)
```

and for `account_update`:
```
account_update_operation_ext = new Serializer(
    "account_update_operation_ext"
    null_ext: optional void
    owner_special_authority: optional static_variant [
    no_special_authority
    top_holders_special_authority
]
    active_special_authority: optional static_variant [
    no_special_authority
    top_holders_special_authority
]
)

account_update = new Serializer(
    "account_update"
    fee: asset
    account: protocol_id_type "account"
    owner: optional authority
    active: optional authority
    new_options: optional account_options
    extensions: account_update_operation_extensions
)
```
Problem i see is that the new serializers don't have the exact same name as the extension field(`account_update_operation_extensions` is serialized as `account_update_operation_ext`.

As i dont know exactly how this is used by the UI i am  unsure if it is an issue or not.