### PR TITLE
add asset names and amount/price calculations to additional

### DIFF
--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -43,7 +43,6 @@ class elasticsearch_plugin_impl
       virtual ~elasticsearch_plugin_impl();
 
       bool update_account_histories( const signed_block& b );
-      void populatePowTable();
 
       graphene::chain::database& database()
       {
@@ -73,7 +72,21 @@ class elasticsearch_plugin_impl
       std::string bulk_line;
       std::string index_name;
       bool is_sync = false;
-      map <uint8_t , uint64_t > lookup_pow_table;
+      const double lookup_pow_table[13] = {
+              1,
+              10,
+              100,
+              1000,
+              10000,
+              100000,
+              1000000,
+              10000000,
+              100000000,
+              1000000000,
+              10000000000,
+              100000000000,
+              1000000000000
+      };
    private:
       bool add_elasticsearch( const account_id_type account_id, const optional<operation_history_object>& oho );
       const account_transaction_history_object& addNewEntry(const account_statistics_object& stats_obj,
@@ -384,23 +397,6 @@ void elasticsearch_plugin_impl::populateESstruct()
    es.query = "";
 }
 
-void elasticsearch_plugin_impl::populatePowTable()
-{
-   lookup_pow_table[0] = 1;
-   lookup_pow_table[1] = 10;
-   lookup_pow_table[2] = 100;
-   lookup_pow_table[3] = 1000;
-   lookup_pow_table[4] = 10000;
-   lookup_pow_table[5] = 100000;
-   lookup_pow_table[6] = 1000000;
-   lookup_pow_table[7] = 10000000;
-   lookup_pow_table[8] = 100000000;
-   lookup_pow_table[9] = 1000000000;
-   lookup_pow_table[10] = 10000000000;
-   lookup_pow_table[11] = 100000000000;
-   lookup_pow_table[12] = 1000000000000;
-}
-
 } // end namespace detail
 
 elasticsearch_plugin::elasticsearch_plugin() :
@@ -478,8 +474,6 @@ void elasticsearch_plugin::plugin_startup()
    if(!graphene::utilities::checkES(es))
       FC_THROW_EXCEPTION(fc::exception, "ES database is not up in url ${url}", ("url", my->_elasticsearch_node_url));
    ilog("elasticsearch ACCOUNT HISTORY: plugin_startup() begin");
-
-   my->populatePowTable();
 }
 
 } }

