### PR TITLE
Add an adaptor to es_objects and template function to reduce code

### DIFF
--- a/libraries/plugins/es_objects/es_objects.cpp
+++ b/libraries/plugins/es_objects/es_objects.cpp
@@ -30,9 +30,11 @@
 #include <graphene/chain/proposal_object.hpp>
 #include <graphene/chain/balance_object.hpp>
 #include <graphene/chain/market_object.hpp>
+#include <graphene/chain/asset_object.hpp>
+#include <graphene/chain/account_object.hpp>
+#include <boost/algorithm/string.hpp>
 
 #include <graphene/utilities/elasticsearch.hpp>
-
 
 namespace graphene { namespace es_objects {
 
@@ -72,12 +74,8 @@ class es_objects_plugin_impl
       fc::time_point_sec block_time;
 
    private:
-      void prepare_proposal(const proposal_object& proposal_object);
-      void prepare_account(const account_object& account_object);
-      void prepare_asset(const asset_object& asset_object);
-      void prepare_balance(const account_balance_object& account_balance_object);
-      void prepare_limit(const limit_order_object& limit_object);
-      void prepare_bitasset(const asset_bitasset_data_object& bitasset_object);
+       template<typename T>
+       void prepareTemplate(T blockchain_object, string index_name);
 };
 
 bool es_objects_plugin_impl::index_database( const vector<object_id_type>& ids, std::string action)
@@ -102,7 +100,7 @@ bool es_objects_plugin_impl::index_database( const vector<object_id_type>& ids, 
             if(action == "delete")
                remove_from_database(p->id, "proposal");
             else
-               prepare_proposal(*p);
+               prepareTemplate<proposal_object>(*p, "proposal");
          }
       }
       else if(value.is<account_object>() && _es_objects_accounts) {
@@ -112,7 +110,7 @@ bool es_objects_plugin_impl::index_database( const vector<object_id_type>& ids, 
             if(action == "delete")
                remove_from_database(a->id, "account");
             else
-               prepare_account(*a);
+               prepareTemplate<account_object>(*a, "account");
          }
       }
       else if(value.is<asset_object>() && _es_objects_assets) {
@@ -122,7 +120,7 @@ bool es_objects_plugin_impl::index_database( const vector<object_id_type>& ids, 
             if(action == "delete")
                remove_from_database(a->id, "asset");
             else
-               prepare_asset(*a);
+               prepareTemplate<asset_object>(*a, "asset");
          }
       }
       else if(value.is<account_balance_object>() && _es_objects_balances) {
@@ -132,7 +130,7 @@ bool es_objects_plugin_impl::index_database( const vector<object_id_type>& ids, 
             if(action == "delete")
                remove_from_database(b->id, "balance");
             else
-               prepare_balance(*b);
+               prepareTemplate<account_balance_object>(*b, "balance");
          }
       }
       else if(value.is<limit_order_object>() && _es_objects_limit_orders) {
@@ -142,7 +140,7 @@ bool es_objects_plugin_impl::index_database( const vector<object_id_type>& ids, 
             if(action == "delete")
                remove_from_database(l->id, "limitorder");
             else
-               prepare_limit(*l);
+               prepareTemplate<limit_order_object>(*l, "limitorder");
          }
       }
       else if(value.is<asset_bitasset_data_object>() && _es_objects_asset_bitasset) {
@@ -152,7 +150,7 @@ bool es_objects_plugin_impl::index_database( const vector<object_id_type>& ids, 
             if(action == "delete")
                remove_from_database(ba->id, "bitasset");
             else
-               prepare_bitasset(*ba);
+               prepareTemplate<asset_bitasset_data_object>(*ba, "bitasset");
          }
       }
    }
@@ -190,179 +188,37 @@ void es_objects_plugin_impl::remove_from_database( object_id_type id, std::strin
    }
 }
 
