### PR TITLE
Performance opt pt 1

### DIFF
--- a/libraries/chain/account_object.cpp
+++ b/libraries/chain/account_object.cpp
@@ -121,9 +121,9 @@ set<account_id_type> account_member_index::get_account_members(const account_obj
       result.insert(auth.first);
    return result;
 }
-set<public_key_type> account_member_index::get_key_members(const account_object& a)const
+set<public_key_type, account_member_index::key_compare> account_member_index::get_key_members(const account_object& a)const
 {
-   set<public_key_type> result;
+   set<public_key_type, key_compare> result;
    for( auto auth : a.owner.key_auths )
       result.insert(auth.first);
    for( auto auth : a.active.key_auths )
@@ -215,7 +215,7 @@ void account_member_index::object_modified(const object& after)
 
 
     {
-       set<public_key_type> after_key_members = get_key_members(a);
+       set<public_key_type, key_compare> after_key_members = get_key_members(a);
 
        vector<public_key_type> removed; removed.reserve(before_key_members.size());
        std::set_difference(before_key_members.begin(), before_key_members.end(),

--- a/libraries/chain/db_block.cpp
+++ b/libraries/chain/db_block.cpp
@@ -626,9 +626,12 @@ processed_transaction database::_apply_transaction(const signed_transaction& trx
 
    auto& trx_idx = get_mutable_index_type<transaction_index>();
    const chain_id_type& chain_id = get_chain_id();
-   auto trx_id = trx.id();
-   FC_ASSERT( (skip & skip_transaction_dupe_check) ||
-              trx_idx.indices().get<by_trx_id>().find(trx_id) == trx_idx.indices().get<by_trx_id>().end() );
+   transaction_id_type trx_id;
+   if( !(skip & skip_transaction_dupe_check) )
+   {
+      trx_id = trx.id();
+      FC_ASSERT( trx_idx.indices().get<by_trx_id>().find(trx_id) == trx_idx.indices().get<by_trx_id>().end() );
+   }
    transaction_evaluation_state eval_state(this);
    const chain_parameters& chain_parameters = get_global_properties().parameters;
    eval_state._trx = &trx;
@@ -662,7 +665,7 @@ processed_transaction database::_apply_transaction(const signed_transaction& trx
    //Insert transaction into unique transactions database.
    if( !(skip & skip_transaction_dupe_check) )
    {
-      create<transaction_object>([&](transaction_object& transaction) {
+      create<transaction_object>([&trx_id,&trx](transaction_object& transaction) {
          transaction.trx_id = trx_id;
          transaction.trx = trx;
       });

--- a/libraries/chain/db_management.cpp
+++ b/libraries/chain/db_management.cpp
@@ -85,6 +85,8 @@ void database::reindex( fc::path data_dir )
 
    size_t total_processed_block_size;
    size_t total_block_size = _block_id_to_block.total_block_size();
+   const auto& gpo = get_global_properties();
+   const fc::time_point_sec now( fc::time_point::now() );
    for( uint32_t i = head_block_num() + 1; i <= last_block_num; ++i )
    {
       if( i % 10000 == 0 ) 
@@ -107,6 +109,8 @@ void database::reindex( fc::path data_dir )
          flush();
          ilog( "Done" );
       }
+      if( head_block_time() >= now - gpo.parameters.maximum_time_until_expiration )
+         skip &= ~skip_transaction_dupe_check;
       fc::optional< signed_block > block = _block_id_to_block.fetch_by_number(i);
       if( !block.valid() )
       {

--- a/libraries/chain/db_management.cpp
+++ b/libraries/chain/db_management.cpp
@@ -86,7 +86,6 @@ void database::reindex( fc::path data_dir )
    size_t total_processed_block_size;
    size_t total_block_size = _block_id_to_block.total_block_size();
    const auto& gpo = get_global_properties();
-   const fc::time_point_sec now( fc::time_point::now() );
    for( uint32_t i = head_block_num() + 1; i <= last_block_num; ++i )
    {
       if( i % 10000 == 0 ) 
@@ -109,7 +108,7 @@ void database::reindex( fc::path data_dir )
          flush();
          ilog( "Done" );
       }
-      if( head_block_time() >= now - gpo.parameters.maximum_time_until_expiration )
+      if( head_block_time() >= last_block->timestamp - gpo.parameters.maximum_time_until_expiration )
          skip &= ~skip_transaction_dupe_check;
       fc::optional< signed_block > block = _block_id_to_block.fetch_by_number(i);
       if( !block.valid() )

--- a/libraries/chain/db_management.cpp
+++ b/libraries/chain/db_management.cpp
@@ -76,6 +76,7 @@ void database::reindex( fc::path data_dir )
 
    uint32_t skip = skip_witness_signature |
                    skip_block_size_check |
+                   skip_merkle_check |
                    skip_transaction_signatures |
                    skip_transaction_dupe_check |
                    skip_tapos_check |

--- a/libraries/chain/include/graphene/chain/account_object.hpp
+++ b/libraries/chain/include/graphene/chain/account_object.hpp
@@ -292,6 +292,14 @@ namespace graphene { namespace chain {
     */
    class account_member_index : public secondary_index
    {
+      class key_compare {
+      public:
+         inline bool operator()( const public_key_type& a, const public_key_type& b )const
+         {
+            return a.key_data < b.key_data;
+         }
+      };
+
       public:
          virtual void object_inserted( const object& obj ) override;
          virtual void object_removed( const object& obj ) override;
@@ -301,18 +309,18 @@ namespace graphene { namespace chain {
 
          /** given an account or key, map it to the set of accounts that reference it in an active or owner authority */
          map< account_id_type, set<account_id_type> > account_to_account_memberships;
-         map< public_key_type, set<account_id_type> > account_to_key_memberships;
+         map< public_key_type, set<account_id_type>, key_compare > account_to_key_memberships;
          /** some accounts use address authorities in the genesis block */
          map< address, set<account_id_type> >         account_to_address_memberships;
 
 
       protected:
          set<account_id_type>  get_account_members( const account_object& a )const;
-         set<public_key_type>  get_key_members( const account_object& a )const;
+         set<public_key_type, key_compare>  get_key_members( const account_object& a )const;
          set<address>          get_address_members( const account_object& a )const;
 
          set<account_id_type>  before_account_members;
-         set<public_key_type>  before_key_members;
+         set<public_key_type, key_compare>  before_key_members;
          set<address>          before_address_members;
    };
 


### PR DESCRIPTION
This is some low hanging fruit discovered during my work on #1079 . I'm afraid the fully parallel pre-computation of blocks and transactions will not be finished in time for the upcoming release, therefore submitting this PR first.
The 4th commit in particular help to greatly improve startup time and should also be helpful with get_key_references API call. Related: #1151