--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -227,23 +227,37 @@ void elasticsearch_plugin_impl::doBlock(uint32_t trx_in_block, const signed_bloc
 
 void elasticsearch_plugin_impl::doVisitor(const optional <operation_history_object>& oho)
 {
+   graphene::chain::database& db = database();
+
    operation_visitor o_v;
    oho->op.visit(o_v);
 
    vs.fee_data.asset = o_v.fee_asset;
+   vs.fee_data.asset_name = o_v.fee_asset(db).symbol;
    vs.fee_data.amount = o_v.fee_amount;
+   vs.fee_data.amount_calculated = (float)(o_v.fee_amount.value)/pow(10, o_v.fee_asset(db).precision);
 
    vs.transfer_data.asset = o_v.transfer_asset_id;
+   vs.transfer_data.asset_name = o_v.transfer_asset_id(db).symbol;
    vs.transfer_data.amount = o_v.transfer_amount;
+   vs.transfer_data.amount_calculated = (float)(o_v.transfer_amount.value)/(pow(10, o_v.transfer_asset_id(db).precision));
    vs.transfer_data.from = o_v.transfer_from;
    vs.transfer_data.to = o_v.transfer_to;
 
    vs.fill_data.order_id = o_v.fill_order_id;
    vs.fill_data.account_id = o_v.fill_account_id;
    vs.fill_data.pays_asset_id = o_v.fill_pays_asset_id;
+   vs.fill_data.pays_asset_name = o_v.fill_pays_asset_id(db).symbol;
    vs.fill_data.pays_amount = o_v.fill_pays_amount;
+   vs.fill_data.pays_amount_calculated = (float)(o_v.fill_pays_amount.value)/pow(10, o_v.fill_pays_asset_id(db).precision);
    vs.fill_data.receives_asset_id = o_v.fill_receives_asset_id;
+   vs.fill_data.receives_asset_name = o_v.fill_receives_asset_id(db).symbol;
    vs.fill_data.receives_amount = o_v.fill_receives_amount;
+   vs.fill_data.receives_amount_calculated = (float)(o_v.fill_receives_amount.value)/pow(10, o_v.fill_receives_asset_id(db).precision);
+
+   float fill_price = (float)(o_v.fill_receives_amount.value/o_v.fill_receives_asset_id(db).precision) /
+           (float)(o_v.fill_pays_amount.value / o_v.fill_pays_asset_id(db).precision);
+   vs.fill_data.fill_price_calculated = fill_price;
    vs.fill_data.fill_price = o_v.fill_fill_price;
    vs.fill_data.is_maker = o_v.fill_is_maker;
 }

--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -235,12 +235,12 @@ void elasticsearch_plugin_impl::doVisitor(const optional <operation_history_obje
    vs.fee_data.asset = o_v.fee_asset;
    vs.fee_data.asset_name = o_v.fee_asset(db).symbol;
    vs.fee_data.amount = o_v.fee_amount;
-   vs.fee_data.amount_units = (o_v.fee_amount.value)/asset::scaled_precision(o_v.fee_asset(db).precision).value;
+   vs.fee_data.amount_units = (o_v.fee_amount.value)/(double)asset::scaled_precision(o_v.fee_asset(db).precision).value;
 
    vs.transfer_data.asset = o_v.transfer_asset_id;
    vs.transfer_data.asset_name = o_v.transfer_asset_id(db).symbol;
    vs.transfer_data.amount = o_v.transfer_amount;
-   vs.transfer_data.amount_units = (o_v.transfer_amount.value)/asset::scaled_precision(o_v.transfer_asset_id(db).precision).value;
+   vs.transfer_data.amount_units = (o_v.transfer_amount.value)/(double)asset::scaled_precision(o_v.transfer_asset_id(db).precision).value;
    vs.transfer_data.from = o_v.transfer_from;
    vs.transfer_data.to = o_v.transfer_to;
 
@@ -249,14 +249,14 @@ void elasticsearch_plugin_impl::doVisitor(const optional <operation_history_obje
    vs.fill_data.pays_asset_id = o_v.fill_pays_asset_id;
    vs.fill_data.pays_asset_name = o_v.fill_pays_asset_id(db).symbol;
    vs.fill_data.pays_amount = o_v.fill_pays_amount;
-   vs.fill_data.pays_amount_units = (o_v.fill_pays_amount.value)/asset::scaled_precision(o_v.fill_pays_asset_id(db).precision).value;
+   vs.fill_data.pays_amount_units = (o_v.fill_pays_amount.value)/(double)asset::scaled_precision(o_v.fill_pays_asset_id(db).precision).value;
    vs.fill_data.receives_asset_id = o_v.fill_receives_asset_id;
    vs.fill_data.receives_asset_name = o_v.fill_receives_asset_id(db).symbol;
    vs.fill_data.receives_amount = o_v.fill_receives_amount;
-   vs.fill_data.receives_amount_units = (o_v.fill_receives_amount.value)/asset::scaled_precision(o_v.fill_receives_asset_id(db).precision).value;
+   vs.fill_data.receives_amount_units = (o_v.fill_receives_amount.value)/(double)asset::scaled_precision(o_v.fill_receives_asset_id(db).precision).value;
 
-   auto fill_price = (double)(o_v.fill_receives_amount.value/asset::scaled_precision(o_v.fill_receives_asset_id(db).precision).value) /
-           (o_v.fill_pays_amount.value / asset::scaled_precision(o_v.fill_pays_asset_id(db).precision).value);
+   auto fill_price = (o_v.fill_receives_amount.value/(double)asset::scaled_precision(o_v.fill_receives_asset_id(db).precision).value) /
+           (o_v.fill_pays_amount.value/(double)asset::scaled_precision(o_v.fill_pays_asset_id(db).precision).value);
    vs.fill_data.fill_price_units = fill_price;
    vs.fill_data.fill_price = o_v.fill_fill_price;
    vs.fill_data.is_maker = o_v.fill_is_maker;

--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -72,21 +72,6 @@ class elasticsearch_plugin_impl
       std::string bulk_line;
       std::string index_name;
       bool is_sync = false;
-      const double lookup_pow_table[13] = {
-              1,
-              10,
-              100,
-              1000,
-              10000,
-              100000,
-              1000000,
-              10000000,
-              100000000,
-              1000000000,
-              10000000000,
-              100000000000,
-              1000000000000
-      };
    private:
       bool add_elasticsearch( const account_id_type account_id, const optional<operation_history_object>& oho );
       const account_transaction_history_object& addNewEntry(const account_statistics_object& stats_obj,
@@ -250,12 +235,12 @@ void elasticsearch_plugin_impl::doVisitor(const optional <operation_history_obje
    vs.fee_data.asset = o_v.fee_asset;
    vs.fee_data.asset_name = o_v.fee_asset(db).symbol;
    vs.fee_data.amount = o_v.fee_amount;
-   vs.fee_data.amount_units = (double)(o_v.fee_amount.value)/lookup_pow_table[o_v.fee_asset(db).precision];
+   vs.fee_data.amount_units = (o_v.fee_amount.value)/asset::scaled_precision(o_v.fee_asset(db).precision).value;
 
    vs.transfer_data.asset = o_v.transfer_asset_id;
    vs.transfer_data.asset_name = o_v.transfer_asset_id(db).symbol;
    vs.transfer_data.amount = o_v.transfer_amount;
-   vs.transfer_data.amount_units = (double)(o_v.transfer_amount.value)/lookup_pow_table[o_v.transfer_asset_id(db).precision];
+   vs.transfer_data.amount_units = (o_v.transfer_amount.value)/asset::scaled_precision(o_v.transfer_asset_id(db).precision).value;
    vs.transfer_data.from = o_v.transfer_from;
    vs.transfer_data.to = o_v.transfer_to;
 
@@ -264,14 +249,14 @@ void elasticsearch_plugin_impl::doVisitor(const optional <operation_history_obje
    vs.fill_data.pays_asset_id = o_v.fill_pays_asset_id;
    vs.fill_data.pays_asset_name = o_v.fill_pays_asset_id(db).symbol;
    vs.fill_data.pays_amount = o_v.fill_pays_amount;
-   vs.fill_data.pays_amount_units = (double)(o_v.fill_pays_amount.value)/lookup_pow_table[o_v.fill_pays_asset_id(db).precision];
+   vs.fill_data.pays_amount_units = (o_v.fill_pays_amount.value)/asset::scaled_precision(o_v.fill_pays_asset_id(db).precision).value;
    vs.fill_data.receives_asset_id = o_v.fill_receives_asset_id;
    vs.fill_data.receives_asset_name = o_v.fill_receives_asset_id(db).symbol;
    vs.fill_data.receives_amount = o_v.fill_receives_amount;
-   vs.fill_data.receives_amount_units = (double)(o_v.fill_receives_amount.value)/lookup_pow_table[o_v.fill_receives_asset_id(db).precision];
+   vs.fill_data.receives_amount_units = (o_v.fill_receives_amount.value)/asset::scaled_precision(o_v.fill_receives_asset_id(db).precision).value;
 
-   auto fill_price = (double)(o_v.fill_receives_amount.value/lookup_pow_table[o_v.fill_receives_asset_id(db).precision]) /
-           (double)(o_v.fill_pays_amount.value / lookup_pow_table[o_v.fill_pays_asset_id(db).precision]);
+   auto fill_price = (double)(o_v.fill_receives_amount.value/asset::scaled_precision(o_v.fill_receives_asset_id(db).precision).value) /
+           (o_v.fill_pays_amount.value / asset::scaled_precision(o_v.fill_pays_asset_id(db).precision).value);
    vs.fill_data.fill_price_units = fill_price;
    vs.fill_data.fill_price = o_v.fill_fill_price;
    vs.fill_data.is_maker = o_v.fill_is_maker;

--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -235,12 +235,12 @@ void elasticsearch_plugin_impl::doVisitor(const optional <operation_history_obje
    vs.fee_data.asset = o_v.fee_asset;
    vs.fee_data.asset_name = o_v.fee_asset(db).symbol;
    vs.fee_data.amount = o_v.fee_amount;
-   vs.fee_data.amount_calculated = (float)(o_v.fee_amount.value)/pow(10, o_v.fee_asset(db).precision);
+   vs.fee_data.amount_units = (float)(o_v.fee_amount.value)/pow(10, o_v.fee_asset(db).precision);
 
    vs.transfer_data.asset = o_v.transfer_asset_id;
    vs.transfer_data.asset_name = o_v.transfer_asset_id(db).symbol;
    vs.transfer_data.amount = o_v.transfer_amount;
-   vs.transfer_data.amount_calculated = (float)(o_v.transfer_amount.value)/(pow(10, o_v.transfer_asset_id(db).precision));
+   vs.transfer_data.amount_units = (float)(o_v.transfer_amount.value)/(pow(10, o_v.transfer_asset_id(db).precision));
    vs.transfer_data.from = o_v.transfer_from;
    vs.transfer_data.to = o_v.transfer_to;
 
@@ -249,15 +249,15 @@ void elasticsearch_plugin_impl::doVisitor(const optional <operation_history_obje
    vs.fill_data.pays_asset_id = o_v.fill_pays_asset_id;
    vs.fill_data.pays_asset_name = o_v.fill_pays_asset_id(db).symbol;
    vs.fill_data.pays_amount = o_v.fill_pays_amount;
-   vs.fill_data.pays_amount_calculated = (float)(o_v.fill_pays_amount.value)/pow(10, o_v.fill_pays_asset_id(db).precision);
+   vs.fill_data.pays_amount_units = (float)(o_v.fill_pays_amount.value)/pow(10, o_v.fill_pays_asset_id(db).precision);
    vs.fill_data.receives_asset_id = o_v.fill_receives_asset_id;
    vs.fill_data.receives_asset_name = o_v.fill_receives_asset_id(db).symbol;
    vs.fill_data.receives_amount = o_v.fill_receives_amount;
-   vs.fill_data.receives_amount_calculated = (float)(o_v.fill_receives_amount.value)/pow(10, o_v.fill_receives_asset_id(db).precision);
+   vs.fill_data.receives_amount_units = (float)(o_v.fill_receives_amount.value)/pow(10, o_v.fill_receives_asset_id(db).precision);
 
    float fill_price = (float)(o_v.fill_receives_amount.value/o_v.fill_receives_asset_id(db).precision) /
            (float)(o_v.fill_pays_amount.value / o_v.fill_pays_asset_id(db).precision);
-   vs.fill_data.fill_price_calculated = fill_price;
+   vs.fill_data.fill_price_units = fill_price;
    vs.fill_data.fill_price = o_v.fill_fill_price;
    vs.fill_data.is_maker = o_v.fill_is_maker;
 }

--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -235,12 +235,12 @@ void elasticsearch_plugin_impl::doVisitor(const optional <operation_history_obje
    vs.fee_data.asset = o_v.fee_asset;
    vs.fee_data.asset_name = o_v.fee_asset(db).symbol;
    vs.fee_data.amount = o_v.fee_amount;
-   vs.fee_data.amount_units = (float)(o_v.fee_amount.value)/pow(10, o_v.fee_asset(db).precision);
+   vs.fee_data.amount_units = (double)(o_v.fee_amount.value)/pow(10, o_v.fee_asset(db).precision);
 
    vs.transfer_data.asset = o_v.transfer_asset_id;
    vs.transfer_data.asset_name = o_v.transfer_asset_id(db).symbol;
    vs.transfer_data.amount = o_v.transfer_amount;
-   vs.transfer_data.amount_units = (float)(o_v.transfer_amount.value)/(pow(10, o_v.transfer_asset_id(db).precision));
+   vs.transfer_data.amount_units = (double)(o_v.transfer_amount.value)/(pow(10, o_v.transfer_asset_id(db).precision));
    vs.transfer_data.from = o_v.transfer_from;
    vs.transfer_data.to = o_v.transfer_to;
 
@@ -249,14 +249,14 @@ void elasticsearch_plugin_impl::doVisitor(const optional <operation_history_obje
    vs.fill_data.pays_asset_id = o_v.fill_pays_asset_id;
    vs.fill_data.pays_asset_name = o_v.fill_pays_asset_id(db).symbol;
    vs.fill_data.pays_amount = o_v.fill_pays_amount;
-   vs.fill_data.pays_amount_units = (float)(o_v.fill_pays_amount.value)/pow(10, o_v.fill_pays_asset_id(db).precision);
+   vs.fill_data.pays_amount_units = (double)(o_v.fill_pays_amount.value)/pow(10, o_v.fill_pays_asset_id(db).precision);
    vs.fill_data.receives_asset_id = o_v.fill_receives_asset_id;
    vs.fill_data.receives_asset_name = o_v.fill_receives_asset_id(db).symbol;
    vs.fill_data.receives_amount = o_v.fill_receives_amount;
-   vs.fill_data.receives_amount_units = (float)(o_v.fill_receives_amount.value)/pow(10, o_v.fill_receives_asset_id(db).precision);
+   vs.fill_data.receives_amount_units = (double)(o_v.fill_receives_amount.value)/pow(10, o_v.fill_receives_asset_id(db).precision);
 
-   float fill_price = (float)(o_v.fill_receives_amount.value/o_v.fill_receives_asset_id(db).precision) /
-           (float)(o_v.fill_pays_amount.value / o_v.fill_pays_asset_id(db).precision);
+   auto fill_price = (o_v.fill_receives_amount.value/pow(10, o_v.fill_receives_asset_id(db).precision)) /
+           (o_v.fill_pays_amount.value / pow(10, o_v.fill_pays_asset_id(db).precision));
    vs.fill_data.fill_price_units = fill_price;
    vs.fill_data.fill_price = o_v.fill_fill_price;
    vs.fill_data.is_maker = o_v.fill_is_maker;

--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -232,31 +232,35 @@ void elasticsearch_plugin_impl::doVisitor(const optional <operation_history_obje
    operation_visitor o_v;
    oho->op.visit(o_v);
 
+   auto fee_asset = o_v.fee_asset(db);
    vs.fee_data.asset = o_v.fee_asset;
-   vs.fee_data.asset_name = o_v.fee_asset(db).symbol;
+   vs.fee_data.asset_name = fee_asset.symbol;
    vs.fee_data.amount = o_v.fee_amount;
-   vs.fee_data.amount_units = (o_v.fee_amount.value)/(double)asset::scaled_precision(o_v.fee_asset(db).precision).value;
+   vs.fee_data.amount_units = (o_v.fee_amount.value)/(double)asset::scaled_precision(fee_asset.precision).value;
 
+   auto transfer_asset = o_v.transfer_asset_id(db);
    vs.transfer_data.asset = o_v.transfer_asset_id;
-   vs.transfer_data.asset_name = o_v.transfer_asset_id(db).symbol;
+   vs.transfer_data.asset_name = transfer_asset.symbol;
    vs.transfer_data.amount = o_v.transfer_amount;
-   vs.transfer_data.amount_units = (o_v.transfer_amount.value)/(double)asset::scaled_precision(o_v.transfer_asset_id(db).precision).value;
+   vs.transfer_data.amount_units = (o_v.transfer_amount.value)/(double)asset::scaled_precision(transfer_asset.precision).value;
    vs.transfer_data.from = o_v.transfer_from;
    vs.transfer_data.to = o_v.transfer_to;
 
+   auto fill_pays_asset = o_v.fill_pays_asset_id(db);
+   auto fill_receives_asset = o_v.fill_receives_asset_id(db);
    vs.fill_data.order_id = o_v.fill_order_id;
    vs.fill_data.account_id = o_v.fill_account_id;
    vs.fill_data.pays_asset_id = o_v.fill_pays_asset_id;
-   vs.fill_data.pays_asset_name = o_v.fill_pays_asset_id(db).symbol;
+   vs.fill_data.pays_asset_name = fill_pays_asset.symbol;
    vs.fill_data.pays_amount = o_v.fill_pays_amount;
-   vs.fill_data.pays_amount_units = (o_v.fill_pays_amount.value)/(double)asset::scaled_precision(o_v.fill_pays_asset_id(db).precision).value;
+   vs.fill_data.pays_amount_units = (o_v.fill_pays_amount.value)/(double)asset::scaled_precision(fill_pays_asset.precision).value;
    vs.fill_data.receives_asset_id = o_v.fill_receives_asset_id;
-   vs.fill_data.receives_asset_name = o_v.fill_receives_asset_id(db).symbol;
+   vs.fill_data.receives_asset_name = fill_receives_asset.symbol;
    vs.fill_data.receives_amount = o_v.fill_receives_amount;
-   vs.fill_data.receives_amount_units = (o_v.fill_receives_amount.value)/(double)asset::scaled_precision(o_v.fill_receives_asset_id(db).precision).value;
+   vs.fill_data.receives_amount_units = (o_v.fill_receives_amount.value)/(double)asset::scaled_precision(fill_receives_asset.precision).value;
 
-   auto fill_price = (o_v.fill_receives_amount.value/(double)asset::scaled_precision(o_v.fill_receives_asset_id(db).precision).value) /
-           (o_v.fill_pays_amount.value/(double)asset::scaled_precision(o_v.fill_pays_asset_id(db).precision).value);
+   auto fill_price = (o_v.fill_receives_amount.value/(double)asset::scaled_precision(fill_receives_asset.precision).value) /
+           (o_v.fill_pays_amount.value/(double)asset::scaled_precision(fill_pays_asset.precision).value);
    vs.fill_data.fill_price_units = fill_price;
    vs.fill_data.fill_price = o_v.fill_fill_price;
    vs.fill_data.is_maker = o_v.fill_is_maker;

--- a/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
+++ b/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
@@ -138,12 +138,16 @@ struct block_struct {
 
 struct fee_struct {
    asset_id_type asset;
+   std::string asset_name;
    share_type amount;
+   float amount_calculated;
 };
 
 struct transfer_struct {
    asset_id_type asset;
+   std::string asset_name;
    share_type amount;
+   float amount_calculated;
    account_id_type from;
    account_id_type to;
 };
@@ -152,10 +156,15 @@ struct fill_struct {
    object_id_type order_id;
    account_id_type account_id;
    asset_id_type pays_asset_id;
+   std::string pays_asset_name;
    share_type pays_amount;
+   float pays_amount_calculated;
    asset_id_type receives_asset_id;
+   std::string receives_asset_name;
    share_type receives_amount;
+   float receives_amount_calculated;
    double fill_price;
+   float fill_price_calculated;
    bool is_maker;
 };
 
@@ -178,8 +187,10 @@ struct bulk_struct {
 
 FC_REFLECT( graphene::elasticsearch::operation_history_struct, (trx_in_block)(op_in_trx)(operation_result)(virtual_op)(op) )
 FC_REFLECT( graphene::elasticsearch::block_struct, (block_num)(block_time)(trx_id) )
-FC_REFLECT( graphene::elasticsearch::fee_struct, (asset)(amount) )
-FC_REFLECT( graphene::elasticsearch::transfer_struct, (asset)(amount)(from)(to) )
-FC_REFLECT( graphene::elasticsearch::fill_struct, (order_id)(account_id)(pays_asset_id)(pays_amount)(receives_asset_id)(receives_amount)(fill_price)(is_maker))
+FC_REFLECT( graphene::elasticsearch::fee_struct, (asset)(asset_name)(amount)(amount_calculated) )
+FC_REFLECT( graphene::elasticsearch::transfer_struct, (asset)(asset_name)(amount)(amount_calculated)(from)(to) )
+FC_REFLECT( graphene::elasticsearch::fill_struct, (order_id)(account_id)(pays_asset_id)(pays_asset_name)(pays_amount)(pays_amount_calculated)
+                                                  (receives_asset_id)(receives_asset_name)(receives_amount)(receives_amount_calculated)(fill_price)
+                                                  (fill_price_calculated)(is_maker))
 FC_REFLECT( graphene::elasticsearch::visitor_struct, (fee_data)(transfer_data)(fill_data) )
 FC_REFLECT( graphene::elasticsearch::bulk_struct, (account_history)(operation_history)(operation_type)(operation_id_num)(block_data)(additional_data) )

--- a/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
+++ b/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
@@ -140,14 +140,14 @@ struct fee_struct {
    asset_id_type asset;
    std::string asset_name;
    share_type amount;
-   float amount_units;
+   double amount_units;
 };
 
 struct transfer_struct {
    asset_id_type asset;
    std::string asset_name;
    share_type amount;
-   float amount_units;
+   double amount_units;
    account_id_type from;
    account_id_type to;
 };
@@ -158,13 +158,13 @@ struct fill_struct {
    asset_id_type pays_asset_id;
    std::string pays_asset_name;
    share_type pays_amount;
-   float pays_amount_units;
+   double pays_amount_units;
    asset_id_type receives_asset_id;
    std::string receives_asset_name;
    share_type receives_amount;
-   float receives_amount_units;
+   double receives_amount_units;
    double fill_price;
-   float fill_price_units;
+   double fill_price_units;
    bool is_maker;
 };
 

--- a/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
+++ b/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
@@ -140,14 +140,14 @@ struct fee_struct {
    asset_id_type asset;
    std::string asset_name;
    share_type amount;
-   float amount_calculated;
+   float amount_units;
 };
 
 struct transfer_struct {
    asset_id_type asset;
    std::string asset_name;
    share_type amount;
-   float amount_calculated;
+   float amount_units;
    account_id_type from;
    account_id_type to;
 };
@@ -158,13 +158,13 @@ struct fill_struct {
    asset_id_type pays_asset_id;
    std::string pays_asset_name;
    share_type pays_amount;
-   float pays_amount_calculated;
+   float pays_amount_units;
    asset_id_type receives_asset_id;
    std::string receives_asset_name;
    share_type receives_amount;
-   float receives_amount_calculated;
+   float receives_amount_units;
    double fill_price;
-   float fill_price_calculated;
+   float fill_price_units;
    bool is_maker;
 };
 
@@ -187,10 +187,10 @@ struct bulk_struct {
 
 FC_REFLECT( graphene::elasticsearch::operation_history_struct, (trx_in_block)(op_in_trx)(operation_result)(virtual_op)(op) )
 FC_REFLECT( graphene::elasticsearch::block_struct, (block_num)(block_time)(trx_id) )
-FC_REFLECT( graphene::elasticsearch::fee_struct, (asset)(asset_name)(amount)(amount_calculated) )
-FC_REFLECT( graphene::elasticsearch::transfer_struct, (asset)(asset_name)(amount)(amount_calculated)(from)(to) )
-FC_REFLECT( graphene::elasticsearch::fill_struct, (order_id)(account_id)(pays_asset_id)(pays_asset_name)(pays_amount)(pays_amount_calculated)
-                                                  (receives_asset_id)(receives_asset_name)(receives_amount)(receives_amount_calculated)(fill_price)
-                                                  (fill_price_calculated)(is_maker))
+FC_REFLECT( graphene::elasticsearch::fee_struct, (asset)(asset_name)(amount)(amount_units) )
+FC_REFLECT( graphene::elasticsearch::transfer_struct, (asset)(asset_name)(amount)(amount_units)(from)(to) )
+FC_REFLECT( graphene::elasticsearch::fill_struct, (order_id)(account_id)(pays_asset_id)(pays_asset_name)(pays_amount)(pays_amount_units)
+                                                  (receives_asset_id)(receives_asset_name)(receives_amount)(receives_amount_units)(fill_price)
+                                                  (fill_price_units)(is_maker))
 FC_REFLECT( graphene::elasticsearch::visitor_struct, (fee_data)(transfer_data)(fill_data) )
 FC_REFLECT( graphene::elasticsearch::bulk_struct, (account_history)(operation_history)(operation_type)(operation_id_num)(block_data)(additional_data) )


### PR DESCRIPTION
https://github.com/bitshares/bitshares-core/issues/1295

Pull add some more data like `asset_name` into `additional_data`. Also calculate prices with `precision`. 

All new data is added into new fields to keep current clients working. 

In open-explorer.io this is done client side, problem is you have to make additional queries to the remote database to get precision, with kibana this is currently not possible, this should help with some visualizations.

more info: https://github.com/bitshares/bitshares-core/issues/1295#issuecomment-425724631