-void es_objects_plugin_impl::prepare_proposal(const proposal_object& proposal_object)
+template<typename T>
+void es_objects_plugin_impl::prepareTemplate(T blockchain_object, string index_name)
 {
-   proposal_struct prop;
-   prop.object_id = proposal_object.id;
-   prop.block_time = block_time;
-   prop.block_number = block_number;
-   prop.expiration_time = proposal_object.expiration_time;
-   prop.review_period_time = proposal_object.review_period_time;
-   prop.proposed_transaction = fc::json::to_string(proposal_object.proposed_transaction);
-   prop.required_owner_approvals = fc::json::to_string(proposal_object.required_owner_approvals);
-   prop.available_owner_approvals = fc::json::to_string(proposal_object.available_owner_approvals);
-   prop.required_active_approvals = fc::json::to_string(proposal_object.required_active_approvals);
-   prop.available_key_approvals = fc::json::to_string(proposal_object.available_key_approvals);
-   prop.proposer = proposal_object.proposer;
-
-   std::string data = fc::json::to_string(prop);
-
    fc::mutable_variant_object bulk_header;
-   bulk_header["_index"] = _es_objects_index_prefix + "proposal";
+   bulk_header["_index"] = _es_objects_index_prefix + index_name;
    bulk_header["_type"] = "data";
    if(_es_objects_keep_only_current)
    {
-      bulk_header["_id"] = string(prop.object_id);
+      bulk_header["_id"] = string(blockchain_object.id);
    }
+
+   auto blockchain_object_string = fc::json::to_string(blockchain_object, fc::json::legacy_generator);
+
+   variant j = fc::json::from_string(blockchain_object_string);
+
+   fc::mutable_variant_object o;
+
+   adaptor_struct adaptor;
+   auto adapted = adaptor.adapt(j.get_object());
+
+   fc::from_variant(adapted, o, FC_PACK_MAX_DEPTH);
+
+   o["object_id"] = string(blockchain_object.id);
+   o["block_time"] = block_time;
+   o["block_number"] = block_number;
+
+   string data = fc::json::to_string(o, fc::json::legacy_generator);
 
    prepare = graphene::utilities::createBulk(bulk_header, std::move(data));
    std::move(prepare.begin(), prepare.end(), std::back_inserter(bulk));
    prepare.clear();
-}
-
-void es_objects_plugin_impl::prepare_account(const account_object& account_object)
-{
-   account_struct acct;
-   acct.object_id = account_object.id;
-   acct.block_time = block_time;
-   acct.block_number = block_number;
-   acct.membership_expiration_date = account_object.membership_expiration_date;
-   acct.registrar = account_object.registrar;
-   acct.referrer = account_object.referrer;
-   acct.lifetime_referrer = account_object.lifetime_referrer;
-   acct.network_fee_percentage = account_object.network_fee_percentage;
-   acct.lifetime_referrer_fee_percentage = account_object.lifetime_referrer_fee_percentage;
-   acct.referrer_rewards_percentage = account_object.referrer_rewards_percentage;
-   acct.name = account_object.name;
-   acct.owner_account_auths = fc::json::to_string(account_object.owner.account_auths);
-   acct.owner_key_auths = fc::json::to_string(account_object.owner.key_auths);
-   acct.owner_address_auths = fc::json::to_string(account_object.owner.address_auths);
-   acct.active_account_auths = fc::json::to_string(account_object.active.account_auths);
-   acct.active_key_auths = fc::json::to_string(account_object.active.key_auths);
-   acct.active_address_auths = fc::json::to_string(account_object.active.address_auths);
-   acct.voting_account = account_object.options.voting_account;
-   acct.votes = fc::json::to_string(account_object.options.votes);
-
-   std::string data = fc::json::to_string(acct);
-
-   fc::mutable_variant_object bulk_header;
-   bulk_header["_index"] = _es_objects_index_prefix + "account";
-   bulk_header["_type"] = "data";
-   if(_es_objects_keep_only_current)
-   {
-      bulk_header["_id"] = string(acct.object_id);
-   }
-
-   prepare = graphene::utilities::createBulk(bulk_header, std::move(data));
-   std::move(prepare.begin(), prepare.end(), std::back_inserter(bulk));
-   prepare.clear();
-}
-
-void es_objects_plugin_impl::prepare_asset(const asset_object& asset_object)
-{
-   asset_struct asset;
-   asset.object_id = asset_object.id;
-   asset.block_time = block_time;
-   asset.block_number = block_number;
-   asset.symbol = asset_object.symbol;
-   asset.issuer = asset_object.issuer;
-   asset.is_market_issued = asset_object.is_market_issued();
-   asset.dynamic_asset_data_id = asset_object.dynamic_asset_data_id;
-   asset.bitasset_data_id = asset_object.bitasset_data_id;
-
-   std::string data = fc::json::to_string(asset);
-
-   fc::mutable_variant_object bulk_header;
-   bulk_header["_index"] = _es_objects_index_prefix + "asset";
-   bulk_header["_type"] = "data";
-   if(_es_objects_keep_only_current)
-   {
-      bulk_header["_id"] = string(asset.object_id);
-   }
-
-   prepare = graphene::utilities::createBulk(bulk_header, std::move(data));
-   std::move(prepare.begin(), prepare.end(), std::back_inserter(bulk));
-   prepare.clear();
-}
-
-void es_objects_plugin_impl::prepare_balance(const account_balance_object& account_balance_object)
-{
-   balance_struct balance;
-   balance.object_id = account_balance_object.id;
-   balance.block_time = block_time;
-   balance.block_number = block_number;
-   balance.owner = account_balance_object.owner;
-   balance.asset_type = account_balance_object.asset_type;
-   balance.balance = account_balance_object.balance;
-   balance.maintenance_flag = account_balance_object.maintenance_flag;
-
-   std::string data = fc::json::to_string(balance);
-
-   fc::mutable_variant_object bulk_header;
-   bulk_header["_index"] = _es_objects_index_prefix + "balance";
-   bulk_header["_type"] = "data";
-   if(_es_objects_keep_only_current)
-   {
-      bulk_header["_id"] = string(balance.object_id);
-   }
-
-   prepare = graphene::utilities::createBulk(bulk_header, std::move(data));
-   std::move(prepare.begin(), prepare.end(), std::back_inserter(bulk));
-   prepare.clear();
-}
-
-void es_objects_plugin_impl::prepare_limit(const limit_order_object& limit_object)
-{
-   limit_order_struct limit;
-   limit.object_id = limit_object.id;
-   limit.block_time = block_time;
-   limit.block_number = block_number;
-   limit.expiration = limit_object.expiration;
-   limit.seller = limit_object.seller;
-   limit.for_sale = limit_object.for_sale;
-   limit.sell_price = limit_object.sell_price;
-   limit.deferred_fee = limit_object.deferred_fee;
-
-   std::string data = fc::json::to_string(limit);
-
-   fc::mutable_variant_object bulk_header;
-   bulk_header["_index"] = _es_objects_index_prefix + "limitorder";
-   bulk_header["_type"] = "data";
-   if(_es_objects_keep_only_current)
-   {
-      bulk_header["_id"] = string(limit.object_id);
-   }
-
-   prepare = graphene::utilities::createBulk(bulk_header, std::move(data));
-   std::move(prepare.begin(), prepare.end(), std::back_inserter(bulk));
-   prepare.clear();
-}
-
-void es_objects_plugin_impl::prepare_bitasset(const asset_bitasset_data_object& bitasset_object)
-{
-   if(!bitasset_object.is_prediction_market) {
-
-      bitasset_struct bitasset;
-      bitasset.object_id = bitasset_object.id;
-      bitasset.block_time = block_time;
-      bitasset.block_number = block_number;
-      bitasset.current_feed = fc::json::to_string(bitasset_object.current_feed);
-      bitasset.current_feed_publication_time = bitasset_object.current_feed_publication_time;
-
-      std::string data = fc::json::to_string(bitasset);
-
-      fc::mutable_variant_object bulk_header;
-      bulk_header["_index"] = _es_objects_index_prefix + "bitasset";
-      bulk_header["_type"] = "data";
-      if(_es_objects_keep_only_current)
-      {
-         bulk_header["_id"] = string(bitasset.object_id);
-      }
-
-      prepare = graphene::utilities::createBulk(bulk_header, std::move(data));
-      std::move(prepare.begin(), prepare.end(), std::back_inserter(bulk));
-      prepare.clear();
-   }
 }
 
 es_objects_plugin_impl::~es_objects_plugin_impl()

