### PR TITLE
Improve block generating performance

### DIFF
--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -162,7 +162,8 @@ namespace graphene { namespace app {
     void network_broadcast_api::broadcast_transaction(const signed_transaction& trx)
     {
        trx.validate();
-       _app.chain_database()->push_transaction(trx);
+       const auto& chain_db = _app.chain_database();
+       chain_db->push_transaction( signed_transaction_with_signees( trx, chain_db->get_chain_id() ) );
        if( _app.p2p_node() != nullptr )
           _app.p2p_node()->broadcast_transaction(trx);
     }
@@ -188,7 +189,8 @@ namespace graphene { namespace app {
     {
        trx.validate();
        _callbacks[trx.id()] = cb;
-       _app.chain_database()->push_transaction(trx);
+       const auto& chain_db = _app.chain_database();
+       chain_db->push_transaction( signed_transaction_with_signees( trx, chain_db->get_chain_id() ) );
        if( _app.p2p_node() != nullptr )
           _app.p2p_node()->broadcast_transaction(trx);
     }

--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -567,7 +567,7 @@ void application_impl::handle_transaction(const graphene::net::trx_message& tran
       trx_count = 0;
    }
 
-   _chain_db->push_transaction( transaction_message.trx );
+   _chain_db->push_transaction( signed_transaction_with_signees( transaction_message.trx, get_chain_id() ) );
 } FC_CAPTURE_AND_RETHROW( (transaction_message) ) }
 
 void application_impl::handle_message(const message& message_to_process)

--- a/libraries/chain/db_block.cpp
+++ b/libraries/chain/db_block.cpp
@@ -360,7 +360,7 @@ signed_block database::_generate_block(
    // pop pending state (reset to head block state)
    for( const processed_transaction_with_signees& tx : _pending_tx )
    {
-      size_t new_total_size = total_block_size + fc::raw::pack_size( tx );
+      size_t new_total_size = total_block_size + fc::raw::pack_size( (const processed_transaction&)tx );
 
       // postpone transaction if it would make block too big
       if( new_total_size >= maximum_block_size )
@@ -378,7 +378,7 @@ signed_block database::_generate_block(
          // We have to recompute pack_size(ptx) because it may be different
          // than pack_size(tx) (i.e. if one or more results increased
          // their size)
-         total_block_size += fc::raw::pack_size( ptx );
+         total_block_size += fc::raw::pack_size( (const processed_transaction&)ptx );
          pending_block.transactions.push_back( ptx );
       }
       catch ( const fc::exception& e )

--- a/libraries/chain/db_block.cpp
+++ b/libraries/chain/db_block.cpp
@@ -415,7 +415,7 @@ signed_block database::_generate_block(
       FC_ASSERT( fc::raw::pack_size(pending_block) <= get_global_properties().parameters.maximum_block_size );
    }
 
-   push_block( pending_block, skip );
+   push_block( pending_block, skip | skip_transaction_signatures ); // skip authority check when pushing self-generated blocks
 
    return pending_block;
 } FC_CAPTURE_AND_RETHROW( (witness_id) ) }

--- a/libraries/chain/include/graphene/chain/config.hpp
+++ b/libraries/chain/include/graphene/chain/config.hpp
@@ -121,7 +121,7 @@
 #define GRAPHENE_RECENTLY_MISSED_COUNT_INCREMENT             4
 #define GRAPHENE_RECENTLY_MISSED_COUNT_DECREMENT             3
 
-#define GRAPHENE_CURRENT_DB_VERSION                          "BTS2.17"
+#define GRAPHENE_CURRENT_DB_VERSION                          "BTS2.18"
 
 #define GRAPHENE_IRREVERSIBLE_THRESHOLD                      (70 * GRAPHENE_1_PERCENT)
 

--- a/libraries/chain/include/graphene/chain/database.hpp
+++ b/libraries/chain/include/graphene/chain/database.hpp
@@ -117,13 +117,13 @@ namespace graphene { namespace chain {
           *  @return true if the block is in our fork DB or saved to disk as
           *  part of the official chain, otherwise return false
           */
-         bool                       is_known_block( const block_id_type& id )const;
-         bool                       is_known_transaction( const transaction_id_type& id )const;
-         block_id_type              get_block_id_for_num( uint32_t block_num )const;
-         optional<signed_block>     fetch_block_by_id( const block_id_type& id )const;
-         optional<signed_block>     fetch_block_by_number( uint32_t num )const;
-         const signed_transaction&  get_recent_transaction( const transaction_id_type& trx_id )const;
-         std::vector<block_id_type> get_block_ids_on_fork(block_id_type head_of_fork) const;
+         bool                                    is_known_block( const block_id_type& id )const;
+         bool                                    is_known_transaction( const transaction_id_type& id )const;
+         block_id_type                           get_block_id_for_num( uint32_t block_num )const;
+         optional<signed_block>                  fetch_block_by_id( const block_id_type& id )const;
+         optional<signed_block>                  fetch_block_by_number( uint32_t num )const;
+         const signed_transaction_with_signees&  get_recent_transaction( const transaction_id_type& trx_id )const;
+         std::vector<block_id_type>              get_block_ids_on_fork(block_id_type head_of_fork) const;
 
          /**
           *  Calculate the percent of block production slots that were missed in the
@@ -136,12 +136,13 @@ namespace graphene { namespace chain {
          bool before_last_checkpoint()const;
 
          bool push_block( const signed_block& b, uint32_t skip = skip_nothing );
-         processed_transaction push_transaction( const signed_transaction& trx, uint32_t skip = skip_nothing );
+         processed_transaction_with_signees push_transaction( const signed_transaction_with_signees& trx,
+                                                              uint32_t skip = skip_nothing );
          bool _push_block( const signed_block& b );
-         processed_transaction _push_transaction( const signed_transaction& trx );
+         processed_transaction_with_signees _push_transaction( const signed_transaction_with_signees& trx );
 
          ///@throws fc::exception if the proposed transaction fails to apply.
-         processed_transaction push_proposal( const proposal_object& proposal );
+         processed_transaction_with_signees push_proposal( const proposal_object& proposal );
 
          signed_block generate_block(
             const fc::time_point_sec when,
@@ -402,12 +403,12 @@ namespace graphene { namespace chain {
           *  This method validates transactions without adding it to the pending state.
           *  @return true if the transaction would validate
           */
-         processed_transaction validate_transaction( const signed_transaction& trx );
+         processed_transaction_with_signees validate_transaction( const signed_transaction_with_signees& trx );
 
 
          /** when popping a block, the transactions that were removed get cached here so they
           * can be reapplied at the proper time */
-         std::deque< signed_transaction >       _popped_tx;
+         std::deque< signed_transaction_with_signees >       _popped_tx;
 
          /**
           * @}
@@ -434,13 +435,16 @@ namespace graphene { namespace chain {
 
        public:
          // these were formerly private, but they have a fairly well-defined API, so let's make them public
-         void                  apply_block( const signed_block& next_block, uint32_t skip = skip_nothing );
-         processed_transaction apply_transaction( const signed_transaction& trx, uint32_t skip = skip_nothing );
-         operation_result      apply_operation( transaction_evaluation_state& eval_state, const operation& op );
+         void                               apply_block( const signed_block& next_block, uint32_t skip = skip_nothing );
+         processed_transaction_with_signees apply_transaction( const signed_transaction_with_signees& trx,
+                                                               uint32_t skip = skip_nothing );
+         operation_result                   apply_operation( transaction_evaluation_state& eval_state, const operation& op );
       private:
-         void                  _apply_block( const signed_block& next_block );
-         processed_transaction _apply_transaction( const signed_transaction& trx );
-         void                  _cancel_bids_and_revive_mpa( const asset_object& bitasset, const asset_bitasset_data_object& bad );
+         void                               _apply_block( const signed_block& next_block );
+         processed_transaction_with_signees _apply_transaction( const signed_transaction_with_signees& trx );
+
+         void                               _cancel_bids_and_revive_mpa( const asset_object& bitasset,
+                                                                         const asset_bitasset_data_object& bad );
 
          ///Steps involved in applying a new block
          ///@{
@@ -487,8 +491,8 @@ namespace graphene { namespace chain {
          ///@}
          ///@}
 
-         vector< processed_transaction >        _pending_tx;
-         fork_database                          _fork_db;
+         vector< processed_transaction_with_signees >        _pending_tx;
+         fork_database                                       _fork_db;
 
          /**
           *  Note: we can probably store blocks by block num rather than

--- a/libraries/chain/include/graphene/chain/db_with.hpp
+++ b/libraries/chain/include/graphene/chain/db_with.hpp
@@ -68,7 +68,7 @@ struct skip_flags_restorer
  */
 struct pending_transactions_restorer
 {
-   pending_transactions_restorer( database& db, std::vector<processed_transaction>&& pending_transactions )
+   pending_transactions_restorer( database& db, std::vector<processed_transaction_with_signees>&& pending_transactions )
       : _db(db), _pending_transactions( std::move(pending_transactions) )
    {
       _db.clear_pending();
@@ -88,7 +88,7 @@ struct pending_transactions_restorer
          }
       }
       _db._popped_tx.clear();
-      for( const processed_transaction& tx : _pending_transactions )
+      for( const processed_transaction_with_signees& tx : _pending_transactions )
       {
          try
          {
@@ -109,7 +109,7 @@ struct pending_transactions_restorer
    }
 
    database& _db;
-   std::vector< processed_transaction > _pending_transactions;
+   std::vector< processed_transaction_with_signees > _pending_transactions;
 };
 
 /**
@@ -139,7 +139,7 @@ void with_skip_flags(
 template< typename Lambda >
 void without_pending_transactions(
    database& db,
-   std::vector<processed_transaction>&& pending_transactions,
+   std::vector<processed_transaction_with_signees>&& pending_transactions,
    Lambda callback )
 {
     pending_transactions_restorer restorer( db, std::move(pending_transactions) );

--- a/libraries/chain/include/graphene/chain/protocol/transaction.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/transaction.hpp
@@ -185,8 +185,17 @@ namespace graphene { namespace chain {
       signed_transaction_with_signees( const signed_transaction& tx ) : signed_transaction(tx) {}
 
       signed_transaction_with_signees( const signed_transaction& tx, const chain_id_type& chain_id )
-      : signed_transaction(tx), signees( get_signature_keys( chain_id ) )
-      {}
+      : signed_transaction(tx)
+      {
+         signees = signed_transaction::get_signature_keys( chain_id );
+      }
+
+      signed_transaction_with_signees( const signed_transaction_with_signees& tx, const chain_id_type& chain_id )
+      : signed_transaction_with_signees(tx)
+      {
+         if( signees.empty() && !signatures.empty() )
+            signees = signed_transaction::get_signature_keys( chain_id );
+      }
 
       virtual ~signed_transaction_with_signees() {}
 
@@ -249,8 +258,17 @@ namespace graphene { namespace chain {
       {}
 
       processed_transaction_with_signees( const processed_transaction& tx, const chain_id_type& chain_id )
-      : processed_transaction(tx), signees( get_signature_keys( chain_id ) )
-      {}
+      : processed_transaction(tx)
+      {
+         signees = signed_transaction::get_signature_keys( chain_id );
+      }
+
+      processed_transaction_with_signees( const processed_transaction_with_signees& tx, const chain_id_type& chain_id )
+      : processed_transaction_with_signees(tx)
+      {
+         if( signees.empty() && !signatures.empty() )
+            signees = signed_transaction::get_signature_keys( chain_id );
+      }
 
       virtual ~processed_transaction_with_signees() {}
 

--- a/libraries/chain/include/graphene/chain/protocol/transaction.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/transaction.hpp
@@ -175,6 +175,7 @@ namespace graphene { namespace chain {
       void clear() { operations.clear(); signatures.clear(); }
    };
 
+   struct processed_transaction_with_signees;
    /**
     *  @brief extract public keys from signatures of a transaction
     */
@@ -196,6 +197,8 @@ namespace graphene { namespace chain {
          if( signees.empty() && !signatures.empty() )
             signees = signed_transaction::get_signature_keys( chain_id );
       }
+
+      signed_transaction_with_signees( const processed_transaction_with_signees& tx );
 
       virtual ~signed_transaction_with_signees() {}
 

--- a/libraries/chain/include/graphene/chain/transaction_object.hpp
+++ b/libraries/chain/include/graphene/chain/transaction_object.hpp
@@ -50,8 +50,8 @@ namespace graphene { namespace chain {
          static const uint8_t space_id = implementation_ids;
          static const uint8_t type_id  = impl_transaction_object_type;
 
-         signed_transaction  trx;
-         transaction_id_type trx_id;
+         signed_transaction_with_signees  trx;
+         transaction_id_type              trx_id;
 
          time_point_sec get_expiration()const { return trx.expiration; }
    };

--- a/libraries/chain/protocol/transaction.cpp
+++ b/libraries/chain/protocol/transaction.cpp
@@ -388,4 +388,8 @@ void signed_transaction::verify_authority(
    graphene::chain::verify_authority( operations, get_signature_keys( chain_id ), get_active, get_owner, max_recursion );
 } FC_CAPTURE_AND_RETHROW( (*this) ) }
 
+signed_transaction_with_signees::signed_transaction_with_signees( const processed_transaction_with_signees& tx )
+: signed_transaction(tx), signees( tx.signees )
+{}
+
 } } // graphene::chain

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -1256,7 +1256,7 @@ bool _push_block( database& db, const signed_block& b, uint32_t skip_flags /* = 
 
 processed_transaction _push_transaction( database& db, const signed_transaction& tx, uint32_t skip_flags /* = 0 */ )
 { try {
-   auto pt = db.push_transaction( tx, skip_flags );
+   auto pt = db.push_transaction( signed_transaction_with_signees( tx, db.get_chain_id() ), skip_flags );
    database_fixture::verify_asset_supplies(db);
    return pt;
 } FC_CAPTURE_AND_RETHROW((tx)) }

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -1937,7 +1937,7 @@ BOOST_AUTO_TEST_CASE( reserve_asset_test )
          asset_reserve_operation op;
          op.payer = payer;
          op.amount_to_reserve = amount_to_reserve;
-         transaction tx;
+         signed_transaction tx;
          tx.operations.push_back( op );
          set_expiration( db, tx );
          db.push_transaction( tx, database::skip_authority_check | database::skip_tapos_check | database::skip_transaction_signatures );
@@ -1949,7 +1949,7 @@ BOOST_AUTO_TEST_CASE( reserve_asset_test )
          op.issuer = amount.asset_id(db).issuer;
          op.asset_to_issue = amount;
          op.issue_to_account = recipient.id;
-         transaction tx;
+         signed_transaction tx;
          tx.operations.push_back( op );
          set_expiration( db, tx );
          db.push_transaction( tx, database::skip_authority_check | database::skip_tapos_check | database::skip_transaction_signatures );
@@ -2040,7 +2040,7 @@ BOOST_AUTO_TEST_CASE( cover_with_collateral_test )
          op.funding_account = acct;
          op.delta_collateral = delta_collateral;
          op.delta_debt = delta_debt;
-         transaction tx;
+         signed_transaction tx;
          tx.operations.push_back( op );
          set_expiration( db, tx );
          db.push_transaction( tx, database::skip_authority_check | database::skip_tapos_check | database::skip_transaction_signatures );
@@ -2182,7 +2182,7 @@ BOOST_AUTO_TEST_CASE( vesting_balance_withdraw_test )
       asset amount, uint32_t vesting_seconds, uint32_t elapsed_seconds
       ) -> const vesting_balance_object&
    {
-      transaction tx;
+      signed_transaction tx;
 
       vesting_balance_create_operation create_op;
       create_op.fee = core.amount( 0 );

--- a/tests/tests/operation_tests2.cpp
+++ b/tests/tests/operation_tests2.cpp
@@ -1921,7 +1921,7 @@ BOOST_AUTO_TEST_CASE(zero_second_vbo)
          asset_reserve_operation op;
          op.payer = alice_id;
          op.amount_to_reserve = asset(int64_t(100000) * 1000 * 1000 * 1000);
-         transaction tx;
+         signed_transaction tx;
          tx.operations.push_back( op );
          set_expiration( db, tx );
          db.push_transaction( tx, database::skip_authority_check | database::skip_tapos_check | database::skip_transaction_signatures );


### PR DESCRIPTION
Improved block generating performance by caching public keys extracted from transaction signatures which reduces number of ECDSA verification calls.

Side effect: due to additional data copy, replay is slightly slower, profiling data says the difference is around 4%.

Perhaps todo:
* extract signing keys for popped transactions in the first place.