### PR TITLE
Changed push_proposal exception log level to warn

### DIFF
--- a/libraries/chain/db_block.cpp
+++ b/libraries/chain/db_block.cpp
@@ -295,7 +295,7 @@ processed_transaction database::push_proposal(const proposal_object& proposal)
       {
          _applied_ops.resize( old_applied_ops_size );
       }
-      elog( "${e}", ("e",e.to_detail_string() ) );
+      wlog( "${e}", ("e",e.to_detail_string() ) );
       throw;
    }
 


### PR DESCRIPTION
IMHO the original log level (`error`) is too aggressive for `push_proposal(...)` call. 