--- a/libraries/plugins/es_objects/es_objects.cpp
+++ b/libraries/plugins/es_objects/es_objects.cpp
@@ -32,7 +32,6 @@
 #include <graphene/chain/market_object.hpp>
 #include <graphene/chain/asset_object.hpp>
 #include <graphene/chain/account_object.hpp>
-#include <boost/algorithm/string.hpp>
 
 #include <graphene/utilities/elasticsearch.hpp>
 
@@ -74,8 +73,8 @@ class es_objects_plugin_impl
       fc::time_point_sec block_time;
 
    private:
-       template<typename T>
-       void prepareTemplate(T blockchain_object, string index_name);
+      template<typename T>
+      void prepareTemplate(T blockchain_object, string index_name);
 };
 
 bool es_objects_plugin_impl::index_database( const vector<object_id_type>& ids, std::string action)

--- a/libraries/plugins/es_objects/es_objects.cpp
+++ b/libraries/plugins/es_objects/es_objects.cpp
@@ -199,16 +199,13 @@ void es_objects_plugin_impl::prepareTemplate(T blockchain_object, string index_n
    }
 
    auto blockchain_object_string = fc::json::to_string(blockchain_object, fc::json::legacy_generator);
-
-   variant j = fc::json::from_string(blockchain_object_string);
-
+   variant blockchain_object_variant = fc::json::from_string(blockchain_object_string);
    fc::mutable_variant_object o;
 
    adaptor_struct adaptor;
