### PR TITLE
add plugin headers to config

### DIFF
--- a/libraries/app/config_util.cpp
+++ b/libraries/app/config_util.cpp
@@ -258,10 +258,26 @@ static void create_new_config_file(const fc::path& config_ini_path, const fc::pa
    };
    deduplicator dedup(modify_option_defaults);
    std::ofstream out_cfg(config_ini_path.preferred_string());
+
+   std::vector<std::pair<std::string, std::string>> plugin_first_option;
+   plugin_first_option.push_back(std::make_pair("account_history", "track-account"));
+   plugin_first_option.push_back(std::make_pair("elasticsearch", "elasticsearch-node-url"));
+   plugin_first_option.push_back(std::make_pair("market_history", "bucket-size"));
+   plugin_first_option.push_back(std::make_pair("delayed_node", "trusted-node"));
+   plugin_first_option.push_back(std::make_pair("snapshot", "snapshot-at-block"));
+   plugin_first_option.push_back(std::make_pair("es_objects", "es-objects-elasticsearch-url"));
+   plugin_first_option.push_back(std::make_pair("grouped_orders", "tracked-groups"));
+
    for( const boost::shared_ptr<bpo::option_description> opt : cfg_options.options() )
    {
       const boost::shared_ptr<bpo::option_description> od = dedup.next(opt);
       if( !od ) continue;
+
+      auto it = std::find_if( plugin_first_option.begin(), plugin_first_option.end(),
+                              [&od](const std::pair<std::string, std::string>& element){ return element.second == od->long_name();} );
+
+      if(*it != std::pair<std::string, std::string>("", ""))
+         out_cfg << "# ==== " << it->first << " ==== \n";
 
       if( !od->description().empty() )
          out_cfg << "# " << od->description() << "\n";

--- a/libraries/app/config_util.cpp
+++ b/libraries/app/config_util.cpp
@@ -260,6 +260,8 @@ static void create_new_config_file(const fc::path& config_ini_path, const fc::pa
    std::ofstream out_cfg(config_ini_path.preferred_string());
 
    std::vector<std::pair<std::string, std::string>> plugin_first_option;
+   plugin_first_option.push_back(std::make_pair("witness", "enable-stale-production"));
+   plugin_first_option.push_back(std::make_pair("debug_witness", "debug-private-key"));
    plugin_first_option.push_back(std::make_pair("account_history", "track-account"));
    plugin_first_option.push_back(std::make_pair("elasticsearch", "elasticsearch-node-url"));
    plugin_first_option.push_back(std::make_pair("market_history", "bucket-size"));
@@ -278,7 +280,7 @@ static void create_new_config_file(const fc::path& config_ini_path, const fc::pa
          return element.second == od->long_name();
       });
 
-      if(*it != std::pair<std::string, std::string>("", ""))
+      if(it != plugin_first_option.end())
          out_cfg << "# ==== " << it->first << " ==== \n";
 
       if( !od->description().empty() )

--- a/libraries/app/config_util.cpp
+++ b/libraries/app/config_util.cpp
@@ -274,7 +274,9 @@ static void create_new_config_file(const fc::path& config_ini_path, const fc::pa
       if( !od ) continue;
 
       auto it = std::find_if( plugin_first_option.begin(), plugin_first_option.end(),
-                              [&od](const std::pair<std::string, std::string>& element){ return element.second == od->long_name();} );
+            [&od](const std::pair<std::string, std::string>& element) {
+         return element.second == od->long_name();
+      });
 
       if(*it != std::pair<std::string, std::string>("", ""))
          out_cfg << "# ==== " << it->first << " ==== \n";


### PR DESCRIPTION
https://github.com/bitshares/bitshares-core/issues/1407

Function `create_new_config_file` receives all the available command line options in order but it will not specify from what plugin they came from.

Here i add a vector of pairs plugin_name, first_plugin_option in order to place a header. I know it is a bit dirty but i think it can work.

New plugins will need to be added here but if they are not added the header will not be added and nothing more, config will be generated anyways.

Here is how it looks:

https://pastebin.com/raw/whb5UDch
