### PR TITLE
Added flag to proposal_create_operation.extension to allow auto appro…

### DIFF
--- a/libraries/chain/include/graphene/chain/protocol/proposal.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/proposal.hpp
@@ -23,6 +23,8 @@
  */
 #pragma once
 #include <graphene/chain/protocol/base.hpp>
+#include <graphene/chain/protocol/ext.hpp>
+#include <fc/reflect/reflect.hpp>
 
 namespace graphene { namespace chain { 
    /**
@@ -73,12 +75,16 @@ namespace graphene { namespace chain {
           uint32_t price_per_kbyte = 10;
        };
 
+       struct ext {
+         optional<bool> auto_approve;
+       };
+
        asset              fee;
        account_id_type    fee_paying_account;
        vector<op_wrapper> proposed_ops;
        time_point_sec     expiration_time;
        optional<uint32_t> review_period_seconds;
-       extensions_type    extensions;
+       extension<ext>     extensions;
 
        /**
         * Constructs a proposal_create_operation suitable for committee
@@ -172,7 +178,7 @@ namespace graphene { namespace chain {
 FC_REFLECT( graphene::chain::proposal_create_operation::fee_parameters_type, (fee)(price_per_kbyte) )
 FC_REFLECT( graphene::chain::proposal_update_operation::fee_parameters_type, (fee)(price_per_kbyte) )
 FC_REFLECT( graphene::chain::proposal_delete_operation::fee_parameters_type, (fee) )
-
+FC_REFLECT( graphene::chain::proposal_create_operation::ext, (auto_approve) );
 FC_REFLECT( graphene::chain::proposal_create_operation, (fee)(fee_paying_account)(expiration_time)
             (proposed_ops)(review_period_seconds)(extensions) )
 FC_REFLECT( graphene::chain::proposal_update_operation, (fee)(fee_paying_account)(proposal)

--- a/libraries/chain/protocol/proposal.cpp
+++ b/libraries/chain/protocol/proposal.cpp
@@ -33,6 +33,7 @@ proposal_create_operation proposal_create_operation::committee_proposal(const ch
    proposal_create_operation op;
    op.expiration_time = head_block_time + global_params.maximum_proposal_lifetime;
    op.review_period_seconds = global_params.committee_proposal_review_period;
+   op.extensions.value.auto_approve = false;
    return op;
 }
 


### PR DESCRIPTION
Added flag to proposal_create_operation.extension to allow auto approval by fee payer.

This feature does not change current behavior but allows to set a flag when creating a new proposal that adds a functionality for the user.

A BSIP for this exists as [BSIP39](https://github.com/bitshares/bsips/blob/master/bsip-0039.md)

Paging @Dimfred