### PR TITLE
Prevent exception when querying account history

### DIFF
--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -370,18 +370,15 @@ namespace graphene { namespace app {
 
              if(node->operation_id(db).op.which() == operation_id)
                result.push_back( node->operation_id(db) );
-             }
+          }
           if( node->next == account_transaction_history_id_type() )
              node = nullptr;
           else node = &node->next(db);
        }
        if( stop.instance.value == 0 && result.size() < limit ) {
-          try
-          {
-            const account_transaction_history_object head = account_transaction_history_id_type()(db);
-            if( head.account == account && head.operation_id(db).op.which() == operation_id )
-               result.push_back(head.operation_id(db));
-          } catch (fc::exception& ignore) { /* limit of history reached, head not found */ }
+          auto head = db.find(account_transaction_history_id_type());
+          if (head != nullptr && head->account == account && head->operation_id(db).op.which() == operation_id)
+            result.push_back(head->operation_id(db));
        }
        return result;
     }

--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -376,9 +376,12 @@ namespace graphene { namespace app {
           else node = &node->next(db);
        }
        if( stop.instance.value == 0 && result.size() < limit ) {
-          const account_transaction_history_object head = account_transaction_history_id_type()(db);
-          if( head.account == account && head.operation_id(db).op.which() == operation_id )
-             result.push_back(head.operation_id(db));
+          try
+          {
+            const account_transaction_history_object head = account_transaction_history_id_type()(db);
+            if( head.account == account && head.operation_id(db).op.which() == operation_id )
+               result.push_back(head.operation_id(db));
+          } catch (fc::exception& ignore) { /* limit of history reached, head not found */ }
        }
        return result;
     }

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -111,8 +111,17 @@ database_fixture::database_fixture()
 
    open_database();
 
+   /**
+    * Test specific settings
+    */
+   auto current_test_name = boost::unit_test::framework::current_test_case().p_name.value;
+   auto current_test_suite_id = boost::unit_test::framework::current_test_case().p_parent_id;
+   if (current_test_name == "get_account_history_operations")
+   {
+      options.insert(std::make_pair("max-ops-per-account", boost::program_options::variable_value((uint64_t)75, false)));
+   }
    // add account tracking for ahplugin for special test case with track-account enabled
