### PR TITLE
prevent child node to generate block

### DIFF
--- a/libraries/plugins/witness/include/graphene/witness/witness.hpp
+++ b/libraries/plugins/witness/include/graphene/witness/witness.hpp
@@ -42,7 +42,8 @@ namespace block_production_condition
       low_participation = 5,
       lag = 6,
       exception_producing_block = 7,
-      shutdown = 8
+      shutdown = 8,
+      not_first_node = 9
    };
 }
 


### PR DESCRIPTION
i hope that child_node's enable-stale-production default value is  false,even if you set it to true,but invalid.