### PR TITLE
Testnet fix for stuck chain with hardfork protection

### DIFF
--- a/libraries/chain/db_maint.cpp
+++ b/libraries/chain/db_maint.cpp
@@ -805,6 +805,7 @@ void database::process_bids( const asset_bitasset_data_object& bad )
    asset_id_type to_revive_id = (asset( 0, bad.options.short_backing_asset ) * bad.settlement_price).asset_id;
    const asset_object& to_revive = to_revive_id( *this );
    const asset_dynamic_data_object& bdd = to_revive.dynamic_data( *this );
+   const bool has_hf_20181128 = head_block_time() >= HARDFORK_TEST_20171128_TIME;
 
    const auto& bid_idx = get_index_type< collateral_bid_index >().indices().get<by_price>();
    const auto start = bid_idx.lower_bound( boost::make_tuple( to_revive_id, price::max( bad.options.short_backing_asset, to_revive_id ), collateral_bid_id_type() ) );
@@ -815,7 +816,7 @@ void database::process_bids( const asset_bitasset_data_object& bad )
    {
       const collateral_bid_object& bid = *itr;
       asset debt_in_bid = bid.inv_swan_price.quote;
-      if( debt_in_bid.amount > bdd.current_supply )
+      if( has_hf_20181128 && debt_in_bid.amount > bdd.current_supply )
          debt_in_bid.amount = bdd.current_supply;
       asset total_collateral = debt_in_bid * bad.settlement_price;
       total_collateral += bid.inv_swan_price.base;

--- a/libraries/chain/hardfork.d/TEST_HF_20181128.hf
+++ b/libraries/chain/hardfork.d/TEST_HF_20181128.hf
@@ -1,0 +1,5 @@
+// Delays the stuck chain fix until this time, to avoid replay problem in testnet
+// 2018-11-28T00:00:00+0200
+#ifndef HARDFORK_TEST_20171128_TIME
+#define HARDFORK_TEST_20171128_TIME (fc::time_point_sec( 1543356000 ))
+#endif

--- a/libraries/chain/include/graphene/chain/config.hpp
+++ b/libraries/chain/include/graphene/chain/config.hpp
@@ -121,7 +121,7 @@
 #define GRAPHENE_RECENTLY_MISSED_COUNT_INCREMENT             4
 #define GRAPHENE_RECENTLY_MISSED_COUNT_DECREMENT             3
 
-#define GRAPHENE_CURRENT_DB_VERSION                          "BTS2.181127"
+#define GRAPHENE_CURRENT_DB_VERSION                          "BTS2.181128"
 
 #define GRAPHENE_IRREVERSIBLE_THRESHOLD                      (70 * GRAPHENE_1_PERCENT)
 

--- a/tests/tests/swan_tests.cpp
+++ b/tests/tests/swan_tests.cpp
@@ -497,7 +497,7 @@ BOOST_AUTO_TEST_CASE( overflow )
 { try {
    init_standard_swan( 700 );
 
-   wait_for_hf_core_216();
+   generate_blocks( HARDFORK_TEST_20171128_TIME );
 
    bid_collateral( borrower(),  back().amount(2200), swan().amount(GRAPHENE_MAX_SHARE_SUPPLY - 1) );
    bid_collateral( borrower2(), back().amount(2100), swan().amount(1399) );


### PR DESCRIPTION
test-2.0.181127 doesn't work because the fix has a retroactive effect on bitasset revivals on testnet, which leads to inconsistent state and replay failure.
This fix adds hardfork protection (for testnet only), with hf time set to 2018-11-28T00:00:00+0200