-   if( !options.count("track-account") && boost::unit_test::framework::current_test_case().p_name.value == "track_account") {
+   if( !options.count("track-account") && current_test_name == "track_account") {
       std::vector<std::string> track_account;
       std::string track = "\"1.2.17\"";
       track_account.push_back(track);
@@ -120,7 +129,7 @@ database_fixture::database_fixture()
       options.insert(std::make_pair("partial-operations", boost::program_options::variable_value(true, false)));
    }
    // account tracking 2 accounts
-   if( !options.count("track-account") && boost::unit_test::framework::current_test_case().p_name.value == "track_account2") {
+   if( !options.count("track-account") && current_test_name == "track_account2") {
       std::vector<std::string> track_account;
       std::string track = "\"1.2.0\"";
       track_account.push_back(track);
@@ -133,10 +142,7 @@ database_fixture::database_fixture()
        boost::unit_test::framework::current_test_case().p_name.value == "track_votes_committee_disabled") {
       app.chain_database()->enable_standby_votes_tracking( false );
    }
-
-   auto test_name = boost::unit_test::framework::current_test_case().p_name.value;
-   auto test_suite_id = boost::unit_test::framework::current_test_case().p_parent_id;
-   if(test_name == "elasticsearch_account_history" || test_name == "elasticsearch_suite") {
+   if(current_test_name == "elasticsearch_account_history" || current_test_name == "elasticsearch_suite") {
       auto esplugin = app.register_plugin<graphene::elasticsearch::elasticsearch_plugin>();
       esplugin->plugin_set_app(&app);
 
@@ -149,7 +155,7 @@ database_fixture::database_fixture()
       esplugin->plugin_initialize(options);
       esplugin->plugin_startup();
    }
-   else if( boost::unit_test::framework::get<boost::unit_test::test_suite>(test_suite_id).p_name.value != "performance_tests" )
+   else if( boost::unit_test::framework::get<boost::unit_test::test_suite>(current_test_suite_id).p_name.value != "performance_tests" )
    {
       auto ahplugin = app.register_plugin<graphene::account_history::account_history_plugin>();
       ahplugin->plugin_set_app(&app);
@@ -157,7 +163,7 @@ database_fixture::database_fixture()
       ahplugin->plugin_startup();
    }
 
-   if(test_name == "elasticsearch_objects" || test_name == "elasticsearch_suite") {
+   if(current_test_name == "elasticsearch_objects" || current_test_name == "elasticsearch_suite") {
       auto esobjects_plugin = app.register_plugin<graphene::es_objects::es_objects_plugin>();
       esobjects_plugin->plugin_set_app(&app);
 

--- a/tests/tests/history_api_tests.cpp
+++ b/tests/tests/history_api_tests.cpp
@@ -582,16 +582,19 @@ BOOST_AUTO_TEST_CASE(get_account_history_operations) {
       BOOST_CHECK_EQUAL(histories[0].op.which(), account_create_op_id);
 
       // create a bunch of accounts
-      for(int i = 0; i < 110; ++i)
+      for(int i = 0; i < 80; ++i)
       {
          std::string acct_name = "mytempacct" + std::to_string(i);
          create_account(acct_name);
       }
       generate_block();
 
+      // history is set to limit transactions to 75 (see database_fixture.hpp)
+      // so asking for more should only return 75 (and not throw exception, 
+      // see https://github.com/bitshares/bitshares-core/issues/1490
       histories = hist_api.get_account_history_operations(
             "committee-account", account_create_op_id, operation_history_id_type(), operation_history_id_type(), 100);
-      BOOST_CHECK_EQUAL(histories.size(), 100);
+      BOOST_CHECK_EQUAL(histories.size(), 75);
       if (histories.size() > 0)
          BOOST_CHECK_EQUAL(histories[0].op.which(), account_create_op_id);
       

--- a/tests/tests/history_api_tests.cpp
+++ b/tests/tests/history_api_tests.cpp
@@ -549,31 +549,52 @@ BOOST_AUTO_TEST_CASE(get_account_history_operations) {
 
       int asset_create_op_id = operation::tag<asset_create_operation>::value;
       int account_create_op_id = operation::tag<account_create_operation>::value;
+      int transfer_op_id = operation::tag<graphene::chain::transfer_operation>::value;
 
       //account_id_type() did 1 asset_create op
-      vector<operation_history_object> histories = hist_api.get_account_history_operations("committee-account", asset_create_op_id, operation_history_id_type(), operation_history_id_type(), 100);
+      vector<operation_history_object> histories = hist_api.get_account_history_operations(
+            "committee-account", asset_create_op_id, operation_history_id_type(), operation_history_id_type(), 100);
       BOOST_CHECK_EQUAL(histories.size(), 1);
       BOOST_CHECK_EQUAL(histories[0].id.instance(), 0);
       BOOST_CHECK_EQUAL(histories[0].op.which(), asset_create_op_id);
 
       //account_id_type() did 2 account_create ops
-      histories = hist_api.get_account_history_operations("committee-account", account_create_op_id, operation_history_id_type(), operation_history_id_type(), 100);
+      histories = hist_api.get_account_history_operations(
+            "committee-account", account_create_op_id, operation_history_id_type(), operation_history_id_type(), 100);
       BOOST_CHECK_EQUAL(histories.size(), 2);
       BOOST_CHECK_EQUAL(histories[0].op.which(), account_create_op_id);
 
       // No asset_create op larger than id1
-      histories = hist_api.get_account_history_operations("committee-account", asset_create_op_id, operation_history_id_type(), operation_history_id_type(1), 100);
+      histories = hist_api.get_account_history_operations(
+            "committee-account", asset_create_op_id, operation_history_id_type(), operation_history_id_type(1), 100);
       BOOST_CHECK_EQUAL(histories.size(), 0);
 
       // Limit 1 returns 1 result
-      histories = hist_api.get_account_history_operations("committee-account", account_create_op_id, operation_history_id_type(),operation_history_id_type(), 1);
+      histories = hist_api.get_account_history_operations(
+            "committee-account", account_create_op_id, operation_history_id_type(),operation_history_id_type(), 1);
       BOOST_CHECK_EQUAL(histories.size(), 1);
       BOOST_CHECK_EQUAL(histories[0].op.which(), account_create_op_id);
 
       // alice has 1 op
-      histories = hist_api.get_account_history_operations("alice", account_create_op_id, operation_history_id_type(),operation_history_id_type(), 100);
+      histories = hist_api.get_account_history_operations(
+            "alice", account_create_op_id, operation_history_id_type(),operation_history_id_type(), 100);
       BOOST_CHECK_EQUAL(histories.size(), 1);
       BOOST_CHECK_EQUAL(histories[0].op.which(), account_create_op_id);
+
+      // create a bunch of accounts
+      for(int i = 0; i < 110; ++i)
+      {
+         std::string acct_name = "mytempacct" + std::to_string(i);
+         create_account(acct_name);
+      }
+      generate_block();
+
+      histories = hist_api.get_account_history_operations(
+            "committee-account", account_create_op_id, operation_history_id_type(), operation_history_id_type(), 100);
+      BOOST_CHECK_EQUAL(histories.size(), 100);
+      if (histories.size() > 0)
+         BOOST_CHECK_EQUAL(histories[0].op.which(), account_create_op_id);
+      
 
    } catch (fc::exception &e) {
       edump((e.to_detail_string()));


### PR DESCRIPTION
Fixes #1490 

When calling get_account_history_operations using a node with limited history, an exception can be thrown that prevents the user from getting any information.

This fix provides the history up to the limit of the connected node.