### PR TITLE
Test of account history pagination

### DIFF
--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -488,7 +488,7 @@ BOOST_AUTO_TEST_CASE( cli_confidential_tx_test )
 }
 
 /******
- * Check account history pagination (see bitshares-core/issue/1176
+ * Check account history pagination (see bitshares-core/issue/1176)
  */
 BOOST_AUTO_TEST_CASE( account_history_pagination )
 {
@@ -525,13 +525,16 @@ BOOST_AUTO_TEST_CASE( account_history_pagination )
       account_object nathan_acct_after_upgrade = con.wallet_api_ptr->get_account("nathan");
 
       // verify that the upgrade was successful
-      BOOST_CHECK_PREDICATE( std::not_equal_to<uint32_t>(), (nathan_acct_before_upgrade.membership_expiration_date.sec_since_epoch())(nathan_acct_after_upgrade.membership_expiration_date.sec_since_epoch()) );
+      BOOST_CHECK_PREDICATE( std::not_equal_to<uint32_t>(),
+    		  (nathan_acct_before_upgrade.membership_expiration_date.sec_since_epoch())
+			  (nathan_acct_after_upgrade.membership_expiration_date.sec_since_epoch()) );
       BOOST_CHECK(nathan_acct_after_upgrade.is_lifetime_member());
 
       // create a new account
       graphene::wallet::brain_key_info bki = con.wallet_api_ptr->suggest_brain_key();
       BOOST_CHECK(!bki.brain_priv_key.empty());
-      signed_transaction create_acct_tx = con.wallet_api_ptr->create_account_with_brain_key(bki.brain_priv_key, "jmjatlanta", "nathan", "nathan", true);
+      signed_transaction create_acct_tx = con.wallet_api_ptr->create_account_with_brain_key(
+    		  bki.brain_priv_key, "jmjatlanta", "nathan", "nathan", true);
       // save the private key for this new account in the wallet file
    	  BOOST_CHECK(con.wallet_api_ptr->import_key("jmjatlanta", bki.wif_priv_key));
       con.wallet_api_ptr->save_wallet_file(con.wallet_filename);
@@ -540,7 +543,8 @@ BOOST_AUTO_TEST_CASE( account_history_pagination )
       BOOST_TEST_MESSAGE("Transferring bitshares from Nathan to jmjatlanta");
       for(int i = 1; i <= 200; i++)
       {
-          signed_transaction transfer_tx = con.wallet_api_ptr->transfer("nathan", "jmjatlanta", std::to_string(i), "1.3.0", "Here are some BTS for your new account", true);
+          signed_transaction transfer_tx = con.wallet_api_ptr->transfer("nathan", "jmjatlanta", std::to_string(i),
+        		  "1.3.0", "Here are some BTS for your new account", true);
       }
 
       BOOST_CHECK(generate_block(app1));

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -95,6 +95,9 @@ std::shared_ptr<graphene::app::application> start_application(fc::temp_directory
    cfg.emplace("seed-nodes", boost::program_options::variable_value(string("[]"), false));
    app1->initialize(app_dir.path(), cfg);
 
+   app1->initialize_plugins(cfg);
+   app1->startup_plugins();
+
    app1->startup();
    fc::usleep(fc::milliseconds(500));
 	return app1;
@@ -544,7 +547,16 @@ BOOST_AUTO_TEST_CASE( account_history_pagination )
 
       // now get account history and make sure everything is there (and no duplicates)
       std::vector<graphene::wallet::operation_detail> history = con.wallet_api_ptr->get_account_history("jmjatlanta", 300);
-      BOOST_CHECK_EQUAL(300, history.size() );
+      BOOST_CHECK_EQUAL(201, history.size() );
+
+      std::set<object_id_type> operation_ids;
+
+      for(auto op : history)
+      {
+    	  if (operation_ids.find(op.op.id) != operation_ids.end())
+    		  BOOST_FAIL("Duplicate found");
+    	  operation_ids.insert(op.op.id);
+      }
 
    } catch( fc::exception& e ) {
       edump((e.to_detail_string()));


### PR DESCRIPTION
Issue https://github.com/bitshares/bitshares-core/issues/1176 caused duplicate entries in the return results due errors in the logic of pagination. This was fixed by PR https://github.com/bitshares/bitshares-core/pull/1177

This PR adds a test to make sure pagination works as it should. I ran this test with and without PR 1177. The test fails without it, and passes with it.