### PR TITLE
Missing FC Typenames (Issue #1217)

### DIFF
--- a/libraries/chain/include/graphene/chain/protocol/ext.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/ext.hpp
@@ -233,8 +233,9 @@ template<typename T> struct get_typename< graphene::chain::extension<T> >
 { 
    static const char* name()
    { 
-      return (std::string("graphene::chain::extension<") 
-         + fc::get_typename<T>::name() + std::string(">")).c_str();   
+      static std::string n = std::string("graphene::chain::extension<") 
+         + fc::get_typename<T>::name() + std::string(">");
+      return n.c_str();
    } 
 };
 

--- a/libraries/chain/include/graphene/chain/protocol/ext.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/ext.hpp
@@ -229,4 +229,14 @@ void unpack( Stream& s, graphene::chain::extension<T>& value, uint32_t _max_dept
 
 } // fc::raw
 
+template<typename T> struct get_typename< graphene::chain::extension<T> >
+{ 
+   static const char* name()
+   { 
+      return (std::string("graphene::chain::extension<") 
+         + fc::get_typename<T>::name() + std::string(">")).c_str();   
+   } 
+};
+
+
 } // fc


### PR DESCRIPTION
This is the core portion of #1217, and works with PR https://github.com/bitshares/bitshares-fc/pull/74

Prior get_typename was generating classes on many unnecessary classes. This modification correctly generates code for only the classes necessary.