### PR TITLE
Log informational message when plugin starts

### DIFF
--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -1151,7 +1151,10 @@ void application::initialize_plugins( const boost::program_options::variables_ma
 void application::startup_plugins()
 {
    for( auto& entry : my->_active_plugins )
+   {
       entry.second->plugin_startup();
+      ilog( "Plugin ${name} started", ( "name", entry.second->plugin_name() ) );
+   }
    return;
 }
 


### PR DESCRIPTION
Fixes #1459 

Once a plugin starts, an informational message is added to the log, showing the name of the plugin and that it has started. Example:

```
674910ms th_a       application.cpp:196           reset_p2p_node       ] Adding seed node 144.202.100.49:1776
674911ms th_a       application.cpp:211           reset_p2p_node       ] Configured p2p node to listen on 0.0.0.0:43911
674912ms th_a       application.cpp:1156          startup_plugins      ] Plugin account_history started
674912ms th_a       application.cpp:1156          startup_plugins      ] Plugin grouped_orders started
674912ms th_a       application.cpp:1156          startup_plugins      ] Plugin market_history started
674912ms th_a       witness.cpp:118               plugin_startup       ] witness plugin:  plugin_startup() begin
674912ms th_a       witness.cpp:139               plugin_startup       ] No witness configured.
674912ms th_a       witness.cpp:141               plugin_startup       ] witness plugin:  plugin_startup() end
674912ms th_a       application.cpp:1156          startup_plugins      ] Plugin witness started
```