### PR TITLE
move --plugins from application to binary #1427

### DIFF
--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -947,7 +947,6 @@ void application::set_program_options(boost::program_options::options_descriptio
          ("genesis-json", bpo::value<boost::filesystem::path>(), "File to read Genesis State from")
          ("dbg-init-key", bpo::value<string>(), "Block signing key to use for init witnesses, overrides genesis file")
          ("api-access", bpo::value<boost::filesystem::path>(), "JSON file specifying API permissions")
-         ("plugins", bpo::value<string>(), "Space-separated list of plugins to activate")
          ("io-threads", bpo::value<uint16_t>()->implicit_value(0), "Number of IO threads, default to 0 for auto-configuration")
          ("enable-subscribe-to-all", bpo::value<bool>()->implicit_value(true),
           "Whether allow API clients to subscribe to universal object creation and removal events")
@@ -1005,19 +1004,6 @@ void application::initialize(const fc::path& data_dir, const boost::program_opti
    {
       const uint16_t num_threads = options["io-threads"].as<uint16_t>();
       fc::asio::default_io_service_scope::set_num_threads(num_threads);
-   }
-
-   if (options.count("plugins")) {
-       std::set<string> plugins;
-       boost::split(plugins, options.at("plugins").as<std::string>(), [](char c){return c == ' ';});
-
-       FC_ASSERT(!(plugins.count("account_history") && plugins.count("elasticsearch")),
-                 "Plugin conflict: Cannot load both account_history plugin and elasticsearch plugin");
-
-       std::for_each(plugins.begin(), plugins.end(), [this](const string& plug) mutable {
-           if (!plug.empty())
-               enable_plugin(plug);
-       });
    }
 }
 

--- a/libraries/app/include/graphene/app/application.hpp
+++ b/libraries/app/include/graphene/app/application.hpp
@@ -101,8 +101,9 @@ namespace graphene { namespace app {
 
          const application_options& get_options();
 
-      private:
          void enable_plugin( const string& name );
+
+      private:
          void add_available_plugin( std::shared_ptr<abstract_plugin> p );
          std::shared_ptr<detail::application_impl> my;
 

--- a/libraries/plugins/delayed_node/delayed_node_plugin.cpp
+++ b/libraries/plugins/delayed_node/delayed_node_plugin.cpp
@@ -58,7 +58,7 @@ delayed_node_plugin::~delayed_node_plugin()
 void delayed_node_plugin::plugin_set_program_options(bpo::options_description& cli, bpo::options_description& cfg)
 {
    cli.add_options()
-         ("trusted-node", boost::program_options::value<std::string>()->default_value("127.0.0.1:8090"), "RPC endpoint of a trusted validating node (required for delayed_node)")
+         ("trusted-node", boost::program_options::value<std::string>(), "RPC endpoint of a trusted validating node (required for delayed_node)")
          ;
    cfg.add(cli);
 }

--- a/libraries/plugins/delayed_node/delayed_node_plugin.cpp
+++ b/libraries/plugins/delayed_node/delayed_node_plugin.cpp
@@ -58,7 +58,7 @@ delayed_node_plugin::~delayed_node_plugin()
 void delayed_node_plugin::plugin_set_program_options(bpo::options_description& cli, bpo::options_description& cfg)
 {
    cli.add_options()
-         ("trusted-node", boost::program_options::value<std::string>(), "RPC endpoint of a trusted validating node (required)")
+         ("trusted-node", boost::program_options::value<std::string>()->default_value("127.0.0.1:8090"), "RPC endpoint of a trusted validating node (required)")
          ;
    cfg.add(cli);
 }

--- a/programs/delayed_node/main.cpp
+++ b/programs/delayed_node/main.cpp
@@ -166,11 +166,6 @@ int main(int argc, char** argv) {
       std::set<std::string> plugins;
       boost::split(plugins, options.at("plugins").as<std::string>(), [](char c){return c == ' ';});
 
-      if(plugins.count("account_history") && plugins.count("elasticsearch")) {
-         std::cerr << "Plugin conflict: Cannot load both account_history plugin and elasticsearch plugin\n";
-         return 1;
-      }
-
       std::for_each(plugins.begin(), plugins.end(), [&](const std::string& plug) mutable {
           if (!plug.empty()) {
              node.enable_plugin(plug);

--- a/programs/delayed_node/main.cpp
+++ b/programs/delayed_node/main.cpp
@@ -70,9 +70,9 @@ int main(int argc, char** argv) {
 
       bpo::variables_map options;
 
-      auto delayed_plug = node->register_plugin<delayed_node::delayed_node_plugin>();
-      auto history_plug = node->register_plugin<account_history::account_history_plugin>();
-      auto market_history_plug = node->register_plugin<market_history::market_history_plugin>();
+      auto delayed_plug = node->register_plugin<delayed_node::delayed_node_plugin>(true);
+      auto history_plug = node->register_plugin<account_history::account_history_plugin>(true);
+      auto market_history_plug = node->register_plugin<market_history::market_history_plugin>(true);
 
       try
       {
@@ -87,13 +87,6 @@ int main(int argc, char** argv) {
         std::cerr << "Error parsing command line: " << e.what() << "\n";
         return 1;
       }
-
-      std::set<std::string> plugins = {"delayed_node", "account_history", "market_history"};
-      std::for_each(plugins.begin(), plugins.end(), [node](const std::string& plug) mutable {
-          if (!plug.empty()) {
-             node->enable_plugin(plug);
-          }
-      });
 
       if( options.count("help") )
       {

--- a/programs/witness_node/main.cpp
+++ b/programs/witness_node/main.cpp
@@ -65,9 +65,11 @@ int main(int argc, char** argv) {
       bpo::options_description cfg_options("Graphene Witness Node");
       app_options.add_options()
             ("help,h", "Print this help message and exit.")
-            ("data-dir,d", bpo::value<boost::filesystem::path>()->default_value("witness_node_data_dir"), "Directory containing databases, configuration file, etc.")
+            ("data-dir,d", bpo::value<boost::filesystem::path>()->default_value("witness_node_data_dir"),
+                    "Directory containing databases, configuration file, etc.")
             ("version,v", "Display version information")
-            ("plugins", bpo::value<std::string>(), "Space-separated list of plugins to activate");
+            ("plugins", bpo::value<std::string>()->default_value("witness account_history market_history grouped_orders"),
+                    "Space-separated list of plugins to activate");
 
       bpo::variables_map options;
 
@@ -110,12 +112,6 @@ int main(int argc, char** argv) {
                 node->enable_plugin(plug);
              }
          });
-      }
-      else {
-         node->enable_plugin("witness");
-         node->enable_plugin("account_history");
-         node->enable_plugin("market_history");
-         node->enable_plugin("grouped_orders");
       }
       
       if( options.count("help") )

--- a/programs/witness_node/main.cpp
+++ b/programs/witness_node/main.cpp
@@ -117,8 +117,7 @@ int main(int argc, char** argv) {
          node->enable_plugin("market_history");
          node->enable_plugin("grouped_orders");
       }
-
-
+      
       if( options.count("help") )
       {
          std::cout << app_options << "\n";

--- a/programs/witness_node/main.cpp
+++ b/programs/witness_node/main.cpp
@@ -97,22 +97,19 @@ int main(int argc, char** argv) {
          return 1;
       }
 
-      if (options.count("plugins")) {
+      std::set<std::string> plugins;
+      boost::split(plugins, options.at("plugins").as<std::string>(), [](char c){return c == ' ';});
 
-         std::set<std::string> plugins;
-         boost::split(plugins, options.at("plugins").as<std::string>(), [](char c){return c == ' ';});
-
-         if(plugins.count("account_history") && plugins.count("elasticsearch")) {
-            std::cerr << "Plugin conflict: Cannot load both account_history plugin and elasticsearch plugin\n";
-            return 1;
-         }
-
-         std::for_each(plugins.begin(), plugins.end(), [node](const std::string& plug) mutable {
-             if (!plug.empty()) {
-                node->enable_plugin(plug);
-             }
-         });
+      if(plugins.count("account_history") && plugins.count("elasticsearch")) {
+         std::cerr << "Plugin conflict: Cannot load both account_history plugin and elasticsearch plugin\n";
+         return 1;
       }
+
+      std::for_each(plugins.begin(), plugins.end(), [node](const std::string& plug) mutable {
+         if (!plug.empty()) {
+            node->enable_plugin(plug);
+         }
+      });
       
       if( options.count("help") )
       {

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -114,10 +114,10 @@ int get_available_port()
 std::shared_ptr<graphene::app::application> start_application(fc::temp_directory& app_dir, int& server_port_number) {
    std::shared_ptr<graphene::app::application> app1(new graphene::app::application{});
 
-   app1->register_plugin<graphene::account_history::account_history_plugin>();
-   app1->register_plugin< graphene::market_history::market_history_plugin >();
-   app1->register_plugin< graphene::witness_plugin::witness_plugin >();
-   app1->register_plugin< graphene::grouped_orders::grouped_orders_plugin>();
+   app1->register_plugin<graphene::account_history::account_history_plugin>(true);
+   app1->register_plugin< graphene::market_history::market_history_plugin >(true);
+   app1->register_plugin< graphene::witness_plugin::witness_plugin >(true);
+   app1->register_plugin< graphene::grouped_orders::grouped_orders_plugin>(true);
    app1->startup_plugins();
    boost::program_options::variables_map cfg;
 #ifdef _WIN32


### PR DESCRIPTION
I am sorry to have to open a new pull request for this ...

Related pulls and history are in: https://github.com/bitshares/bitshares-core/pull/1427 and https://github.com/bitshares/bitshares-core/pull/1431

In this one i used the commits from @nathanhourt but moved the plugin option to the executable as suggested by https://github.com/bitshares/bitshares-core/pull/1431#issuecomment-438271766

In `witness_node/main.cpp` all plugins need to be registered: https://github.com/oxarbitrage/bitshares-core/blob/f5031bde96c5f3e20fc71c1d34a519bb417e850d/programs/witness_node/main.cpp#L74-L82 but only the ones from the command line will be enabled: https://github.com/oxarbitrage/bitshares-core/blob/f5031bde96c5f3e20fc71c1d34a519bb417e850d/programs/witness_node/main.cpp#L110 or the default ones: https://github.com/oxarbitrage/bitshares-core/blob/f5031bde96c5f3e20fc71c1d34a519bb417e850d/programs/witness_node/main.cpp#L115-L118

This will at least remove the hardcoded plugins from the application. 

I was not able to use `register_plugin<>(true)` here as they all need to be registered before parsing the command line but only some enabled after it, however i did not removed the option as there is probably a workaround for my code there that can make it simpler by the use of that.

Another thing changed is `enable_plugin()` member from private to public to be called by the executable.

Let me know what do you guys think as if we go with this approach i will need to do something similar in delayed node.

A few things i also noticed while working on this and related are, probably to consider as new issues:

- Some plugins(snapshot, witness) add some log msg to the console when they start so you can know they are loaded, others don't do this so you actually dont know from the console if they were loaded or not. I think we should do something for that.
- The options you add to the command line are ignored in the config file created, for example if you call the node with `witness_node --someoption true`, then `someoption` should be the only line not commented in the config file however this is not the case, it loads the default options. Same behaviour without this pull request(not related to this changes).