### PR TITLE
Improve plugin loader

### DIFF
--- a/libraries/app/include/graphene/app/application.hpp
+++ b/libraries/app/include/graphene/app/application.hpp
@@ -48,18 +48,17 @@ namespace graphene { namespace app {
          application();
          ~application();
 
-         void set_program_options( boost::program_options::options_description& command_line_options,
-                                   boost::program_options::options_description& configuration_file_options )const;
-         void initialize(const fc::path& data_dir, const boost::program_options::variables_map&options);
-         void initialize_plugins( const boost::program_options::variables_map& options );
+         void set_program_options(boost::program_options::options_description& command_line_options,
+                                  boost::program_options::options_description& configuration_file_options)const;
+         void initialize(const fc::path& data_dir, const boost::program_options::variables_map& options);
+         void initialize_plugins(const boost::program_options::variables_map& options);
          void startup();
          void shutdown();
          void startup_plugins();
          void shutdown_plugins();
 
          template<typename PluginType>
-         std::shared_ptr<PluginType> register_plugin()
-         {
+         std::shared_ptr<PluginType> register_plugin(bool auto_load = false) {
             auto plug = std::make_shared<PluginType>();
             plug->plugin_set_app(this);
 
@@ -72,6 +71,10 @@ namespace graphene { namespace app {
                _cfg_options.add(plugin_cfg_options);
 
             add_available_plugin( plug );
+
+            if (auto_load)
+                enable_plugin(plug->plugin_name());
+
             return plug;
          }
          std::shared_ptr<abstract_plugin> get_plugin( const string& name )const;


### PR DESCRIPTION
Replaces #1424

This PR adds the ability for client code of the `application` class to request plugins be loaded automatically when it registers them. I don't know if upstream bitshares will want this or not, but here's a PR just in case!

This PR is mostly a clean-up/correctness fix (the old conflict detection between the `account_history` and `elasticsearch` plugins was clumsy and would false-positive if either plugin showed up twice in the list), but it does add the ability to mark plugins to be loaded automatically when they are registered.

Please note that this PR does remove the hard-coded list of "wanted" plugins, as this shortcut is annoying to third party code, like that of Follow My Vote, which may not want to be cluttered up by having those plugins linked in. This may cause mild turbulence to existing environments which depend on this shortcut. #sorrynotsorry =) This turbulence can be avoided by calling `register_plugin(true)` for the desired auto-load plugins, however, doing so will prevent disabling these plugins from the config.