### PR TITLE
elasticsearch move instead of copy

### DIFF
--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -323,7 +323,7 @@ void elasticsearch_plugin_impl::prepareBulk(const account_transaction_history_id
    bulk_header["_index"] = index_name;
    bulk_header["_type"] = "data";
    bulk_header["_id"] = fc::to_string(ath_id.space_id) + "." + fc::to_string(ath_id.type_id) + "." + ath_id.instance;
-   prepare = graphene::utilities::createBulk(bulk_header, bulk_line);
+   prepare = graphene::utilities::createBulk(bulk_header, std::move(bulk_line));
    std::move(prepare.begin(), prepare.end(), std::back_inserter(bulk_lines));
    prepare.clear();
 }

--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -393,11 +393,11 @@ void elasticsearch_plugin::plugin_set_program_options(
    )
 {
    cli.add_options()
-         ("elasticsearch-node-url", boost::program_options::value<std::string>(), "Elastic Search database node url")
-         ("elasticsearch-bulk-replay", boost::program_options::value<uint32_t>(), "Number of bulk documents to index on replay(5000)")
-         ("elasticsearch-bulk-sync", boost::program_options::value<uint32_t>(), "Number of bulk documents to index on a syncronied chain(10)")
-         ("elasticsearch-visitor", boost::program_options::value<bool>(), "Use visitor to index additional data(slows down the replay)")
-         ("elasticsearch-basic-auth", boost::program_options::value<std::string>(), "Pass basic auth to elasticsearch database ")
+         ("elasticsearch-node-url", boost::program_options::value<std::string>(), "Elastic Search database node url(http://localhost:9200/)")
+         ("elasticsearch-bulk-replay", boost::program_options::value<uint32_t>(), "Number of bulk documents to index on replay(10000)")
+         ("elasticsearch-bulk-sync", boost::program_options::value<uint32_t>(), "Number of bulk documents to index on a syncronied chain(100)")
+         ("elasticsearch-visitor", boost::program_options::value<bool>(), "Use visitor to index additional data(slows down the replay(false))")
+         ("elasticsearch-basic-auth", boost::program_options::value<std::string>(), "Pass basic auth to elasticsearch database('')")
          ("elasticsearch-index-prefix", boost::program_options::value<std::string>(), "Add a prefix to the index(bitshares-)")
          ;
    cfg.add(cli);

--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -73,7 +73,7 @@ class elasticsearch_plugin_impl
       std::string index_name;
       bool is_sync = false;
    private:
-      bool add_elasticsearch( const account_id_type account_id, const optional<operation_history_object>& oho, const signed_block& b );
+      bool add_elasticsearch( const account_id_type account_id, const optional<operation_history_object>& oho );
       const account_transaction_history_object& addNewEntry(const account_statistics_object& stats_obj,
                                                             const account_id_type account_id,
                                                             const optional <operation_history_object>& oho);
@@ -162,7 +162,7 @@ bool elasticsearch_plugin_impl::update_account_histories( const signed_block& b 
 
       for( auto& account_id : impacted )
       {
-         if(!add_elasticsearch( account_id, oho, b ))
+         if(!add_elasticsearch( account_id, oho ))
             return false;
       }
    }
@@ -249,8 +249,7 @@ void elasticsearch_plugin_impl::doVisitor(const optional <operation_history_obje
 }
 
 bool elasticsearch_plugin_impl::add_elasticsearch( const account_id_type account_id,
-                                                   const optional <operation_history_object>& oho,
-                                                   const signed_block& b)
+                                                   const optional <operation_history_object>& oho)
 {
    const auto &stats_obj = getStatsObject(account_id);
    const auto &ath = addNewEntry(stats_obj, account_id, oho);

--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -173,7 +173,7 @@ bool elasticsearch_plugin_impl::update_account_histories( const signed_block& b 
       if(es.bulk_lines.size() > 0)
       {
          prepare.clear();
-         if(!graphene::utilities::SendBulk(es))
+         if(!graphene::utilities::SendBulk(std::move(es)))
             return false;
          else
             bulk_lines.clear();
@@ -261,7 +261,7 @@ bool elasticsearch_plugin_impl::add_elasticsearch( const account_id_type account
    if (curl && bulk_lines.size() >= limit_documents) { // we are in bulk time, ready to add data to elasticsearech
       prepare.clear();
       populateESstruct();
-      if(!graphene::utilities::SendBulk(es))
+      if(!graphene::utilities::SendBulk(std::move(es)))
          return false;
       else
          bulk_lines.clear();
@@ -359,7 +359,7 @@ void elasticsearch_plugin_impl::cleanObjects(const account_transaction_history_o
 void elasticsearch_plugin_impl::populateESstruct()
 {
    es.curl = curl;
-   es.bulk_lines = bulk_lines;
+   es.bulk_lines = std::move(bulk_lines);
    es.elasticsearch_url = _elasticsearch_node_url;
    es.auth = _elasticsearch_basic_auth;
 }

--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -81,7 +81,7 @@ class elasticsearch_plugin_impl
       void growStats(const account_statistics_object& stats_obj, const account_transaction_history_object& ath);
       void getOperationType(const optional <operation_history_object>& oho);
       void doOperationHistory(const optional <operation_history_object>& oho);
-      void doBlock(const optional <operation_history_object>& oho, const signed_block& b);
+      void doBlock(uint32_t trx_in_block, const signed_block& b);
       void doVisitor(const optional <operation_history_object>& oho);
       void checkState(const fc::time_point_sec& block_time);
       void cleanObjects(const account_transaction_history_object& ath, account_id_type account_id);
@@ -140,7 +140,7 @@ bool elasticsearch_plugin_impl::update_account_histories( const signed_block& b 
       // populate what we can before impacted loop
       getOperationType(oho);
       doOperationHistory(oho);
-      doBlock(oho, b);
+      doBlock(oho->trx_in_block, b);
       if(_elasticsearch_visitor)
          doVisitor(oho);
 
@@ -215,11 +215,11 @@ void elasticsearch_plugin_impl::doOperationHistory(const optional <operation_his
    os.op = fc::json::to_string(oho->op);
 }
 
-void elasticsearch_plugin_impl::doBlock(const optional <operation_history_object>& oho, const signed_block& b)
+void elasticsearch_plugin_impl::doBlock(uint32_t trx_in_block, const signed_block& b)
 {
    std::string trx_id = "";
-   if(oho->trx_in_block < b.transactions.size())
-      trx_id = b.transactions[oho->trx_in_block].id().str();
+   if(trx_in_block < b.transactions.size())
+      trx_id = b.transactions[trx_in_block].id().str();
    bs.block_num = b.block_num();
    bs.block_time = b.timestamp;
    bs.trx_id = trx_id;

--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -362,6 +362,9 @@ void elasticsearch_plugin_impl::populateESstruct()
    es.bulk_lines = std::move(bulk_lines);
    es.elasticsearch_url = _elasticsearch_node_url;
    es.auth = _elasticsearch_basic_auth;
+   es.index_prefix = _elasticsearch_index_prefix;
+   es.endpoint = "";
+   es.query = "";
 }
 
 } // end namespace detail

--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -180,6 +180,9 @@ bool elasticsearch_plugin_impl::update_account_histories( const signed_block& b 
       }
    }
 
+   if(bulk_lines.size() != limit_documents)
+      bulk_lines.reserve(limit_documents);
+
    return true;
 }
 
@@ -321,7 +324,8 @@ void elasticsearch_plugin_impl::prepareBulk(const account_transaction_history_id
    bulk_header["_type"] = "data";
    bulk_header["_id"] = fc::to_string(ath_id.space_id) + "." + fc::to_string(ath_id.type_id) + "." + ath_id.instance;
    prepare = graphene::utilities::createBulk(bulk_header, bulk_line);
-   bulk_lines.insert(bulk_lines.end(), prepare.begin(), prepare.end());
+   std::move(prepare.begin(), prepare.end(), std::back_inserter(bulk_lines));
+   prepare.clear();
 }
 
 void elasticsearch_plugin_impl::cleanObjects(const account_transaction_history_object& ath, account_id_type account_id)

--- a/libraries/plugins/es_objects/es_objects.cpp
+++ b/libraries/plugins/es_objects/es_objects.cpp
@@ -140,7 +140,7 @@ bool es_objects_plugin_impl::updateDatabase( const vector<object_id_type>& ids ,
       es.elasticsearch_url = _es_objects_elasticsearch_url;
       es.auth = _es_objects_auth;
 
-      if(!graphene::utilities::SendBulk(es))
+      if(!graphene::utilities::SendBulk(std::move(es)))
          return false;
       else
          bulk.clear();

--- a/libraries/plugins/es_objects/es_objects.cpp
+++ b/libraries/plugins/es_objects/es_objects.cpp
@@ -179,7 +179,7 @@ void es_objects_plugin_impl::PrepareProposal(const proposal_object& proposal_obj
    bulk_header["_index"] = _es_objects_index_prefix + "proposal";
    bulk_header["_type"] = "data";
 
-   prepare = graphene::utilities::createBulk(bulk_header, data);
+   prepare = graphene::utilities::createBulk(bulk_header, std::move(data));
    bulk.insert(bulk.end(), prepare.begin(), prepare.end());
    prepare.clear();
 }
@@ -221,7 +221,7 @@ void es_objects_plugin_impl::PrepareAccount(const account_object& account_object
    bulk_header["_index"] = _es_objects_index_prefix + "acount";
    bulk_header["_type"] = "data";
 
-   prepare = graphene::utilities::createBulk(bulk_header, data);
+   prepare = graphene::utilities::createBulk(bulk_header, std::move(data));
    bulk.insert(bulk.end(), prepare.begin(), prepare.end());
    prepare.clear();
 }
@@ -253,7 +253,7 @@ void es_objects_plugin_impl::PrepareAsset(const asset_object& asset_object,
    bulk_header["_index"] = _es_objects_index_prefix + "asset";
    bulk_header["_type"] = "data";
 
-   prepare = graphene::utilities::createBulk(bulk_header, data);
+   prepare = graphene::utilities::createBulk(bulk_header, std::move(data));
    bulk.insert(bulk.end(), prepare.begin(), prepare.end());
    prepare.clear();
 }
@@ -282,7 +282,7 @@ void es_objects_plugin_impl::PrepareBalance(const balance_object& balance_object
    bulk_header["_index"] = _es_objects_index_prefix + "balance";
    bulk_header["_type"] = "data";
 
-   prepare = graphene::utilities::createBulk(bulk_header, data);
+   prepare = graphene::utilities::createBulk(bulk_header, std::move(data));
    bulk.insert(bulk.end(), prepare.begin(), prepare.end());
    prepare.clear();
 }
@@ -314,7 +314,7 @@ void es_objects_plugin_impl::PrepareLimit(const limit_order_object& limit_object
    bulk_header["_index"] = _es_objects_index_prefix + "limitorder";
    bulk_header["_type"] = "data";
 
-   prepare = graphene::utilities::createBulk(bulk_header, data);
+   prepare = graphene::utilities::createBulk(bulk_header, std::move(data));
    bulk.insert(bulk.end(), prepare.begin(), prepare.end());
    prepare.clear();
 }
@@ -345,7 +345,7 @@ void es_objects_plugin_impl::PrepareBitAsset(const asset_bitasset_data_object& b
       bulk_header["_index"] = _es_objects_index_prefix + "bitasset";
       bulk_header["_type"] = "data";
 
-      prepare = graphene::utilities::createBulk(bulk_header, data);
+      prepare = graphene::utilities::createBulk(bulk_header, std::move(data));
       bulk.insert(bulk.end(), prepare.begin(), prepare.end());
       prepare.clear();
    }

--- a/libraries/utilities/elasticsearch.cpp
+++ b/libraries/utilities/elasticsearch.cpp
@@ -74,7 +74,7 @@ bool SendBulk(ES&& es)
 
    auto curlResponse = doCurl(curl_request);
 
-   if(handleBulkResponse(getResponseCode(curl_request.handler)))
+   if(handleBulkResponse(getResponseCode(curl_request.handler), curlResponse))
       return true;
    return false;
 }
@@ -93,16 +93,15 @@ long getResponseCode(CURL *handler)
    return http_code;
 }
 
-bool handleBulkResponse(long http_code)
+bool handleBulkResponse(long http_code, const std::string& CurlReadBuffer)
 {
    if(http_code == 200) {
       // all good, but check errors in response
-      // removed this for performance
-      //fc::variant j = fc::json::from_string(CurlReadBuffer);
-      //bool errors = j["errors"].as_bool();
-      //if(errors == true) {
-      //   return false;
-      //}
+      fc::variant j = fc::json::from_string(CurlReadBuffer);
+      bool errors = j["errors"].as_bool();
+      if(errors == true) {
+         return false;
+      }
    }
    else {
       if(http_code == 413) {

--- a/libraries/utilities/elasticsearch.cpp
+++ b/libraries/utilities/elasticsearch.cpp
@@ -118,7 +118,7 @@ bool handleBulkResponse(long http_code, const std::string& CurlReadBuffer)
    return true;
 }
 
-const std::vector<std::string> createBulk(const fc::mutable_variant_object& bulk_header, const std::string& data)
+const std::vector<std::string> createBulk(const fc::mutable_variant_object& bulk_header, const std::string&& data)
 {
    std::vector<std::string> bulk;
    fc::mutable_variant_object final_bulk_header;

--- a/libraries/utilities/elasticsearch.cpp
+++ b/libraries/utilities/elasticsearch.cpp
@@ -44,7 +44,7 @@ bool checkES(ES& es)
    curl_request.auth = es.auth;
    curl_request.type = "GET";
 
-   if(doCurl(curl_request).empty())
+   if(doCurl(std::move(curl_request)).empty())
       return false;
    return true;
 
@@ -58,28 +58,28 @@ const std::string simpleQuery(ES& es)
    curl_request.type = "POST";
    curl_request.query = es.query;
 
-   return doCurl(curl_request);
+   return doCurl(std::move(curl_request));
 }
 
 bool SendBulk(ES& es)
 {
-   std::string bulking = joinBulkLines(es.bulk_lines);
+   std::string bulking = joinBulkLines(std::move(es.bulk_lines));
 
    graphene::utilities::CurlRequest curl_request;
    curl_request.handler = es.curl;
    curl_request.url = es.elasticsearch_url + "_bulk";
    curl_request.auth = es.auth;
    curl_request.type = "POST";
-   curl_request.query = bulking;
+   curl_request.query = std::move(bulking);
 
-   auto curlResponse = doCurl(curl_request);
+   auto curlResponse = doCurl(std::move(curl_request));
 
    if(handleBulkResponse(getResponseCode(curl_request.handler), curlResponse))
       return true;
    return false;
 }
 
-const std::string joinBulkLines(const std::vector<std::string>& bulk)
+const std::string joinBulkLines(const std::vector<std::string>&& bulk)
 {
    auto bulking = boost::algorithm::join(bulk, "\n");
    bulking = bulking + "\n";
@@ -137,7 +137,7 @@ bool deleteAll(ES& es)
    curl_request.auth = es.auth;
    curl_request.type = "DELETE";
 
-   auto curl_response =  doCurl(curl_request);
+   auto curl_response =  doCurl(std::move(curl_request));
    if(curl_response.empty())
       return false;
    else
@@ -151,7 +151,7 @@ const std::string getEndPoint(ES& es)
    curl_request.auth = es.auth;
    curl_request.type = "GET";
 
-   return doCurl(curl_request);
+   return doCurl(std::move(curl_request));
 }
 
 const std::string generateIndexName(const fc::time_point_sec& block_date, const std::string& _elasticsearch_index_prefix)
@@ -163,7 +163,7 @@ const std::string generateIndexName(const fc::time_point_sec& block_date, const 
    return index_name;
 }
 
-const std::string doCurl(CurlRequest& curl)
+const std::string doCurl(CurlRequest&& curl)
 {
    std::string CurlReadBuffer;
    struct curl_slist *headers = NULL;

--- a/libraries/utilities/elasticsearch.cpp
+++ b/libraries/utilities/elasticsearch.cpp
@@ -61,7 +61,7 @@ const std::string simpleQuery(ES& es)
    return doCurl(std::move(curl_request));
 }
 
-bool SendBulk(ES& es)
+bool SendBulk(ES&& es)
 {
    std::string bulking = joinBulkLines(std::move(es.bulk_lines));
 

--- a/libraries/utilities/elasticsearch.cpp
+++ b/libraries/utilities/elasticsearch.cpp
@@ -74,7 +74,7 @@ bool SendBulk(ES&& es)
 
    auto curlResponse = doCurl(std::move(curl_request));
 
-   if(handleBulkResponse(getResponseCode(curl_request.handler), curlResponse))
+   if(handleBulkResponse(getResponseCode(curl_request.handler)))
       return true;
    return false;
 }
@@ -93,15 +93,16 @@ long getResponseCode(CURL *handler)
    return http_code;
 }
 
-bool handleBulkResponse(long http_code, const std::string& CurlReadBuffer)
+bool handleBulkResponse(long http_code)
 {
    if(http_code == 200) {
       // all good, but check errors in response
-      fc::variant j = fc::json::from_string(CurlReadBuffer);
-      bool errors = j["errors"].as_bool();
-      if(errors == true) {
-         return false;
-      }
+      // removed this for performance
+      //fc::variant j = fc::json::from_string(CurlReadBuffer);
+      //bool errors = j["errors"].as_bool();
+      //if(errors == true) {
+      //   return false;
+      //}
    }
    else {
       if(http_code == 413) {

--- a/libraries/utilities/elasticsearch.cpp
+++ b/libraries/utilities/elasticsearch.cpp
@@ -44,7 +44,7 @@ bool checkES(ES& es)
    curl_request.auth = es.auth;
    curl_request.type = "GET";
 
-   if(doCurl(std::move(curl_request)).empty())
+   if(doCurl(curl_request).empty())
       return false;
    return true;
 
@@ -58,12 +58,12 @@ const std::string simpleQuery(ES& es)
    curl_request.type = "POST";
    curl_request.query = es.query;
 
-   return doCurl(std::move(curl_request));
+   return doCurl(curl_request);
 }
 
 bool SendBulk(ES&& es)
 {
-   std::string bulking = joinBulkLines(std::move(es.bulk_lines));
+   std::string bulking = joinBulkLines(es.bulk_lines);
 
    graphene::utilities::CurlRequest curl_request;
    curl_request.handler = es.curl;
@@ -72,14 +72,14 @@ bool SendBulk(ES&& es)
    curl_request.type = "POST";
    curl_request.query = std::move(bulking);
 
-   auto curlResponse = doCurl(std::move(curl_request));
+   auto curlResponse = doCurl(curl_request);
 
    if(handleBulkResponse(getResponseCode(curl_request.handler)))
       return true;
    return false;
 }
 
-const std::string joinBulkLines(const std::vector<std::string>&& bulk)
+const std::string joinBulkLines(const std::vector<std::string>& bulk)
 {
    auto bulking = boost::algorithm::join(bulk, "\n");
    bulking = bulking + "\n";
@@ -138,7 +138,7 @@ bool deleteAll(ES& es)
    curl_request.auth = es.auth;
    curl_request.type = "DELETE";
 
-   auto curl_response = doCurl(std::move(curl_request));
+   auto curl_response = doCurl(curl_request);
    if(curl_response.empty())
       return false;
    else
@@ -152,7 +152,7 @@ const std::string getEndPoint(ES& es)
    curl_request.auth = es.auth;
    curl_request.type = "GET";
 
-   return doCurl(std::move(curl_request));
+   return doCurl(curl_request);
 }
 
 const std::string generateIndexName(const fc::time_point_sec& block_date, const std::string& _elasticsearch_index_prefix)
@@ -164,7 +164,7 @@ const std::string generateIndexName(const fc::time_point_sec& block_date, const 
    return index_name;
 }
 
-const std::string doCurl(CurlRequest&& curl)
+const std::string doCurl(CurlRequest& curl)
 {
    std::string CurlReadBuffer;
    struct curl_slist *headers = NULL;

--- a/libraries/utilities/elasticsearch.cpp
+++ b/libraries/utilities/elasticsearch.cpp
@@ -119,7 +119,7 @@ bool handleBulkResponse(long http_code)
    return true;
 }
 
-const std::vector<std::string> createBulk(const fc::mutable_variant_object& bulk_header, const std::string&& data)
+const std::vector<std::string> createBulk(const fc::mutable_variant_object& bulk_header, std::string&& data)
 {
    std::vector<std::string> bulk;
    fc::mutable_variant_object final_bulk_header;

--- a/libraries/utilities/elasticsearch.cpp
+++ b/libraries/utilities/elasticsearch.cpp
@@ -138,7 +138,7 @@ bool deleteAll(ES& es)
    curl_request.auth = es.auth;
    curl_request.type = "DELETE";
 
-   auto curl_response =  doCurl(std::move(curl_request));
+   auto curl_response = doCurl(std::move(curl_request));
    if(curl_response.empty())
       return false;
    else

--- a/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
+++ b/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
@@ -54,7 +54,7 @@ namespace graphene { namespace utilities {
    };
 
    bool SendBulk(ES&& es);
-   const std::vector<std::string> createBulk(const fc::mutable_variant_object& bulk_header, const std::string&& data);
+   const std::vector<std::string> createBulk(const fc::mutable_variant_object& bulk_header, std::string&& data);
    bool checkES(ES& es);
    const std::string simpleQuery(ES& es);
    bool deleteAll(ES& es);

--- a/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
+++ b/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
@@ -61,8 +61,8 @@ namespace graphene { namespace utilities {
    bool handleBulkResponse(long http_code);
    const std::string getEndPoint(ES& es);
    const std::string generateIndexName(const fc::time_point_sec& block_date, const std::string& _elasticsearch_index_prefix);
-   const std::string doCurl(CurlRequest&& curl);
-   const std::string joinBulkLines(const std::vector<std::string>&& bulk);
+   const std::string doCurl(CurlRequest& curl);
+   const std::string joinBulkLines(const std::vector<std::string>& bulk);
    long getResponseCode(CURL *handler);
 
 } } // end namespace graphene::utilities

--- a/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
+++ b/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
@@ -58,7 +58,7 @@ namespace graphene { namespace utilities {
    bool checkES(ES& es);
    const std::string simpleQuery(ES& es);
    bool deleteAll(ES& es);
-   bool handleBulkResponse(long http_code, const std::string& CurlReadBuffer);
+   bool handleBulkResponse(long http_code);
    const std::string getEndPoint(ES& es);
    const std::string generateIndexName(const fc::time_point_sec& block_date, const std::string& _elasticsearch_index_prefix);
    const std::string doCurl(CurlRequest&& curl);

--- a/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
+++ b/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
@@ -61,8 +61,8 @@ namespace graphene { namespace utilities {
    bool handleBulkResponse(long http_code, const std::string& CurlReadBuffer);
    const std::string getEndPoint(ES& es);
    const std::string generateIndexName(const fc::time_point_sec& block_date, const std::string& _elasticsearch_index_prefix);
-   const std::string doCurl(CurlRequest& curl);
-   const std::string joinBulkLines(const std::vector<std::string>& bulk);
+   const std::string doCurl(CurlRequest&& curl);
+   const std::string joinBulkLines(const std::vector<std::string>&& bulk);
    long getResponseCode(CURL *handler);
 
 } } // end namespace graphene::utilities

--- a/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
+++ b/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
@@ -58,7 +58,7 @@ namespace graphene { namespace utilities {
    bool checkES(ES& es);
    const std::string simpleQuery(ES& es);
    bool deleteAll(ES& es);
-   bool handleBulkResponse(long http_code);
+   bool handleBulkResponse(long http_code, const std::string& CurlReadBuffer);
    const std::string getEndPoint(ES& es);
    const std::string generateIndexName(const fc::time_point_sec& block_date, const std::string& _elasticsearch_index_prefix);
    const std::string doCurl(CurlRequest& curl);

--- a/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
+++ b/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
@@ -53,7 +53,7 @@ namespace graphene { namespace utilities {
          std::string query;
    };
 
-   bool SendBulk(ES& es);
+   bool SendBulk(ES&& es);
    const std::vector<std::string> createBulk(const fc::mutable_variant_object& bulk_header, const std::string&& data);
    bool checkES(ES& es);
    const std::string simpleQuery(ES& es);

--- a/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
+++ b/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
@@ -54,7 +54,7 @@ namespace graphene { namespace utilities {
    };
 
    bool SendBulk(ES& es);
-   const std::vector<std::string> createBulk(const fc::mutable_variant_object& bulk_header, const std::string& data);
+   const std::vector<std::string> createBulk(const fc::mutable_variant_object& bulk_header, const std::string&& data);
    bool checkES(ES& es);
    const std::string simpleQuery(ES& es);
    bool deleteAll(ES& es);


### PR DESCRIPTION
This is an attempt to apply a `move` instead of `copy` in the high frequency action of appending an operation(2 lines) into the `bulk_lines` vector. 
This is part of https://github.com/bitshares/bitshares-core/issues/1224 , mainly for review and see if we can apply to some other places if good enough.

It also reserve the size of the vector, should be better than extending it dynamically with each new op. The `bulk_lines` can only be of 2 different sizes, depending on if we are in sync or not so we have to make a check on each block but the reserve itself should be only executed 2 times(1- we add replay size 2- change to "in sync" size).