### PR TITLE
add dascoin adaptor

### DIFF
--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -341,7 +341,7 @@ void elasticsearch_plugin_impl::createBulkLine(const account_transaction_history
    bulk_line_struct.block_data = bs;
    if(_elasticsearch_visitor)
       bulk_line_struct.additional_data = vs;
-   bulk_line = fc::json::to_string(bulk_line_struct);
+   bulk_line = fc::json::to_string(bulk_line_struct, fc::json::legacy_generator);
 }
 
 void elasticsearch_plugin_impl::prepareBulk(const account_transaction_history_id_type& ath_id)

--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -216,10 +216,8 @@ void elasticsearch_plugin_impl::doOperationHistory(const optional <operation_his
 
    if(_elasticsearch_operation_object) {
       oho->op.visit(fc::from_static_variant(os.op_object, FC_PACK_MAX_DEPTH));
-      if (os.op_object.is_object()) {
-         adaptor_struct adaptor;
-         os.op_object = adaptor.adapt(os.op_object.get_object());
-      }
+      adaptor_struct adaptor;
+      os.op_object = adaptor.adapt(os.op_object.get_object());
    }
    else
       os.op = fc::json::to_string(oho->op);

--- a/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
+++ b/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
@@ -228,10 +228,6 @@ struct adaptor_struct {
             }
          }
       }
