### PR TITLE
Fix build errors and a warning

### DIFF
--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -2439,7 +2439,7 @@ void database_api_impl::on_applied_block()
       }
       if( market.valid() && _market_subscriptions.count(*market) )
          // FIXME this may cause fill_order_operation be pushed before order creation
-         subscribed_markets_ops[*market].emplace_back( std::move( std::make_pair( op.op, op.result ) ) );
+         subscribed_markets_ops[*market].emplace_back(std::make_pair(op.op, op.result));
    }
    /// we need to ensure the database_api is not deleted for the life of the async operation
    auto capture_this = shared_from_this();

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -24,6 +24,8 @@
 #include <graphene/chain/fork_database.hpp>
 #include <graphene/chain/exceptions.hpp>
 
+#include <fc/smart_ref_impl.hpp>
+
 namespace graphene { namespace chain {
 fork_database::fork_database()
 {

--- a/libraries/chain/include/graphene/chain/protocol/account.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/account.hpp
@@ -274,6 +274,7 @@ FC_REFLECT_ENUM( graphene::chain::account_whitelist_operation::account_listing,
                 (no_listing)(white_listed)(black_listed)(white_and_black_listed))
 
 FC_REFLECT(graphene::chain::account_create_operation::ext, (null_ext)(owner_special_authority)(active_special_authority)(buyback_options) )
+FC_REFLECT_TYPENAME(graphene::chain::extension<graphene::chain::account_create_operation::ext>)
 FC_REFLECT( graphene::chain::account_create_operation,
             (fee)(registrar)
             (referrer)(referrer_percent)
@@ -281,6 +282,7 @@ FC_REFLECT( graphene::chain::account_create_operation,
           )
 
 FC_REFLECT(graphene::chain::account_update_operation::ext, (null_ext)(owner_special_authority)(active_special_authority) )
+FC_REFLECT_TYPENAME(graphene::chain::extension<graphene::chain::account_update_operation::ext>)
 FC_REFLECT( graphene::chain::account_update_operation,
             (fee)(account)(owner)(active)(new_options)(extensions)
           )

--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -317,7 +317,7 @@ namespace graphene { namespace net { namespace detail {
       _maximum_blocks_per_peer_during_syncing(GRAPHENE_NET_MAX_BLOCKS_PER_PEER_DURING_SYNCING)
     {
       _rate_limiter.set_actual_rate_time_constant(fc::seconds(2));
-      fc::rand_pseudo_bytes(&_node_id.data[0], (int)_node_id.size());
+      fc::rand_bytes(&_node_id.data[0], (int)_node_id.size());
     }
 
     node_impl::~node_impl()


### PR DESCRIPTION
 - Fix warning that using `std::move` on a temporary value prevents copy elision
 - Add missing `FC_REFLECT_TYPENAME` on account operation extensions
 - Replace deprecated call to `fc::rand_pseudo_bytes` with
`fc::rand_bytes`.
 - Include `smart_ref_impl.hpp` in `fork_database.cpp` which is required for build on some configurations