### PR TITLE
Elasticsearch: flush the pending ops after processing a block

### DIFF
--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -147,6 +147,13 @@ void elasticsearch_plugin_impl::update_account_histories( const signed_block& b 
          add_elasticsearch( account_id, oho, b );
       }
    }
+   
+   if((fc::time_point::now() - b.timestamp) < fc::seconds(30)) {
+      if (curl && bulk.size() != 0) { // flush the pending bulk if we are not in replay
+         prepare.clear();
+         graphene::utilities::SendBulk(curl, bulk, _elasticsearch_node_url, _elasticsearch_logs, "logs-account-history");
+      }
+   }
 }
 
 void elasticsearch_plugin_impl::add_elasticsearch( const account_id_type account_id, const optional <operation_history_object>& oho, const signed_block& b)


### PR DESCRIPTION
Otherwise some ops will be left behind until bulk size is reached, resulting in a latency of >=3s.
This behavior is unfriendly to real-time applications, versus the slight performance hit of flushing.

Replay is not affected by this change.