### PR TITLE
add additional checks to adaptor for live chain sync

### DIFF
--- a/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
+++ b/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
@@ -254,6 +254,11 @@ struct adaptor_struct {
       {
          o["initializer"] = fc::json::to_string(o["initializer"]);
       }
+      if (o.find("policy") != o.end())
+      {
+         o["policy"] = fc::json::to_string(o["policy"]);
+      }
+
 
       variant v;
       fc::to_variant(o, v, FC_PACK_MAX_DEPTH);

--- a/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
+++ b/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
@@ -262,7 +262,10 @@ struct adaptor_struct {
       {
          o["predicates"] = fc::json::to_string(o["predicates"]);
       }
-
+      if (o.find("active_special_authority") != o.end())
+      {
+         o["active_special_authority"] = fc::json::to_string(o["active_special_authority"]);
+      }
 
       variant v;
       fc::to_variant(o, v, FC_PACK_MAX_DEPTH);

--- a/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
+++ b/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
@@ -258,6 +258,10 @@ struct adaptor_struct {
       {
          o["policy"] = fc::json::to_string(o["policy"]);
       }
+      if (o.find("predicates") != o.end())
+      {
+         o["predicates"] = fc::json::to_string(o["predicates"]);
+      }
 
 
       variant v;

--- a/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
+++ b/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
@@ -266,6 +266,11 @@ struct adaptor_struct {
       {
          o["active_special_authority"] = fc::json::to_string(o["active_special_authority"]);
       }
+      if (o.find("owner_special_authority") != o.end())
+      {
+         o["owner_special_authority"] = fc::json::to_string(o["owner_special_authority"]);
+      }
+
 
       variant v;
       fc::to_variant(o, v, FC_PACK_MAX_DEPTH);


### PR DESCRIPTION
Elasticsearch plugin with adaptor included at https://github.com/bitshares/bitshares-core/pull/1356 start to fail at around block 24M due to error:

```
java.lang.IllegalArgumentException: Can't merge a non object mapping [operation_history.op_object.policy] with an object mapping [operation_history.op_object.policy]
```
This pull attempts to fix it, testing now. Will check the full logs of all ES looking for errors until sync.