### PR TITLE
Change description of delayed_node option

### DIFF
--- a/libraries/plugins/delayed_node/delayed_node_plugin.cpp
+++ b/libraries/plugins/delayed_node/delayed_node_plugin.cpp
@@ -58,7 +58,7 @@ delayed_node_plugin::~delayed_node_plugin()
 void delayed_node_plugin::plugin_set_program_options(bpo::options_description& cli, bpo::options_description& cfg)
 {
    cli.add_options()
-         ("trusted-node", boost::program_options::value<std::string>(), "RPC endpoint of a trusted validating node (required)")
+         ("trusted-node", boost::program_options::value<std::string>(), "RPC endpoint of a trusted validating node (required for delayed_node)")
          ;
    cfg.add(cli);
 }


### PR DESCRIPTION
It seems that witness_node will populate all possible options to config.ini from all available nodes in new data dir, and the description of `trusted-node` for delayed node is a bit confusing.

It looks like:
```
# Will only store matched orders in last X seconds...
max-order-his-seconds-per-market = 2592000

# RPC endpoint of a trusted validating node (required)
# trusted-node =

# Block number after which to do a snapshot
# snapshot-at-block =
```
while it's not required for a normal node.

Maybe we should not merge this, instead prepend the name of plugin before corresponding options to clarify this (#1407).