### PR TITLE
Implement `account_update_votes_operation`

### DIFF
--- a/libraries/chain/db_init.cpp
+++ b/libraries/chain/db_init.cpp
@@ -173,6 +173,7 @@ void database::initialize_evaluators()
    register_evaluator<asset_claim_fees_evaluator>();
    register_evaluator<asset_update_issuer_evaluator>();
    register_evaluator<asset_claim_pool_evaluator>();
+   register_evaluator<account_update_votes_evaluator>();
 }
 
 void database::initialize_indexes()

--- a/libraries/chain/db_notify.cpp
+++ b/libraries/chain/db_notify.cpp
@@ -78,6 +78,10 @@ struct get_impacted_account_visitor
       if( op.active )
          add_authority_accounts( _impacted, *(op.active) );
    }
+   void operator()( const account_update_votes_operation& op )
+   {
+      _impacted.insert( op.fee_payer() ); // account
+   }
    void operator()( const account_whitelist_operation& op )
    {
       _impacted.insert( op.fee_payer() ); // authorizing_account

--- a/libraries/chain/include/graphene/chain/account_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/account_evaluator.hpp
@@ -47,6 +47,18 @@ public:
    const account_object* acnt;
 };
 
+class account_update_votes_evaluator : public evaluator<account_update_votes_evaluator>
+{
+public:
+   typedef account_update_votes_operation operation_type;
+
+   void_result do_evaluate ( const account_update_votes_operation& o );
+   void_result do_apply( const account_update_votes_operation& o );
+
+   const account_object* acnt;
+   account_options _new_options;
+};
+
 class account_upgrade_evaluator : public evaluator<account_upgrade_evaluator>
 {
 public:

--- a/libraries/chain/include/graphene/chain/protocol/account.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/account.hpp
@@ -166,6 +166,44 @@ namespace graphene { namespace chain {
    };
 
    /**
+    * @ingroup operations
+    * @brief Update the votes, num_witness, num_committee and proxy of an existing account
+    * This operation is used to update the votes, num_witness, num_committee and proxy of an existing account.
+    *
+    */
+   struct account_update_votes_operation : public base_operation
+   {
+      struct fee_parameters_type
+      {
+         share_type fee             = 20 * GRAPHENE_BLOCKCHAIN_PRECISION;
+         uint32_t   price_per_kbyte = GRAPHENE_BLOCKCHAIN_PRECISION;
+      };
+
+      asset fee;
+      /// The account to update
+      account_id_type account;
+
+      /// New account options
+      flat_set<vote_id_type>    votes_to_add;
+      flat_set<vote_id_type>    votes_to_remove;
+
+      // a new voting account to set
+      optional<account_id_type> voting_account;
+      // a new number of witness_votes to set
+      optional<uint16_t> num_witness;
+      // a new number of commitee_votes to set
+      optional<uint16_t> num_committee;
+
+      // for future extensions (see account_update_operation)
+      extensions_type extensions;
+
+      account_id_type fee_payer()const { return account; }
+      void            validate()const;
+      share_type      calculate_fee( const fee_parameters_type& k )const;
+
+   };
+
+   /**
     * @brief This operation is used to whitelist and blacklist accounts, primarily for transacting in whitelisted assets
     * @ingroup operations
     *
@@ -284,6 +322,10 @@ FC_REFLECT(graphene::chain::account_update_operation::ext, (null_ext)(owner_spec
 FC_REFLECT( graphene::chain::account_update_operation,
             (fee)(account)(owner)(active)(new_options)(extensions)
           )
+
+FC_REFLECT( graphene::chain::account_update_votes_operation,
+            (fee) (account) (votes_to_add) (votes_to_remove) (voting_account) (num_witness) (num_committee) (extensions) )
+FC_REFLECT( graphene::chain::account_update_votes_operation::fee_parameters_type, (fee) (price_per_kbyte) )
 
 FC_REFLECT( graphene::chain::account_upgrade_operation,
             (fee)(account_to_upgrade)(upgrade_to_lifetime_member)(extensions) )

--- a/libraries/chain/include/graphene/chain/protocol/operations.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/operations.hpp
@@ -95,7 +95,8 @@ namespace graphene { namespace chain {
             bid_collateral_operation,
             execute_bid_operation,          // VIRTUAL
             asset_claim_pool_operation,
-            asset_update_issuer_operation
+            asset_update_issuer_operation,
+            account_update_votes_operation
          > operation;
 
    /// @} // operations group

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -2357,6 +2357,167 @@ BOOST_AUTO_TEST_CASE( vesting_balance_withdraw_test )
    // TODO:  Test with non-core asset and Bob account
 } FC_LOG_AND_RETHROW() }
 
+BOOST_AUTO_TEST_CASE( account_update_votes_operation_test )
+{
+   try
+   {
+      const fc::ecc::private_key alice_private = fc::ecc::private_key::generate();
+      const public_key_type alice_public       = alice_private.get_public_key();
+      const account_object& alice              = create_account("alice", alice_public);
+
+      const auto& active_committee_members = db.get_global_properties().active_committee_members;
+      const auto& active_witness_members   = db.get_global_properties().active_witnesses;
+
+      transfer( account_id_type()(db), alice, asset(1000000000) );
+      trx.operations.clear();
+
+      // creating committee and witness test votes
+      vote_id_type vote_id_c0 = active_committee_members[0](db).vote_id;
+      vote_id_type vote_id_c1 = active_committee_members[1](db).vote_id;
+      vote_id_type vote_id_c2 = active_committee_members[2](db).vote_id;
+      vote_id_type vote_id_w0;
+      vote_id_type vote_id_w1;
+      vote_id_type vote_id_w2;
+
+      int i = 0;
+      for(auto& vote_id : active_witness_members)
+      {
+         if(i == 0)      vote_id_w0 = vote_id(db).vote_id;
+         else if(i == 1) vote_id_w1 = vote_id(db).vote_id;
+         else if(i == 2) vote_id_w2 = vote_id(db).vote_id;
+         else if(i == 3) break;
+         ++i;
+      }
+
+      #define VOTES_FIND(X) alice.options.votes.find(X)
+      #define VOTES_END     alice.options.votes.end()
+
+      BOOST_TEST_MESSAGE( "\n1. Checking for correct witness and committee num and if votes were added.\n" );
+      {
+         account_update_votes_operation op;
+         op.account       = alice.id;
+         op.votes_to_add  = flat_set<vote_id_type>( {vote_id_c0, vote_id_c1, vote_id_w0, vote_id_w1} );
+         op.num_committee = 2;
+         op.num_witness   = 2;
+
+         trx = signed_transaction();
+         set_expiration(db, trx);
+         trx.operations.push_back(op);
+         PUSH_TX( db, trx, ~0 );
+
+         BOOST_CHECK( VOTES_FIND(vote_id_c0) != VOTES_END && VOTES_FIND(vote_id_c1) != VOTES_END
+                   && VOTES_FIND(vote_id_w0) != VOTES_END && VOTES_FIND(vote_id_w1) != VOTES_END );
+         BOOST_CHECK( alice.options.num_committee == 2 );
+         BOOST_CHECK( alice.options.num_witness   == 2 );
+      }
+
+      BOOST_TEST_MESSAGE( "\n2. Checking for correct witness and committee num and if votes were removed.\n" );
+      {
+         account_update_votes_operation op;
+         op.account         = alice.id;
+         op.votes_to_remove = flat_set<vote_id_type>( {vote_id_c0, vote_id_c1, vote_id_w0, vote_id_w1} );
+         op.num_committee   = 0;
+         op.num_witness     = 0;
+
+         trx = signed_transaction();
+         set_expiration(db, trx);
+         trx.operations.push_back(op);
+         PUSH_TX( db, trx, ~0 );
+
+         BOOST_CHECK( VOTES_FIND(vote_id_c0) == VOTES_END && VOTES_FIND(vote_id_c1) == VOTES_END
+                   && VOTES_FIND(vote_id_w0) == VOTES_END && VOTES_FIND(vote_id_w1) == VOTES_END );
+         BOOST_CHECK( alice.options.num_committee == 0 );
+         BOOST_CHECK( alice.options.num_witness   == 0 );
+      }
+
+      BOOST_TEST_MESSAGE( "\n3. Trying to add and remove the same votes.\n" );
+      {
+         account_update_votes_operation op;
+         op.account         = alice.id;
+         op.votes_to_add    = flat_set<vote_id_type>( {vote_id_c0, vote_id_c1, vote_id_w0, vote_id_w1} );
+         op.votes_to_remove = flat_set<vote_id_type>( {vote_id_c0, vote_id_w0} );
+         op.num_committee   = 0;
+         op.num_witness     = 0;
+
+         trx = signed_transaction();
+         set_expiration(db, trx);
+         trx.operations.push_back(op);
+
+         GRAPHENE_REQUIRE_THROW( PUSH_TX( db, trx, ~0 ), fc::assert_exception);
+      }
+
+      BOOST_TEST_MESSAGE( "\n4. Add and remove at the same time. num_committee && num_witness should stay the same\n" );
+      {
+         account_update_votes_operation op;
+         op.account       = alice.id;
+         op.votes_to_add  = flat_set<vote_id_type>( {vote_id_c0, vote_id_c1, vote_id_w0, vote_id_w1} );
+         op.num_committee = 2;
+         op.num_witness   = 2;
+
+         trx = signed_transaction();
+         set_expiration(db, trx);
+         trx.operations.push_back(op);
+         trx.validate();
+         PUSH_TX( db, trx, ~0 );
+
+         op = account_update_votes_operation();
+         op.account         = alice.id;
+         op.votes_to_add    = flat_set<vote_id_type>( {vote_id_c2, vote_id_w2} );
+         op.votes_to_remove = flat_set<vote_id_type>( {vote_id_c1, vote_id_w1} );
+
+         trx = signed_transaction();
+         set_expiration(db, trx);
+         trx.operations.push_back(op);
+         PUSH_TX( db, trx, ~0 );
+
+         BOOST_CHECK( VOTES_FIND(vote_id_c0) != VOTES_END
+                   && VOTES_FIND(vote_id_c1) == VOTES_END
+                   && VOTES_FIND(vote_id_c2) != VOTES_END
+                   && VOTES_FIND(vote_id_w0) != VOTES_END
+                   && VOTES_FIND(vote_id_w1) == VOTES_END
+                   && VOTES_FIND(vote_id_w2) != VOTES_END
+         );
+         BOOST_CHECK( alice.options.num_committee == 2 );
+         BOOST_CHECK( alice.options.num_witness   == 2 );
+
+      }
+
+      BOOST_TEST_MESSAGE( "\n5. Change the voting_account.\n" );
+      {
+         BOOST_CHECK( alice.options.voting_account == GRAPHENE_PROXY_TO_SELF_ACCOUNT );
+
+         account_update_votes_operation op;
+         op.account         = alice.id;
+         op.voting_account  = GRAPHENE_NULL_ACCOUNT;
+         op.votes_to_remove = flat_set<vote_id_type>( {vote_id_c0, vote_id_c2, vote_id_w0, vote_id_w2} );
+         op.num_committee   = 0;
+         op.num_witness     = 0;
+
+         trx = signed_transaction();
+         set_expiration(db, trx);
+         trx.operations.push_back(op);
+         PUSH_TX( db, trx, ~0 );
+
+         BOOST_CHECK( alice.options.voting_account == GRAPHENE_NULL_ACCOUNT );
+         BOOST_CHECK( alice.options.is_voting() );
+      }
+
+      BOOST_TEST_MESSAGE( "\n6. Set no parameters.\n" );
+      {
+         account_update_votes_operation op;
+         op.account = alice.id;
+
+         trx = signed_transaction();
+         set_expiration(db, trx);
+         trx.operations.push_back(op);
+
+         GRAPHENE_REQUIRE_THROW( PUSH_TX( db, trx, ~0 ), fc::assert_exception );
+      }
+   } catch (fc::exception& e) {
+      edump( (e.to_detail_string() ) );
+   }
+}
+
 // TODO:  Write linear VBO tests
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR introduces a new operation `account_update_votes_operation` that we feel is necessary in conjunction with BSIP40 and allows for setting a separate key for updating account votes. It has been manged in BSIP40