-   auto adapted = adaptor.adapt(j.get_object());
+   auto adapted = adaptor.adapt(blockchain_object_variant.get_object());
 
    fc::from_variant(adapted, o, FC_PACK_MAX_DEPTH);
-
    o["object_id"] = string(blockchain_object.id);
    o["block_time"] = block_time;
    o["block_number"] = block_number;

--- a/libraries/plugins/es_objects/es_objects.cpp
+++ b/libraries/plugins/es_objects/es_objects.cpp
@@ -198,14 +198,11 @@ void es_objects_plugin_impl::prepareTemplate(T blockchain_object, string index_n
       bulk_header["_id"] = string(blockchain_object.id);
    }
 
-   auto blockchain_object_string = fc::json::to_string(blockchain_object, fc::json::legacy_generator);
-   variant blockchain_object_variant = fc::json::from_string(blockchain_object_string);
-   fc::mutable_variant_object o;
-
    adaptor_struct adaptor;
-   auto adapted = adaptor.adapt(blockchain_object_variant.get_object());
+   fc::variant blockchain_object_variant;
+   fc::to_variant( blockchain_object, blockchain_object_variant, GRAPHENE_NET_MAX_NESTED_OBJECTS );
+   fc::mutable_variant_object o = adaptor.adapt(blockchain_object_variant.get_object());
 
-   fc::from_variant(adapted, o, FC_PACK_MAX_DEPTH);
    o["object_id"] = string(blockchain_object.id);
    o["block_time"] = block_time;
    o["block_number"] = block_number;