-      if (o.find("kind") != o.end())
-      {
-         o["kind"] = o["kind"].as_string();
-      }
       if (o.find("new_parameters") != o.end())
       {
          auto& tmp = o["new_parameters"];

--- a/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
+++ b/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
@@ -215,7 +215,7 @@ struct adaptor_struct {
          auto& memo = o["memo"];
          if (memo.is_string())
          {
-            o["memo_"] = variant(o["memo"]);
+            o["memo_"] = o["memo"];
             o.erase("memo");
          }
          else if (memo.is_object())

--- a/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
+++ b/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
@@ -128,6 +128,7 @@ struct operation_history_struct {
    std::string operation_result;
    int virtual_op;
    std::string op;
+   variant op_object;
 };
 
 struct block_struct {
@@ -183,9 +184,94 @@ struct bulk_struct {
    optional<visitor_struct> additional_data;
 };
 
+struct adaptor_struct {
+   variant adapt(const variant_object& op)
+   {
+       fc::mutable_variant_object o(op);
+       vector<string> keys_to_rename;
+       for (auto i = o.begin(); i != o.end(); ++i)
+       {
+           auto& element = (*i).value();
+           if (element.is_object())
+           {
+               const string& name = (*i).key();
+               auto& vo = element.get_object();
+               if (vo.contains(name.c_str()))
+                   keys_to_rename.emplace_back(name);
+               element = adapt(vo);
+           }
+           else if (element.is_array())
+               adapt(element.get_array());
+       }
+       for (const auto& i : keys_to_rename)
+       {
+           string new_name = i + "_";
+           o[new_name] = variant(o[i]);
+           o.erase(i);
+       }
+
+       if (o.find("memo") != o.end())
+       {
+           auto& memo = o["memo"];
+           if (memo.is_string())
+           {
+               o["memo_"] = variant(o["memo"]);
+               o.erase("memo");
+           }
+           else if (memo.is_object())
+           {
+               fc::mutable_variant_object tmp(memo.get_object());
+               if (tmp.find("nonce") != tmp.end())
+               {
+                   tmp["nonce"] = tmp["nonce"].as_string();
+                   o["memo"] = tmp;
+               }
+           }
+       }
+       if (o.find("kind") != o.end())
+       {
+           o["kind"] = o["kind"].as_string();
+       }
+       if (o.find("new_parameters") != o.end())
+       {
+           auto& tmp = o["new_parameters"];
+           if (tmp.is_object())
+           {
+               fc::mutable_variant_object tmp2(tmp.get_object());
+               if (tmp2.find("current_fees") != tmp2.end())
+               {
+                   tmp2.erase("current_fees");
+                   o["new_parameters"] = tmp2;
+               }
+           }
+       }
+       if (o.find("owner") != o.end() && o["owner"].is_string())
+       {
+           o["owner_"] = o["owner"].as_string();
+           o.erase("owner");
+       }
+       variant v;
+       fc::to_variant(o, v, FC_PACK_MAX_DEPTH);
+       return v;
+   }
+
+   void adapt(fc::variants& v)
+   {
+       for (auto& array_element : v)
+       {
+           if (array_element.is_object())
+               array_element = adapt(array_element.get_object());
+           else if (array_element.is_array())
+               adapt(array_element.get_array());
+           else
+               array_element = array_element.as_string();
+       }
+   }
+};
+
 } } //graphene::elasticsearch
 
-FC_REFLECT( graphene::elasticsearch::operation_history_struct, (trx_in_block)(op_in_trx)(operation_result)(virtual_op)(op) )
+FC_REFLECT( graphene::elasticsearch::operation_history_struct, (trx_in_block)(op_in_trx)(operation_result)(virtual_op)(op)(op_object) )
 FC_REFLECT( graphene::elasticsearch::block_struct, (block_num)(block_time)(trx_id) )
 FC_REFLECT( graphene::elasticsearch::fee_struct, (asset)(asset_name)(amount)(amount_units) )
 FC_REFLECT( graphene::elasticsearch::transfer_struct, (asset)(asset_name)(amount)(amount_units)(from)(to) )

--- a/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
+++ b/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
@@ -250,6 +250,15 @@ struct adaptor_struct {
            o["owner_"] = o["owner"].as_string();
            o.erase("owner");
        }
+       if (o.find("proposed_ops") != o.end())
+       {
+          o["proposed_ops"] = fc::json::to_string(o["proposed_ops"]);
+       }
+      if (o.find("initializer") != o.end())
+      {
+         o["initializer"] = fc::json::to_string(o["initializer"]);
+      }
+
        variant v;
        fc::to_variant(o, v, FC_PACK_MAX_DEPTH);
        return v;

--- a/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
+++ b/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
@@ -187,94 +187,94 @@ struct bulk_struct {
 struct adaptor_struct {
    variant adapt(const variant_object& op)
    {
-       fc::mutable_variant_object o(op);
-       vector<string> keys_to_rename;
-       for (auto i = o.begin(); i != o.end(); ++i)
-       {
-           auto& element = (*i).value();
-           if (element.is_object())
-           {
-               const string& name = (*i).key();
-               auto& vo = element.get_object();
-               if (vo.contains(name.c_str()))
-                   keys_to_rename.emplace_back(name);
-               element = adapt(vo);
-           }
-           else if (element.is_array())
-               adapt(element.get_array());
-       }
-       for (const auto& i : keys_to_rename)
-       {
-           string new_name = i + "_";
-           o[new_name] = variant(o[i]);
-           o.erase(i);
-       }
+      fc::mutable_variant_object o(op);
+      vector<string> keys_to_rename;
+      for (auto i = o.begin(); i != o.end(); ++i)
+      {
+         auto& element = (*i).value();
+         if (element.is_object())
+         {
+            const string& name = (*i).key();
+            auto& vo = element.get_object();
+            if (vo.contains(name.c_str()))
+               keys_to_rename.emplace_back(name);
+            element = adapt(vo);
+         }
+         else if (element.is_array())
+            adapt(element.get_array());
+      }
+      for (const auto& i : keys_to_rename)
+      {
+         string new_name = i + "_";
+         o[new_name] = variant(o[i]);
+         o.erase(i);
+      }
 
-       if (o.find("memo") != o.end())
-       {
-           auto& memo = o["memo"];
-           if (memo.is_string())
-           {
-               o["memo_"] = variant(o["memo"]);
-               o.erase("memo");
-           }
-           else if (memo.is_object())
-           {
-               fc::mutable_variant_object tmp(memo.get_object());
-               if (tmp.find("nonce") != tmp.end())
-               {
-                   tmp["nonce"] = tmp["nonce"].as_string();
-                   o["memo"] = tmp;
-               }
-           }
-       }
-       if (o.find("kind") != o.end())
-       {
-           o["kind"] = o["kind"].as_string();
-       }
-       if (o.find("new_parameters") != o.end())
-       {
-           auto& tmp = o["new_parameters"];
-           if (tmp.is_object())
-           {
-               fc::mutable_variant_object tmp2(tmp.get_object());
-               if (tmp2.find("current_fees") != tmp2.end())
-               {
-                   tmp2.erase("current_fees");
-                   o["new_parameters"] = tmp2;
-               }
-           }
-       }
-       if (o.find("owner") != o.end() && o["owner"].is_string())
-       {
-           o["owner_"] = o["owner"].as_string();
-           o.erase("owner");
-       }
-       if (o.find("proposed_ops") != o.end())
-       {
-          o["proposed_ops"] = fc::json::to_string(o["proposed_ops"]);
-       }
+      if (o.find("memo") != o.end())
+      {
+         auto& memo = o["memo"];
+         if (memo.is_string())
+         {
+            o["memo_"] = variant(o["memo"]);
+            o.erase("memo");
+         }
+         else if (memo.is_object())
+         {
+            fc::mutable_variant_object tmp(memo.get_object());
+            if (tmp.find("nonce") != tmp.end())
+            {
+               tmp["nonce"] = tmp["nonce"].as_string();
+               o["memo"] = tmp;
+            }
+         }
+      }
+      if (o.find("kind") != o.end())
+      {
+         o["kind"] = o["kind"].as_string();
+      }
+      if (o.find("new_parameters") != o.end())
+      {
+         auto& tmp = o["new_parameters"];
+         if (tmp.is_object())
+         {
+            fc::mutable_variant_object tmp2(tmp.get_object());
+            if (tmp2.find("current_fees") != tmp2.end())
+            {
+               tmp2.erase("current_fees");
+               o["new_parameters"] = tmp2;
+            }
+         }
+      }
+      if (o.find("owner") != o.end() && o["owner"].is_string())
+      {
+         o["owner_"] = o["owner"].as_string();
+         o.erase("owner");
+      }
+      if (o.find("proposed_ops") != o.end())
+      {
+         o["proposed_ops"] = fc::json::to_string(o["proposed_ops"]);
+      }
       if (o.find("initializer") != o.end())
       {
          o["initializer"] = fc::json::to_string(o["initializer"]);
       }
 
-       variant v;
-       fc::to_variant(o, v, FC_PACK_MAX_DEPTH);
-       return v;
+      variant v;
+      fc::to_variant(o, v, FC_PACK_MAX_DEPTH);
+      return v;
    }
 
    void adapt(fc::variants& v)
    {
-       for (auto& array_element : v)
-       {
-           if (array_element.is_object())
-               array_element = adapt(array_element.get_object());
-           else if (array_element.is_array())
-               adapt(array_element.get_array());
-           else
-               array_element = array_element.as_string();
-       }
+      for (auto& array_element : v)
+      {
+         if (array_element.is_object())
+            array_element = adapt(array_element.get_object());
+         else if (array_element.is_array())
+            adapt(array_element.get_array());
+         else
+            array_element = array_element.as_string();
+      }
    }
 };
 


### PR DESCRIPTION
This pull request is the Dascoin(https://github.com/techsolutions-ltd/dascoin-blockchain) modifications made to elasticsearch plugin to index all operation fields. This code was provided to me by Damir from Dascoin.

Basically it creates the `adaptor_struct` in the hpp and visit it at the cpp in `doOperationHistory` when sending `op` field.

The rest are some specific changes made by me to remain compatible with previous plugin versions like adding the object in new field `op_object` and adding argument to use this code with `elasticsearch-operation-object`

Now we have everything indexed as:
![op_object](https://user-images.githubusercontent.com/21685097/46407702-2d531f00-c6e6-11e8-884d-268d07d06e97.png)

Problem i am having is that many blocks seems to be having some issue that i am trying to identify:

```
727117ms th_a       fork_database.cpp:64          push_block           ] Pushing block to fork database that failed to link: 000031d6c902288a4b9a95081868ec7a2945f0cb, 12758
727117ms th_a       fork_database.cpp:65          push_block           ] Head: 12573, 0000311d1f7e38432188f30026e9215726f55bcb
727117ms th_a       application.cpp:545           handle_block         ] Error when pushing block:
3080000 unlinkable_block_exception: unlinkable block
block does not link to known chain
    {}
    th_a  fork_database.cpp:85 _push_block

    {"new_block":{"previous":"000031d5e78b74404f9e00bf0a3a6135d9f3d1d6","timestamp":"2015-10-14T01:34:30","witness":"1.6.33","transaction_merkle_root":"0000000000000000000000000000000000000000","extensions":[],"witness_signature":"20423494a7759d6c9e5ded507f448dbb15fc7a777a420bc5e51861ba36cb04771f5f7292bba96868f89ec1e08e30861e7939c458c8cfe6006f5283cf1eba2d5ecd","transactions":[]}}
    th_a  db_block.cpp:219 _push_block
```

any input is appreciated.

