### PR TITLE
Add disk space requirements to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ In order to run a full node with all the account history you need to remove `par
 
 | Default | Full | Minimal  | ElasticSearch 
 | --- | --- | --- | ---
-| 16G RAM | 120G RAM | 4G RAM | 500G SSD HD, 32G RAM
+| 100G SSD, 16G RAM | 200G SSD, 120G RAM | 80G SSD, 8G RAM | 500G SSD, 32G RAM
 
 After starting the witness node again, in a separate terminal you can run:
 


### PR DESCRIPTION
On 2018-10-15,
* block file (plus index) is around 35G;
* on-disk object database is around 1/5 of RAM used;
* default p2p logs are around 12G (level = warn, keep 7 days);
* console logs and rpc logs are relatively small.