### PR TITLE
Fix for errors while loading object_database

### DIFF
--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -577,7 +577,7 @@ vector<vector<account_id_type>> database_api_impl::get_key_references( vector<pu
           auto itr = refs.account_to_address_memberships.find(a);
           if( itr != refs.account_to_address_memberships.end() )
           {
-             result.reserve( itr->second.size() );
+             result.reserve( result.size() + itr->second.size() );
              for( auto item : itr->second )
              {
                 result.push_back(item);
@@ -587,7 +587,7 @@ vector<vector<account_id_type>> database_api_impl::get_key_references( vector<pu
 
       if( itr != refs.account_to_key_memberships.end() )
       {
-         result.reserve( itr->second.size() );
+         result.reserve( result.size() + itr->second.size() );
          for( auto item : itr->second ) result.push_back(item);
       }
       final_result.emplace_back( std::move(result) );

--- a/libraries/db/include/graphene/db/index.hpp
+++ b/libraries/db/include/graphene/db/index.hpp
@@ -234,14 +234,12 @@ namespace graphene { namespace db {
             fc::raw::unpack(ds, _next_id);
             fc::raw::unpack(ds, open_ver);
             FC_ASSERT( open_ver == get_object_version(), "Incompatible Version, the serialization of objects in this index has changed" );
-            try {
-               vector<char> tmp;
-               while( true ) 
-               {
-                  fc::raw::unpack( ds, tmp );
-                  load( tmp );
-               }
-            } catch ( const fc::exception&  ){}
+            vector<char> tmp;
+            while( ds.remaining() > 0 )
+            {
+               fc::raw::unpack( ds, tmp );
+               load( tmp );
+            }
          }
 
          virtual void save( const path& db ) override 


### PR DESCRIPTION
Errors while reading object_database were silently ignored, which could lead to an incomplete or inconsistent database after restart. Now, exceptions are no longer caught and will trigger application abort.

Also includes a fix for a minor efficiency in an API call.