--- a/libraries/plugins/es_objects/include/graphene/es_objects/es_objects.hpp
+++ b/libraries/plugins/es_objects/include/graphene/es_objects/es_objects.hpp
@@ -54,7 +54,7 @@ class es_objects_plugin : public graphene::app::plugin
 };
 
 struct adaptor_struct {
-   variant adapt(const variant_object &obj) {
+    fc::mutable_variant_object adapt(const variant_object &obj) {
       fc::mutable_variant_object o(obj);
       vector<string> keys_to_rename;
       for (auto i = o.begin(); i != o.end(); ++i) {
@@ -94,10 +94,8 @@ struct adaptor_struct {
       {
          o["operations"] = fc::json::to_string(o["operations"]);
       }
-
-      variant v;
-      fc::to_variant(o, v, FC_PACK_MAX_DEPTH);
-      return v;
+      
+      return o;
    }
 
    void adapt(fc::variants &v) {

--- a/libraries/plugins/es_objects/include/graphene/es_objects/es_objects.hpp
+++ b/libraries/plugins/es_objects/include/graphene/es_objects/es_objects.hpp
@@ -30,7 +30,6 @@ namespace graphene { namespace es_objects {
 
 using namespace chain;
 
-
 namespace detail
 {
     class es_objects_plugin_impl;
@@ -54,105 +53,63 @@ class es_objects_plugin : public graphene::app::plugin
       std::unique_ptr<detail::es_objects_plugin_impl> my;
 };
 
-struct proposal_struct {
-   object_id_type object_id;
-   fc::time_point_sec block_time;
-   uint32_t block_number;
-   time_point_sec expiration_time;
-   optional<time_point_sec> review_period_time;
-   string proposed_transaction;
-   string required_active_approvals;
-   string available_active_approvals;
-   string required_owner_approvals;
-   string available_owner_approvals;
-   string available_key_approvals;
-   account_id_type proposer;
-};
-struct account_struct {
-   object_id_type object_id;
-   fc::time_point_sec block_time;
-   uint32_t block_number;
-   time_point_sec membership_expiration_date;
-   account_id_type registrar;
-   account_id_type referrer;
-   account_id_type lifetime_referrer;
-   uint16_t network_fee_percentage;
-   uint16_t lifetime_referrer_fee_percentage;
-   uint16_t referrer_rewards_percentage;
-   string name;
-   string owner_account_auths;
-   string owner_key_auths;
-   string owner_address_auths;
-   string active_account_auths;
-   string active_key_auths;
-   string active_address_auths;
-   account_id_type voting_account;
-   string votes;
-};
-struct asset_struct {
-   object_id_type object_id;
-   fc::time_point_sec block_time;
-   uint32_t block_number;
-   string symbol;
-   account_id_type issuer;
-   bool is_market_issued;
-   asset_dynamic_data_id_type dynamic_asset_data_id;
-   optional<asset_bitasset_data_id_type> bitasset_data_id;
-};
-struct balance_struct {
-   object_id_type object_id;
-   fc::time_point_sec block_time;
-   uint32_t block_number;
-   account_id_type owner;
-   asset_id_type asset_type;
-   share_type balance;
-   bool maintenance_flag;
-};
-struct limit_order_struct {
-   object_id_type object_id;
-   fc::time_point_sec block_time;
-   uint32_t block_number;
-   time_point_sec expiration;
-   account_id_type seller;
-   share_type for_sale;
-   price sell_price;
-   share_type deferred_fee;
-};
-struct bitasset_struct {
-   object_id_type object_id;
-   fc::time_point_sec block_time;
-   uint32_t block_number;
-   string current_feed;
-   time_point_sec current_feed_publication_time;
-   time_point_sec feed_expiration_time;
+struct adaptor_struct {
+   variant adapt(const variant_object &obj) {
+      fc::mutable_variant_object o(obj);
+      vector<string> keys_to_rename;
+      for (auto i = o.begin(); i != o.end(); ++i) {
+         auto &element = (*i).value();
+         if (element.is_object()) {
+            const string &name = (*i).key();
+            auto &vo = element.get_object();
+            if (vo.contains(name.c_str()))
+               keys_to_rename.emplace_back(name);
+            element = adapt(vo);
+         } else if (element.is_array())
+            adapt(element.get_array());
+      }
+      for (const auto &i : keys_to_rename) {
+         string new_name = i + "_";
+         o[new_name] = variant(o[i]);
+         o.erase(i);
+      }
+      if (o.find("owner") != o.end() && o["owner"].is_string())
+      {
+         o["owner_"] = o["owner"].as_string();
+         o.erase("owner");
+      }
+      if (o.find("active_special_authority") != o.end())
+      {
+         o["active_special_authority"] = fc::json::to_string(o["active_special_authority"]);
+      }
+      if (o.find("owner_special_authority") != o.end())
+      {
+         o["owner_special_authority"] = fc::json::to_string(o["owner_special_authority"]);
+      }
+      if (o.find("feeds") != o.end())
+      {
+         o["feeds"] = fc::json::to_string(o["feeds"]);
+      }
+      if (o.find("operations") != o.end())
+      {
+         o["operations"] = fc::json::to_string(o["operations"]);
+      }
+
+      variant v;
+      fc::to_variant(o, v, FC_PACK_MAX_DEPTH);
+      return v;
+   }
+
+   void adapt(fc::variants &v) {
+      for (auto &array_element : v) {
+         if (array_element.is_object())
+            array_element = adapt(array_element.get_object());
+         else if (array_element.is_array())
+            adapt(array_element.get_array());
+         else
+            array_element = array_element.as_string();
+      }
+   }
 };
 
 } } //graphene::es_objects
-
-FC_REFLECT(
-        graphene::es_objects::proposal_struct,
-        (object_id)(block_time)(block_number)(expiration_time)(review_period_time)(proposed_transaction)(required_active_approvals)
-        (available_active_approvals)(required_owner_approvals)(available_owner_approvals)(available_key_approvals)(proposer)
-)
-FC_REFLECT(
-        graphene::es_objects::account_struct,
-        (object_id)(block_time)(block_number)(membership_expiration_date)(registrar)(referrer)(lifetime_referrer)
-        (network_fee_percentage)(lifetime_referrer_fee_percentage)(referrer_rewards_percentage)(name)(owner_account_auths)
-        (owner_key_auths)(owner_address_auths)(active_account_auths)(active_key_auths)(active_address_auths)(voting_account)(votes)
-)
-FC_REFLECT(
-        graphene::es_objects::asset_struct,
-        (object_id)(block_time)(block_number)(symbol)(issuer)(is_market_issued)(dynamic_asset_data_id)(bitasset_data_id)
-)
-FC_REFLECT(
-        graphene::es_objects::balance_struct,
-        (object_id)(block_time)(block_number)(owner)(asset_type)(balance)(maintenance_flag)
-)
-FC_REFLECT(
-        graphene::es_objects::limit_order_struct,
-        (object_id)(block_time)(block_number)(expiration)(seller)(for_sale)(sell_price)(deferred_fee)
-)
-FC_REFLECT(
-        graphene::es_objects::bitasset_struct,
-        (object_id)(block_time)(block_number)(current_feed)(current_feed_publication_time)
-)


### PR DESCRIPTION
The following pull request is an attempt to reduce the amount of code in the es_objects plugin and make it easier to add new objects. It uses an adaptor approach very similar to the one used in elasticsearch plugin for account history, this time for objects.

I think more can be done, specifically there is duplicated code in `index_database` function that i tried to reduce however i was not able to make it due to casting, types, etc.

I opted on submitting this changes as i think they go in the right direction, as i don't know exactly when i will have the time to work on this again i preferred to submit what i have now and don't let the code lost.

This is a refactor, users can continue using this plugin the same way they were doing before without changes in the options however i am considering it will be better to add the objects the user want to save in a vector instead of individual options for each as it is now.

In initial testings i was able to sync without any error up to 2016-05-10T02:10:30 with everything turned on(all objects) with command:

```
./programs/witness_node/witness_node --plugins "es_objects" --es-objects-proposals "true" --es-objects-accounts "true" --es-objects-assets "true" --es-objects-balances "true" --es-objects-limit-orders "true" --es-objects-asset-bitasset "true"
```