### PR TITLE
Fix : Segmentation fault when running several witness nodes on the same machine

### DIFF
--- a/libraries/chain/db_getter.cpp
+++ b/libraries/chain/db_getter.cpp
@@ -99,7 +99,7 @@ node_property_object& database::node_properties()
 
 uint32_t database::last_non_undoable_block_num() const
 {
-   return head_block_num() - _undo_db.size();
+   return head_block_num() - ( _undo_db.size() - _undo_db.active_sessions());
 }
 
 const account_statistics_object& database::get_account_stats_by_owner( account_id_type owner )const

--- a/libraries/chain/db_getter.cpp
+++ b/libraries/chain/db_getter.cpp
@@ -99,7 +99,14 @@ node_property_object& database::node_properties()
 
 uint32_t database::last_non_undoable_block_num() const
 {
-   return head_block_num() - ( _undo_db.size() - _undo_db.active_sessions());
+   //see https://github.com/bitshares/bitshares-core/issues/377
+   /*
+   There is a case when a value of undo_db.size() is greater then head_block_num(),
+   and as result we get a wrong value for last_non_undoable_block_num.
+   To resolve it we should take into account a number of active_sessions in calculations of
+   last_non_undoable_block_num (active sessions are related to a new block which is under generation).
+   */
+   return head_block_num() - ( _undo_db.size() - _undo_db.active_sessions() );
 }
 
 const account_statistics_object& database::get_account_stats_by_owner( account_id_type owner )const

--- a/libraries/db/include/graphene/db/undo_database.hpp
+++ b/libraries/db/include/graphene/db/undo_database.hpp
@@ -129,6 +129,7 @@ namespace graphene { namespace db {
          std::size_t size()const { return _stack.size(); }
          void set_max_size(size_t new_max_size) { _max_size = new_max_size; }
          size_t max_size()const { return _max_size; }
+         uint32_t active_sessions()const { return _active_sessions; }
 
          const undo_state& head()const;
 


### PR DESCRIPTION
#377
There is a case when a value of undo_db.size() is greater then head_block_num(), and as result we get a wrong value for last_non_undoable_block_num. To resolve it we should take into account a number of active_sessions in calculations of last_non_undoable_block_num (active sessions are related to a new block which is under generation).