### PR TITLE
Update max-ops-per-account program option to 64bit

### DIFF
--- a/libraries/plugins/account_history/account_history_plugin.cpp
+++ b/libraries/plugins/account_history/account_history_plugin.cpp
@@ -282,7 +282,7 @@ void account_history_plugin::plugin_set_program_options(
    cli.add_options()
          ("track-account", boost::program_options::value<std::vector<std::string>>()->composing()->multitoken(), "Account ID to track history for (may specify multiple times)")
          ("partial-operations", boost::program_options::value<bool>(), "Keep only those operations in memory that are related to account history tracking")
-         ("max-ops-per-account", boost::program_options::value<uint32_t>(), "Maximum number of operations per account will be kept in memory")
+         ("max-ops-per-account", boost::program_options::value<uint64_t>(), "Maximum number of operations per account will be kept in memory")
          ;
    cfg.add(cli);
 }


### PR DESCRIPTION
For https://github.com/bitshares/bitshares-core/issues/1206.

Was missing in https://github.com/bitshares/bitshares-core/pull/1347.
