### PR TITLE
Changed default docker p2p port to 1776

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ VOLUME ["/var/lib/bitshares", "/etc/bitshares"]
 # rpc service:
 EXPOSE 8090
 # p2p service:
-EXPOSE 2001
+EXPOSE 1776
 
 # default exec/config files
 ADD docker/default_config.ini /etc/bitshares/config.ini

--- a/README-docker.md
+++ b/README-docker.md
@@ -16,7 +16,7 @@ The `Dockerfile` performs the following steps:
 7. Purge source code off the container
 8. Add a local bitshares user and set `$HOME` to `/var/lib/bitshares`
 9. Make `/var/lib/bitshares` and `/etc/bitshares` a docker *volume*
-10. Expose ports `8090` and `2001`
+10. Expose ports `8090` and `1776`
 11. Add default config from `docker/default_config.ini` and entry point script
 12. Run entry point script by default
 

--- a/docker/default_config.ini
+++ b/docker/default_config.ini
@@ -1,5 +1,5 @@
 # Endpoint for P2P node to listen on
-p2p-endpoint = 0.0.0.0:2001
+p2p-endpoint = 0.0.0.0:1776
 
 # P2P nodes to connect to on startup (may specify multiple times)
 # seed-node = 


### PR DESCRIPTION
Changed default p2p port in Docker related files from 2001 to 1776.

Note: 2001 is commonly used p2p port for Steem, 1776 is for BitShares.