### PR TITLE
Fix compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ else( WIN32 ) # Apple AND Linux
     else( APPLE )
         # Linux Specific Options Here
         message( STATUS "Configuring BitShares on Linux" )
-        set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++11 -Wall -Wno-class-memaccess -Wno-parentheses" )
+        set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++11 -Wall" )
         if(USE_PROFILER)
             set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pg" )
         endif( USE_PROFILER )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ else( WIN32 ) # Apple AND Linux
     else( APPLE )
         # Linux Specific Options Here
         message( STATUS "Configuring BitShares on Linux" )
-        set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++11 -Wall" )
+        set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++11 -Wall -Wno-class-memaccess -Wno-parentheses" )
         if(USE_PROFILER)
             set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pg" )
         endif( USE_PROFILER )

--- a/libraries/db/include/graphene/db/undo_database.hpp
+++ b/libraries/db/include/graphene/db/undo_database.hpp
@@ -59,7 +59,7 @@ namespace graphene { namespace db {
                {
                   mv._apply_undo = false;
                }
-               ~session(); // defined in implementation file to prevent repeated compiler warnings
+               ~session();
                void commit() { _apply_undo = false; _db.commit();  }
                void undo()   { if( _apply_undo ) _db.undo(); _apply_undo = false; }
                void merge()  { if( _apply_undo ) _db.merge(); _apply_undo = false; }

--- a/libraries/db/include/graphene/db/undo_database.hpp
+++ b/libraries/db/include/graphene/db/undo_database.hpp
@@ -59,17 +59,7 @@ namespace graphene { namespace db {
                {
                   mv._apply_undo = false;
                }
-               ~session() {
-                  try {
-                     if( _apply_undo ) _db.undo();
-                  }
-                  catch ( const fc::exception& e )
-                  {
-                     elog( "${e}", ("e",e.to_detail_string() ) );
-                     throw; // maybe crash..
-                  }
-                  if( _disable_on_exit ) _db.disable();
-               }
+               ~session(); // defined in implementation file to prevent repeated compiler warnings
                void commit() { _apply_undo = false; _db.commit();  }
                void undo()   { if( _apply_undo ) _db.undo(); _apply_undo = false; }
                void merge()  { if( _apply_undo ) _db.merge(); _apply_undo = false; }

--- a/libraries/db/undo_database.cpp
+++ b/libraries/db/undo_database.cpp
@@ -30,6 +30,19 @@ namespace graphene { namespace db {
 void undo_database::enable()  { _disabled = false; }
 void undo_database::disable() { _disabled = true; }
 
+undo_database::session::~session()
+{
+   try {
+      if( _apply_undo ) _db.undo();
+   }
+   catch ( const fc::exception& e )
+   {
+      elog( "${e}", ("e",e.to_detail_string() ) );
+      throw; // maybe crash..
+   }
+   if( _disable_on_exit ) _db.disable();
+}
+
 undo_database::session undo_database::start_undo_session( bool force_enable )
 {
    if( _disabled && !force_enable ) return session(*this);

--- a/tests/app/main.cpp
+++ b/tests/app/main.cpp
@@ -78,8 +78,8 @@ BOOST_AUTO_TEST_CASE(load_configuration_options_test_config_logging_files_create
    /// check post-conditions
    BOOST_CHECK(fc::exists(config_ini_file));
    BOOST_CHECK(fc::exists(logging_ini_file));
-   BOOST_CHECK_GT(fc::file_size(config_ini_file), 0);
-   BOOST_CHECK_GT(fc::file_size(logging_ini_file), 0);
+   BOOST_CHECK_GT(fc::file_size(config_ini_file), 0u);
+   BOOST_CHECK_GT(fc::file_size(logging_ini_file), 0u);
 }
 
 BOOST_AUTO_TEST_CASE(load_configuration_options_test_config_ini_options)
@@ -109,8 +109,8 @@ BOOST_AUTO_TEST_CASE(load_configuration_options_test_config_ini_options)
 
    /// check the options values are parsed into the output map
    BOOST_CHECK(!options.empty());
-   BOOST_CHECK_EQUAL(options.count("option1"), 1);
-   BOOST_CHECK_EQUAL(options.count("option2"), 1);
+   BOOST_CHECK_EQUAL(options.count("option1"), 1u);
+   BOOST_CHECK_EQUAL(options.count("option2"), 1u);
    BOOST_CHECK_EQUAL(options["option1"].as<std::string>(), "is present");
    BOOST_CHECK_EQUAL(options["option2"].as<int>(), 1);
 
@@ -151,9 +151,9 @@ BOOST_AUTO_TEST_CASE(load_configuration_options_test_logging_ini_options)
    /// this is a little bit tricky since load_configuration_options() doesn't provide output variable for logging_config
    auto logger_map = fc::get_logger_map();
    auto appender_map = fc::get_appender_map();
-   BOOST_CHECK_EQUAL(logger_map.size(), 1);
+   BOOST_CHECK_EQUAL(logger_map.size(), 1u);
    BOOST_CHECK(logger_map.count("default"));
-   BOOST_CHECK_EQUAL(appender_map.size(), 1);
+   BOOST_CHECK_EQUAL(appender_map.size(), 1u);
    BOOST_CHECK(appender_map.count("default"));
 }
 
@@ -195,16 +195,16 @@ BOOST_AUTO_TEST_CASE(load_configuration_options_test_legacy_config_ini_options)
 
    /// check the options values are parsed into the output map
    BOOST_CHECK(!options.empty());
-   BOOST_CHECK_EQUAL(options.count("option1"), 1);
-   BOOST_CHECK_EQUAL(options.count("option2"), 1);
+   BOOST_CHECK_EQUAL(options.count("option1"), 1u);
+   BOOST_CHECK_EQUAL(options.count("option2"), 1u);
    BOOST_CHECK_EQUAL(options["option1"].as<std::string>(), "is present");
    BOOST_CHECK_EQUAL(options["option2"].as<int>(), 1);
 
    auto logger_map = fc::get_logger_map();
    auto appender_map = fc::get_appender_map();
-   BOOST_CHECK_EQUAL(logger_map.size(), 1);
+   BOOST_CHECK_EQUAL(logger_map.size(), 1u);
    BOOST_CHECK(logger_map.count("default"));
-   BOOST_CHECK_EQUAL(appender_map.size(), 1);
+   BOOST_CHECK_EQUAL(appender_map.size(), 1u);
    BOOST_CHECK(appender_map.count("default"));
 }
 
@@ -256,7 +256,7 @@ BOOST_AUTO_TEST_CASE( two_node_network )
       app2.startup();
       fc::usleep(fc::milliseconds(500));
 
-      BOOST_REQUIRE_EQUAL(app1.p2p_node()->get_connection_count(), 1);
+      BOOST_REQUIRE_EQUAL(app1.p2p_node()->get_connection_count(), 1u);
       BOOST_CHECK_EQUAL(std::string(app1.p2p_node()->get_connected_peers().front().host.get_address()), "127.0.0.1");
       BOOST_TEST_MESSAGE( "app1 and app2 successfully connected" );
 
@@ -321,8 +321,8 @@ BOOST_AUTO_TEST_CASE( two_node_network )
 
       fc::usleep(fc::milliseconds(500));
       BOOST_TEST_MESSAGE( "Verifying nodes are still connected" );
-      BOOST_CHECK_EQUAL(app1.p2p_node()->get_connection_count(), 1);
-      BOOST_CHECK_EQUAL(app1.chain_database()->head_block_num(), 1);
+      BOOST_CHECK_EQUAL(app1.p2p_node()->get_connection_count(), 1u);
+      BOOST_CHECK_EQUAL(app1.chain_database()->head_block_num(), 1u);
 
       BOOST_TEST_MESSAGE( "Checking GRAPHENE_NULL_ACCOUNT has balance" );
    } catch( fc::exception& e ) {

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -549,7 +549,7 @@ BOOST_FIXTURE_TEST_CASE( account_history_pagination, cli_fixture )
 
       // now get account history and make sure everything is there (and no duplicates)
       std::vector<graphene::wallet::operation_detail> history = con.wallet_api_ptr->get_account_history("jmjatlanta", 300);
-      BOOST_CHECK_EQUAL(201, history.size() );
+      BOOST_CHECK_EQUAL(201u, history.size() );
 
       std::set<object_id_type> operation_ids;
 

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -219,7 +219,11 @@ database_fixture::~database_fixture()
       }
       return;
    } catch (fc::exception& ex) {
-      BOOST_FAIL( ex.to_detail_string() );
+      BOOST_FAIL( std::string("fc::exception in ~database_fixture: ") + ex.to_detail_string() );
+   } catch (std::exception& e) {
+      BOOST_FAIL( std::string("std::exception in ~database_fixture:") + e.what() );
+   } catch (...) {
+      BOOST_FAIL( "Uncaught exception in ~database_fixture" );
    }
 } 
 

--- a/tests/tests/asset_api_tests.cpp
+++ b/tests/tests/asset_api_tests.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE( asset_holders )
 
    // make call
    vector<account_asset_balance> holders = asset_api.get_asset_holders(asset_id_type(), 0, 100);
-   BOOST_CHECK_EQUAL(holders.size(), 4);
+   BOOST_CHECK_EQUAL(holders.size(), 4u);
 
    // by now we can guarantee the order
    BOOST_CHECK(holders[0].name == "committee-account");

--- a/tests/tests/authority_tests.cpp
+++ b/tests/tests/authority_tests.cpp
@@ -1734,7 +1734,7 @@ BOOST_AUTO_TEST_CASE( self_approving_proposal )
    trx.operations.push_back(pop);
    const proposal_id_type pid1 = PUSH_TX( db, trx, ~0 ).operation_results[0].get<object_id_type>();
    trx.clear();
-   BOOST_REQUIRE_EQUAL( 0, pid1.instance.value );
+   BOOST_REQUIRE_EQUAL( 0u, pid1.instance.value );
    db.get<proposal_object>(pid1);
 
    trx.operations.push_back(pup);
@@ -1765,7 +1765,7 @@ BOOST_AUTO_TEST_CASE( self_deleting_proposal )
    trx.operations.push_back( pop );
    const proposal_id_type pid1 = PUSH_TX( db, trx, ~0 ).operation_results[0].get<object_id_type>();
    trx.clear();
-   BOOST_REQUIRE_EQUAL( 0, pid1.instance.value );
+   BOOST_REQUIRE_EQUAL( 0u, pid1.instance.value );
    db.get<proposal_object>(pid1);
 
    proposal_update_operation pup;

--- a/tests/tests/block_tests.cpp
+++ b/tests/tests/block_tests.cpp
@@ -847,7 +847,7 @@ BOOST_FIXTURE_TEST_CASE( maintenance_interval, database_fixture )
 {
    try {
       generate_block();
-      BOOST_CHECK_EQUAL(db.head_block_num(), 2);
+      BOOST_CHECK_EQUAL(db.head_block_num(), 2u);
 
       fc::time_point_sec maintenence_time = db.get_dynamic_global_properties().next_maintenance_time;
       BOOST_CHECK_GT(maintenence_time.sec_since_epoch(), db.head_block_time().sec_since_epoch());
@@ -1024,17 +1024,17 @@ BOOST_FIXTURE_TEST_CASE( change_block_interval, database_fixture )
    }
    BOOST_TEST_MESSAGE( "Verifying that the interval didn't change immediately" );
 
-   BOOST_CHECK_EQUAL(db.get_global_properties().parameters.block_interval, 5);
+   BOOST_CHECK_EQUAL(db.get_global_properties().parameters.block_interval, 5u);
    auto past_time = db.head_block_time().sec_since_epoch();
    generate_block();
-   BOOST_CHECK_EQUAL(db.head_block_time().sec_since_epoch() - past_time, 5);
+   BOOST_CHECK_EQUAL(db.head_block_time().sec_since_epoch() - past_time, 5u);
    generate_block();
-   BOOST_CHECK_EQUAL(db.head_block_time().sec_since_epoch() - past_time, 10);
+   BOOST_CHECK_EQUAL(db.head_block_time().sec_since_epoch() - past_time, 10u);
 
    BOOST_TEST_MESSAGE( "Generating blocks until proposal expires" );
    generate_blocks(proposal_id_type()(db).expiration_time + 5);
    BOOST_TEST_MESSAGE( "Verify that the block interval is still 5 seconds" );
-   BOOST_CHECK_EQUAL(db.get_global_properties().parameters.block_interval, 5);
+   BOOST_CHECK_EQUAL(db.get_global_properties().parameters.block_interval, 5u);
 
    BOOST_TEST_MESSAGE( "Generating blocks until next maintenance interval" );
    generate_blocks(db.get_dynamic_global_properties().next_maintenance_time);
@@ -1044,9 +1044,9 @@ BOOST_FIXTURE_TEST_CASE( change_block_interval, database_fixture )
    BOOST_CHECK_EQUAL(db.get_global_properties().parameters.block_interval, 1);
    past_time = db.head_block_time().sec_since_epoch();
    generate_block();
-   BOOST_CHECK_EQUAL(db.head_block_time().sec_since_epoch() - past_time, 1);
+   BOOST_CHECK_EQUAL(db.head_block_time().sec_since_epoch() - past_time, 1u);
    generate_block();
-   BOOST_CHECK_EQUAL(db.head_block_time().sec_since_epoch() - past_time, 2);
+   BOOST_CHECK_EQUAL(db.head_block_time().sec_since_epoch() - past_time, 2u);
 } FC_LOG_AND_RETHROW() }
 
 BOOST_FIXTURE_TEST_CASE( pop_block_twice, database_fixture )
@@ -1122,7 +1122,7 @@ BOOST_FIXTURE_TEST_CASE( rsf_missed_blocks, database_fixture )
          "1111111111111111111111111111111111111111111111111111111111111111"
          "1111111111111111111111111111111111111111111111111111111111111111"
       );
-      BOOST_CHECK_EQUAL( db.witness_participation_rate(), GRAPHENE_100_PERCENT );
+      BOOST_CHECK_EQUAL( db.witness_participation_rate(), (uint32_t)GRAPHENE_100_PERCENT );
 
       generate_block( ~0, init_account_priv_key, 1 );
       BOOST_CHECK_EQUAL( rsf(),
@@ -1419,7 +1419,7 @@ BOOST_AUTO_TEST_CASE( genesis_reserve_ids )
 BOOST_FIXTURE_TEST_CASE( miss_some_blocks, database_fixture )
 { try {
    std::vector<witness_id_type> witnesses = witness_schedule_id_type()(db).current_shuffled_witnesses;
-   BOOST_CHECK_EQUAL( 10, witnesses.size() );
+   BOOST_CHECK_EQUAL( 10u, witnesses.size() );
    // database_fixture constructor calls generate_block once, signed by witnesses[0]
    generate_block(); // witnesses[1]
    generate_block(); // witnesses[2]
@@ -1914,7 +1914,7 @@ BOOST_FIXTURE_TEST_CASE( block_size_test, database_fixture )
          idump( (fc::raw::pack_size(good_block)) );
       }
       // make sure we have tested at least once pushing a large block
-      BOOST_CHECK_GT( large_block_count, 0 );
+      BOOST_CHECK_GT( large_block_count, 0u );
    }
    catch( fc::exception& e )
    {

--- a/tests/tests/database_tests.cpp
+++ b/tests/tests/database_tests.cpp
@@ -73,13 +73,13 @@ BOOST_AUTO_TEST_CASE(failed_modify_test)
                      obj.owner = account_id_type(123);
                   });
    account_balance_id_type obj_id = obj.id;
-   BOOST_CHECK_EQUAL(obj.owner.instance.value, 123);
+   BOOST_CHECK_EQUAL(obj.owner.instance.value, 123u);
 
    // Modify dummy object, check that changes stick
    db.modify(obj, [](account_balance_object& obj) {
       obj.owner = account_id_type(234);
    });
-   BOOST_CHECK_EQUAL(obj_id(db).owner.instance.value, 234);
+   BOOST_CHECK_EQUAL(obj_id(db).owner.instance.value, 234u);
 
    // Throw exception when modifying object, check that object still exists after
    BOOST_CHECK_THROW(db.modify(obj, [](account_balance_object& obj) {
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE( direct_index_test )
 
    graphene::db::primary_index< account_index, 8 > my_accounts( db );
    const auto& direct = my_accounts.get_secondary_index<graphene::db::direct_index< account_object, 8 >>();
-   BOOST_CHECK_EQUAL( 0, my_accounts.indices().size() );
+   BOOST_CHECK_EQUAL( 0u, my_accounts.indices().size() );
    BOOST_CHECK( nullptr == direct.find( account_id_type( 1 ) ) );
    // BOOST_CHECK_THROW( direct.find( asset_id_type( 1 ) ), fc::assert_exception ); // compile-time error
    BOOST_CHECK_THROW( direct.find( object_id_type( asset_id_type( 1 ) ) ), fc::assert_exception );
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE( direct_index_test )
 
    my_accounts.load( fc::raw::pack( test_account ) );
 
-   BOOST_CHECK_EQUAL( 1, my_accounts.indices().size() );
+   BOOST_CHECK_EQUAL( 1u, my_accounts.indices().size() );
    BOOST_CHECK( nullptr == direct.find( account_id_type( 0 ) ) );
    BOOST_CHECK( nullptr == direct.find( account_id_type( 2 ) ) );
    BOOST_CHECK( nullptr != direct.find( account_id_type( 1 ) ) );
@@ -174,7 +174,7 @@ BOOST_AUTO_TEST_CASE( direct_index_test )
    // direct.next is now 103, but index sequence counter is 0
    my_accounts.create( [] ( object& o ) {
        account_object& acct = dynamic_cast< account_object& >( o );
-       BOOST_CHECK_EQUAL( 0, acct.id.instance() );
+       BOOST_CHECK_EQUAL( 0u, acct.id.instance() );
        acct.name = "account0";
    } );
 
@@ -198,7 +198,7 @@ BOOST_AUTO_TEST_CASE( direct_index_test )
    GRAPHENE_REQUIRE_THROW( my_accounts.load( fc::raw::pack( test_account ) ), fc::assert_exception );
    // This is actually undefined behaviour. The object has been inserted into
    // the primary index, but the secondary has refused to insert it!
-   BOOST_CHECK_EQUAL( 5, my_accounts.indices().size() );
+   BOOST_CHECK_EQUAL( 5u, my_accounts.indices().size() );
 
    uint32_t count = 0;
    for( uint32_t i = 0; i < 250; i++ )

--- a/tests/tests/fee_tests.cpp
+++ b/tests/tests/fee_tests.cpp
@@ -437,11 +437,11 @@ BOOST_AUTO_TEST_CASE( cashback_test )
    PREP_ACTOR(stud);
    PREP_ACTOR(pleb);
    // use ##_public_key vars to silence unused variable warning
-   BOOST_CHECK_GT(ann_public_key.key_data.size(), 0);
-   BOOST_CHECK_GT(scud_public_key.key_data.size(), 0);
-   BOOST_CHECK_GT(dumy_public_key.key_data.size(), 0);
-   BOOST_CHECK_GT(stud_public_key.key_data.size(), 0);
-   BOOST_CHECK_GT(pleb_public_key.key_data.size(), 0);
+   BOOST_CHECK_GT(ann_public_key.key_data.size(), 0u);
+   BOOST_CHECK_GT(scud_public_key.key_data.size(), 0u);
+   BOOST_CHECK_GT(dumy_public_key.key_data.size(), 0u);
+   BOOST_CHECK_GT(stud_public_key.key_data.size(), 0u);
+   BOOST_CHECK_GT(pleb_public_key.key_data.size(), 0u);
 
    account_id_type ann_id, scud_id, dumy_id, stud_id, pleb_id;
    actor_audit alife, arog, aann, ascud, adumy, astud, apleb;
@@ -716,23 +716,23 @@ BOOST_AUTO_TEST_CASE( account_create_fee_scaling )
 
    for( int i = db.get_dynamic_global_properties().accounts_registered_this_interval; i < accounts_per_scale; ++i )
    {
-      BOOST_CHECK_EQUAL(db.get_global_properties().parameters.current_fees->get<account_create_operation>().basic_fee, 1);
+      BOOST_CHECK_EQUAL(db.get_global_properties().parameters.current_fees->get<account_create_operation>().basic_fee, 1u);
       create_account("shill" + fc::to_string(i));
    }
    for( int i = 0; i < accounts_per_scale; ++i )
    {
-      BOOST_CHECK_EQUAL(db.get_global_properties().parameters.current_fees->get<account_create_operation>().basic_fee, 16);
+      BOOST_CHECK_EQUAL(db.get_global_properties().parameters.current_fees->get<account_create_operation>().basic_fee, 16u);
       create_account("moreshills" + fc::to_string(i));
    }
    for( int i = 0; i < accounts_per_scale; ++i )
    {
-      BOOST_CHECK_EQUAL(db.get_global_properties().parameters.current_fees->get<account_create_operation>().basic_fee, 256);
+      BOOST_CHECK_EQUAL(db.get_global_properties().parameters.current_fees->get<account_create_operation>().basic_fee, 256u);
       create_account("moarshills" + fc::to_string(i));
    }
-   BOOST_CHECK_EQUAL(db.get_global_properties().parameters.current_fees->get<account_create_operation>().basic_fee, 4096);
+   BOOST_CHECK_EQUAL(db.get_global_properties().parameters.current_fees->get<account_create_operation>().basic_fee, 4096u);
 
    generate_blocks(db.get_dynamic_global_properties().next_maintenance_time);
-   BOOST_CHECK_EQUAL(db.get_global_properties().parameters.current_fees->get<account_create_operation>().basic_fee, 1);
+   BOOST_CHECK_EQUAL(db.get_global_properties().parameters.current_fees->get<account_create_operation>().basic_fee, 1u);
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE( fee_refund_test )
@@ -3651,31 +3651,31 @@ BOOST_AUTO_TEST_CASE( defaults_test )
 
     // no fees set yet -> default
     asset fee = schedule.calculate_fee( limit_order_create_operation() );
-    BOOST_CHECK_EQUAL( default_order_fee.fee, fee.amount.value );
+    BOOST_CHECK_EQUAL( (int64_t)default_order_fee.fee, fee.amount.value );
 
     limit_order_create_operation::fee_parameters_type new_order_fee; new_order_fee.fee = 123;
     // set fee + check
     schedule.parameters.insert( new_order_fee );
     fee = schedule.calculate_fee( limit_order_create_operation() );
-    BOOST_CHECK_EQUAL( new_order_fee.fee, fee.amount.value );
+    BOOST_CHECK_EQUAL( (int64_t)new_order_fee.fee, fee.amount.value );
 
     // bid_collateral fee defaults to call_order_update fee
     // call_order_update fee is unset -> default
     const call_order_update_operation::fee_parameters_type default_short_fee {};
     call_order_update_operation::fee_parameters_type new_short_fee; new_short_fee.fee = 123;
     fee = schedule.calculate_fee( bid_collateral_operation() );
-    BOOST_CHECK_EQUAL( default_short_fee.fee, fee.amount.value );
+    BOOST_CHECK_EQUAL( (int64_t)default_short_fee.fee, fee.amount.value );
 
     // set call_order_update fee + check bid_collateral fee
     schedule.parameters.insert( new_short_fee );
     fee = schedule.calculate_fee( bid_collateral_operation() );
-    BOOST_CHECK_EQUAL( new_short_fee.fee, fee.amount.value );
+    BOOST_CHECK_EQUAL( (int64_t)new_short_fee.fee, fee.amount.value );
 
     // set bid_collateral fee + check
     bid_collateral_operation::fee_parameters_type new_bid_fee; new_bid_fee.fee = 124;
     schedule.parameters.insert( new_bid_fee );
     fee = schedule.calculate_fee( bid_collateral_operation() );
-    BOOST_CHECK_EQUAL( new_bid_fee.fee, fee.amount.value );
+    BOOST_CHECK_EQUAL( (int64_t)new_bid_fee.fee, fee.amount.value );
   }
   catch( const fc::exception& e )
   {

--- a/tests/tests/history_api_tests.cpp
+++ b/tests/tests/history_api_tests.cpp
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(get_account_history) {
       vector<operation_history_object> histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 100, operation_history_id_type());
 
       BOOST_CHECK_EQUAL(histories.size(), 3u);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 7u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 0u);
       BOOST_CHECK_EQUAL(histories[2].op.which(), asset_create_op_id);
 
       // 1 account_create op larger than id1

--- a/tests/tests/history_api_tests.cpp
+++ b/tests/tests/history_api_tests.cpp
@@ -56,25 +56,25 @@ BOOST_AUTO_TEST_CASE(get_account_history) {
       //account_id_type() did 3 ops and includes id0
       vector<operation_history_object> histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 100, operation_history_id_type());
 
-      BOOST_CHECK_EQUAL(histories.size(), 3);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 3u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 7u);
       BOOST_CHECK_EQUAL(histories[2].op.which(), asset_create_op_id);
 
       // 1 account_create op larger than id1
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(1), 100, operation_history_id_type());
-      BOOST_CHECK_EQUAL(histories.size(), 1);
+      BOOST_CHECK_EQUAL(histories.size(), 1u);
       BOOST_CHECK(histories[0].id.instance() != 0);
       BOOST_CHECK_EQUAL(histories[0].op.which(), account_create_op_id);
 
 
       // Limit 2 returns 2 result
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 2, operation_history_id_type());
-      BOOST_CHECK_EQUAL(histories.size(), 2);
+      BOOST_CHECK_EQUAL(histories.size(), 2u);
       BOOST_CHECK(histories[1].id.instance() != 0);
       BOOST_CHECK_EQUAL(histories[1].op.which(), account_create_op_id);
       // bob has 1 op
       histories = hist_api.get_account_history("bob", operation_history_id_type(), 100, operation_history_id_type());
-      BOOST_CHECK_EQUAL(histories.size(), 1);
+      BOOST_CHECK_EQUAL(histories.size(), 1u);
       BOOST_CHECK_EQUAL(histories[0].op.which(), account_create_op_id);
 
 
@@ -93,14 +93,14 @@ BOOST_AUTO_TEST_CASE(get_account_history_additional) {
 
       // no history at all in the chain
       vector<operation_history_object> histories = hist_api.get_account_history("1.2.0", operation_history_id_type(0), 4, operation_history_id_type(0));
-      BOOST_CHECK_EQUAL(histories.size(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
 
       create_bitasset("USD", account_id_type()); // create op 0
       generate_block();
       // what if the account only has one history entry and it is 0?
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 4, operation_history_id_type());
-      BOOST_CHECK_EQUAL(histories.size(), 1);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 1u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 0u);
 
       const account_object& dan = create_account("dan"); // create op 1
 
@@ -114,262 +114,262 @@ BOOST_AUTO_TEST_CASE(get_account_history_additional) {
 
       // f(A, 0, 4, 9) = { 5, 3, 1, 0 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 4, operation_history_id_type(9));
-      BOOST_CHECK_EQUAL(histories.size(), 4);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1);
-      BOOST_CHECK_EQUAL(histories[3].id.instance(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 4u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1u);
+      BOOST_CHECK_EQUAL(histories[3].id.instance(), 0u);
 
       // f(A, 0, 4, 6) = { 5, 3, 1, 0 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 4, operation_history_id_type(6));
-      BOOST_CHECK_EQUAL(histories.size(), 4);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1);
-      BOOST_CHECK_EQUAL(histories[3].id.instance(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 4u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1u);
+      BOOST_CHECK_EQUAL(histories[3].id.instance(), 0u);
 
       // f(A, 0, 4, 5) = { 5, 3, 1, 0 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 4, operation_history_id_type(5));
-      BOOST_CHECK_EQUAL(histories.size(), 4);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1);
-      BOOST_CHECK_EQUAL(histories[3].id.instance(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 4u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1u);
+      BOOST_CHECK_EQUAL(histories[3].id.instance(), 0u);
 
       // f(A, 0, 4, 4) = { 3, 1, 0 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 4, operation_history_id_type(4));
-      BOOST_CHECK_EQUAL(histories.size(), 3);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 3);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 1);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 3u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 3u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 1u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 0u);
 
       // f(A, 0, 4, 3) = { 3, 1, 0 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 4, operation_history_id_type(3));
-      BOOST_CHECK_EQUAL(histories.size(), 3);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 3);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 1);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 3u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 3u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 1u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 0u);
 
       // f(A, 0, 4, 2) = { 1, 0 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 4, operation_history_id_type(2));
-      BOOST_CHECK_EQUAL(histories.size(), 2);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 1);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 2u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 1u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 0u);
 
       // f(A, 0, 4, 1) = { 1, 0 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 4, operation_history_id_type(1));
-      BOOST_CHECK_EQUAL(histories.size(), 2);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 1);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 2u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 1u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 0u);
 
       // f(A, 0, 4, 0) = { 5, 3, 1, 0 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 4, operation_history_id_type());
-      BOOST_CHECK_EQUAL(histories.size(), 4);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1);
-      BOOST_CHECK_EQUAL(histories[3].id.instance(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 4u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1u);
+      BOOST_CHECK_EQUAL(histories[3].id.instance(), 0u);
 
       // f(A, 1, 5, 9) = { 5, 3 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(1), 5, operation_history_id_type(9));
-      BOOST_CHECK_EQUAL(histories.size(), 2);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
+      BOOST_CHECK_EQUAL(histories.size(), 2u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3u);
 
       // f(A, 1, 5, 6) = { 5, 3 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(1), 5, operation_history_id_type(6));
-      BOOST_CHECK_EQUAL(histories.size(), 2);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
+      BOOST_CHECK_EQUAL(histories.size(), 2u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3u);
 
       // f(A, 1, 5, 5) = { 5, 3 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(1), 5, operation_history_id_type(5));
-      BOOST_CHECK_EQUAL(histories.size(), 2);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
+      BOOST_CHECK_EQUAL(histories.size(), 2u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3u);
 
       // f(A, 1, 5, 4) = { 3 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(1), 5, operation_history_id_type(4));
-      BOOST_CHECK_EQUAL(histories.size(), 1);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 3);
+      BOOST_CHECK_EQUAL(histories.size(), 1u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 3u);
 
       // f(A, 1, 5, 3) = { 3 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(1), 5, operation_history_id_type(3));
-      BOOST_CHECK_EQUAL(histories.size(), 1);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 3);
+      BOOST_CHECK_EQUAL(histories.size(), 1u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 3u);
 
       // f(A, 1, 5, 2) = { }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(1), 5, operation_history_id_type(2));
-      BOOST_CHECK_EQUAL(histories.size(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
 
       // f(A, 1, 5, 1) = { }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(1), 5, operation_history_id_type(1));
-      BOOST_CHECK_EQUAL(histories.size(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
 
       // f(A, 1, 5, 0) = { 5, 3 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(1), 5, operation_history_id_type(0));
-      BOOST_CHECK_EQUAL(histories.size(), 2);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
+      BOOST_CHECK_EQUAL(histories.size(), 2u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3u);
 
       // f(A, 0, 3, 9) = { 5, 3, 1 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 3, operation_history_id_type(9));
-      BOOST_CHECK_EQUAL(histories.size(), 3);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1);
+      BOOST_CHECK_EQUAL(histories.size(), 3u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1u);
 
       // f(A, 0, 3, 6) = { 5, 3, 1 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 3, operation_history_id_type(6));
-      BOOST_CHECK_EQUAL(histories.size(), 3);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1);
+      BOOST_CHECK_EQUAL(histories.size(), 3u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1u);
 
       // f(A, 0, 3, 5) = { 5, 3, 1 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 3, operation_history_id_type(5));
-      BOOST_CHECK_EQUAL(histories.size(), 3);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1);
+      BOOST_CHECK_EQUAL(histories.size(), 3u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1u);
 
       // f(A, 0, 3, 4) = { 3, 1, 0 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 3, operation_history_id_type(4));
-      BOOST_CHECK_EQUAL(histories.size(), 3);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 3);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 1);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 3u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 3u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 1u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 0u);
 
       // f(A, 0, 3, 3) = { 3, 1, 0 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 3, operation_history_id_type(3));
-      BOOST_CHECK_EQUAL(histories.size(), 3);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 3);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 1);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 3u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 3u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 1u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 0u);
 
       // f(A, 0, 3, 2) = { 1, 0 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 3, operation_history_id_type(2));
-      BOOST_CHECK_EQUAL(histories.size(), 2);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 1);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 2u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 1u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 0u);
 
       // f(A, 0, 3, 1) = { 1, 0 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 3, operation_history_id_type(1));
-      BOOST_CHECK_EQUAL(histories.size(), 2);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 1);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 2u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 1u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 0u);
 
       // f(A, 0, 3, 0) = { 5, 3, 1 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 3, operation_history_id_type());
-      BOOST_CHECK_EQUAL(histories.size(), 3);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1);
+      BOOST_CHECK_EQUAL(histories.size(), 3u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1u);
 
       // f(B, 0, 4, 9) = { 6, 4, 2, 1 }
       histories = hist_api.get_account_history("dan", operation_history_id_type(), 4, operation_history_id_type(9));
-      BOOST_CHECK_EQUAL(histories.size(), 4);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 2);
-      BOOST_CHECK_EQUAL(histories[3].id.instance(), 1);
+      BOOST_CHECK_EQUAL(histories.size(), 4u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 2u);
+      BOOST_CHECK_EQUAL(histories[3].id.instance(), 1u);
 
       // f(B, 0, 4, 6) = { 6, 4, 2, 1 }
       histories = hist_api.get_account_history("dan", operation_history_id_type(), 4, operation_history_id_type(6));
-      BOOST_CHECK_EQUAL(histories.size(), 4);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 2);
-      BOOST_CHECK_EQUAL(histories[3].id.instance(), 1);
+      BOOST_CHECK_EQUAL(histories.size(), 4u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 2u);
+      BOOST_CHECK_EQUAL(histories[3].id.instance(), 1u);
 
       // f(B, 0, 4, 5) = { 4, 2, 1 }
       histories = hist_api.get_account_history("dan", operation_history_id_type(), 4, operation_history_id_type(5));
-      BOOST_CHECK_EQUAL(histories.size(), 3);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 4);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 2);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1);
+      BOOST_CHECK_EQUAL(histories.size(), 3u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 4u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 2u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1u);
 
       // f(B, 0, 4, 4) = { 4, 2, 1 }
       histories = hist_api.get_account_history("dan", operation_history_id_type(), 4, operation_history_id_type(4));
-      BOOST_CHECK_EQUAL(histories.size(), 3);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 4);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 2);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1);
+      BOOST_CHECK_EQUAL(histories.size(), 3u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 4u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 2u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1u);
 
       // f(B, 0, 4, 3) = { 2, 1 }
       histories = hist_api.get_account_history("dan", operation_history_id_type(), 4, operation_history_id_type(3));
-      BOOST_CHECK_EQUAL(histories.size(), 2);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 2);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 1);
+      BOOST_CHECK_EQUAL(histories.size(), 2u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 2u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 1u);
 
       // f(B, 0, 4, 2) = { 2, 1 }
       histories = hist_api.get_account_history("dan", operation_history_id_type(), 4, operation_history_id_type(2));
-      BOOST_CHECK_EQUAL(histories.size(), 2);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 2);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 1);
+      BOOST_CHECK_EQUAL(histories.size(), 2u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 2u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 1u);
 
       // f(B, 0, 4, 1) = { 1 }
       histories = hist_api.get_account_history("dan", operation_history_id_type(), 4, operation_history_id_type(1));
-      BOOST_CHECK_EQUAL(histories.size(), 1);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 1);
+      BOOST_CHECK_EQUAL(histories.size(), 1u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 1u);
 
       // f(B, 0, 4, 0) = { 6, 4, 2, 1 }
       histories = hist_api.get_account_history("dan", operation_history_id_type(), 4, operation_history_id_type());
-      BOOST_CHECK_EQUAL(histories.size(), 4);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 2);
-      BOOST_CHECK_EQUAL(histories[3].id.instance(), 1);
+      BOOST_CHECK_EQUAL(histories.size(), 4u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 2u);
+      BOOST_CHECK_EQUAL(histories[3].id.instance(), 1u);
 
       // f(B, 2, 4, 9) = { 6, 4 }
       histories = hist_api.get_account_history("dan", operation_history_id_type(2), 4, operation_history_id_type(9));
-      BOOST_CHECK_EQUAL(histories.size(), 2);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4);
+      BOOST_CHECK_EQUAL(histories.size(), 2u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4u);
 
       // f(B, 2, 4, 6) = { 6, 4 }
       histories = hist_api.get_account_history("dan", operation_history_id_type(2), 4, operation_history_id_type(6));
-      BOOST_CHECK_EQUAL(histories.size(), 2);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4);
+      BOOST_CHECK_EQUAL(histories.size(), 2u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4u);
 
       // f(B, 2, 4, 5) = { 4 }
       histories = hist_api.get_account_history("dan", operation_history_id_type(2), 4, operation_history_id_type(5));
-      BOOST_CHECK_EQUAL(histories.size(), 1);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 4);
+      BOOST_CHECK_EQUAL(histories.size(), 1u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 4u);
 
       // f(B, 2, 4, 4) = { 4 }
       histories = hist_api.get_account_history("dan", operation_history_id_type(2), 4, operation_history_id_type(4));
-      BOOST_CHECK_EQUAL(histories.size(), 1);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 4);
+      BOOST_CHECK_EQUAL(histories.size(), 1u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 4u);
 
       // f(B, 2, 4, 3) = { }
       histories = hist_api.get_account_history("dan", operation_history_id_type(2), 4, operation_history_id_type(3));
-      BOOST_CHECK_EQUAL(histories.size(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
 
       // f(B, 2, 4, 2) = { }
       histories = hist_api.get_account_history("dan", operation_history_id_type(2), 4, operation_history_id_type(2));
-      BOOST_CHECK_EQUAL(histories.size(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
 
       // f(B, 2, 4, 1) = { }
       histories = hist_api.get_account_history("dan", operation_history_id_type(2), 4, operation_history_id_type(1));
-      BOOST_CHECK_EQUAL(histories.size(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
 
       // f(B, 2, 4, 0) = { 6, 4 }
       histories = hist_api.get_account_history("dan", operation_history_id_type(2), 4, operation_history_id_type(0));
-      BOOST_CHECK_EQUAL(histories.size(), 2);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4);
+      BOOST_CHECK_EQUAL(histories.size(), 2u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4u);
 
       // 0 limits
       histories = hist_api.get_account_history("dan", operation_history_id_type(0), 0, operation_history_id_type(0));
-      BOOST_CHECK_EQUAL(histories.size(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(3), 0, operation_history_id_type(9));
-      BOOST_CHECK_EQUAL(histories.size(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
 
       // non existent account
       histories = hist_api.get_account_history("1.2.18", operation_history_id_type(0), 4, operation_history_id_type(0));
-      BOOST_CHECK_EQUAL(histories.size(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
 
       // create a new account C = alice { 7 }
       create_account("alice");
@@ -378,21 +378,21 @@ BOOST_AUTO_TEST_CASE(get_account_history_additional) {
 
       // f(C, 0, 4, 10) = { 7 }
       histories = hist_api.get_account_history("alice", operation_history_id_type(0), 4, operation_history_id_type(10));
-      BOOST_CHECK_EQUAL(histories.size(), 1);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 7);
+      BOOST_CHECK_EQUAL(histories.size(), 1u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 7u);
 
       // f(C, 8, 4, 10) = { }
       histories = hist_api.get_account_history("alice", operation_history_id_type(8), 4, operation_history_id_type(10));
-      BOOST_CHECK_EQUAL(histories.size(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
 
       // f(A, 0, 10, 0) = { 7, 5, 3, 1, 0 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(0), 10, operation_history_id_type(0));
-      BOOST_CHECK_EQUAL(histories.size(), 5);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 7);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 5);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 3);
-      BOOST_CHECK_EQUAL(histories[3].id.instance(), 1);
-      BOOST_CHECK_EQUAL(histories[4].id.instance(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 5u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 7u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 5u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 3u);
+      BOOST_CHECK_EQUAL(histories[3].id.instance(), 1u);
+      BOOST_CHECK_EQUAL(histories[4].id.instance(), 0u);
 
    }
    catch (fc::exception &e) {
@@ -425,25 +425,25 @@ BOOST_AUTO_TEST_CASE(track_account) {
 
       // anything against account_id_type() should be {}
       vector<operation_history_object> histories = hist_api.get_account_history("1.2.0", operation_history_id_type(0), 10, operation_history_id_type(0));
-      BOOST_CHECK_EQUAL(histories.size(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(1), 10, operation_history_id_type(0));
-      BOOST_CHECK_EQUAL(histories.size(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(1), 1, operation_history_id_type(2));
-      BOOST_CHECK_EQUAL(histories.size(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
 
       // anything against alice should be {}
       histories = hist_api.get_account_history("alice", operation_history_id_type(0), 10, operation_history_id_type(0));
-      BOOST_CHECK_EQUAL(histories.size(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
       histories = hist_api.get_account_history("alice", operation_history_id_type(1), 10, operation_history_id_type(0));
-      BOOST_CHECK_EQUAL(histories.size(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
       histories = hist_api.get_account_history("alice", operation_history_id_type(1), 1, operation_history_id_type(2));
-      BOOST_CHECK_EQUAL(histories.size(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
 
       // dan should have history
       histories = hist_api.get_account_history("dan", operation_history_id_type(0), 10, operation_history_id_type(0));
-      BOOST_CHECK_EQUAL(histories.size(), 2);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 4);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3);
+      BOOST_CHECK_EQUAL(histories.size(), 2u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 4u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3u);
 
       // create more ops, starting with an untracked account
       create_bitasset( "BTC", account_id_type() );
@@ -452,10 +452,10 @@ BOOST_AUTO_TEST_CASE(track_account) {
       generate_block( ~database::skip_fork_db );
 
       histories = hist_api.get_account_history("dan", operation_history_id_type(0), 10, operation_history_id_type(0));
-      BOOST_CHECK_EQUAL(histories.size(), 3);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 3);
+      BOOST_CHECK_EQUAL(histories.size(), 3u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 3u);
 
       db.pop_block();
 
@@ -466,10 +466,10 @@ BOOST_AUTO_TEST_CASE(track_account) {
       generate_block();
 
       histories = hist_api.get_account_history("dan", operation_history_id_type(0), 10, operation_history_id_type(0));
-      BOOST_CHECK_EQUAL(histories.size(), 3);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 3);
+      BOOST_CHECK_EQUAL(histories.size(), 3u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 3u);
    } catch (fc::exception &e) {
       edump((e.to_detail_string()));
       throw;
@@ -499,35 +499,35 @@ BOOST_AUTO_TEST_CASE(track_account2) {
 
       // all account_id_type() should have 4 ops {4,2,1,0}
       vector<operation_history_object> histories = hist_api.get_account_history("committee-account", operation_history_id_type(0), 10, operation_history_id_type(0));
-      BOOST_CHECK_EQUAL(histories.size(), 4);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 4);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 2);
-      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1);
-      BOOST_CHECK_EQUAL(histories[3].id.instance(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 4u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 4u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 2u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1u);
+      BOOST_CHECK_EQUAL(histories[3].id.instance(), 0u);
 
       // all alice account should have 2 ops {3, 0}
       histories = hist_api.get_account_history("alice", operation_history_id_type(0), 10, operation_history_id_type(0));
-      BOOST_CHECK_EQUAL(histories.size(), 2);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 3);
-      BOOST_CHECK_EQUAL(histories[1].id.instance(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 2u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 3u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 0u);
 
       // alice first op should be {0}
       histories = hist_api.get_account_history("alice", operation_history_id_type(0), 1, operation_history_id_type(1));
-      BOOST_CHECK_EQUAL(histories.size(), 1);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 1u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 0u);
 
       // alice second op should be {3}
       histories = hist_api.get_account_history("alice", operation_history_id_type(1), 1, operation_history_id_type(0));
-      BOOST_CHECK_EQUAL(histories.size(), 1);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 3);
+      BOOST_CHECK_EQUAL(histories.size(), 1u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 3u);
 
       // anything against dan should be {}
       histories = hist_api.get_account_history("dan", operation_history_id_type(0), 10, operation_history_id_type(0));
-      BOOST_CHECK_EQUAL(histories.size(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
       histories = hist_api.get_account_history("dan", operation_history_id_type(1), 10, operation_history_id_type(0));
-      BOOST_CHECK_EQUAL(histories.size(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
       histories = hist_api.get_account_history("dan", operation_history_id_type(1), 1, operation_history_id_type(2));
-      BOOST_CHECK_EQUAL(histories.size(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
 
    } catch (fc::exception &e) {
       edump((e.to_detail_string()));
@@ -554,31 +554,31 @@ BOOST_AUTO_TEST_CASE(get_account_history_operations) {
       //account_id_type() did 1 asset_create op
       vector<operation_history_object> histories = hist_api.get_account_history_operations(
             "committee-account", asset_create_op_id, operation_history_id_type(), operation_history_id_type(), 100);
-      BOOST_CHECK_EQUAL(histories.size(), 1);
-      BOOST_CHECK_EQUAL(histories[0].id.instance(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 1u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 0u);
       BOOST_CHECK_EQUAL(histories[0].op.which(), asset_create_op_id);
 
       //account_id_type() did 2 account_create ops
       histories = hist_api.get_account_history_operations(
             "committee-account", account_create_op_id, operation_history_id_type(), operation_history_id_type(), 100);
-      BOOST_CHECK_EQUAL(histories.size(), 2);
+      BOOST_CHECK_EQUAL(histories.size(), 2u);
       BOOST_CHECK_EQUAL(histories[0].op.which(), account_create_op_id);
 
       // No asset_create op larger than id1
       histories = hist_api.get_account_history_operations(
             "committee-account", asset_create_op_id, operation_history_id_type(), operation_history_id_type(1), 100);
-      BOOST_CHECK_EQUAL(histories.size(), 0);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
 
       // Limit 1 returns 1 result
       histories = hist_api.get_account_history_operations(
             "committee-account", account_create_op_id, operation_history_id_type(),operation_history_id_type(), 1);
-      BOOST_CHECK_EQUAL(histories.size(), 1);
+      BOOST_CHECK_EQUAL(histories.size(), 1u);
       BOOST_CHECK_EQUAL(histories[0].op.which(), account_create_op_id);
 
       // alice has 1 op
       histories = hist_api.get_account_history_operations(
-            "alice", account_create_op_id, operation_history_id_type(),operation_history_id_type(), 100);
-      BOOST_CHECK_EQUAL(histories.size(), 1);
+         "alice", account_create_op_id, operation_history_id_type(),operation_history_id_type(), 100);
+      BOOST_CHECK_EQUAL(histories.size(), 1u);
       BOOST_CHECK_EQUAL(histories[0].op.which(), account_create_op_id);
 
       // create a bunch of accounts

--- a/tests/tests/history_api_tests.cpp
+++ b/tests/tests/history_api_tests.cpp
@@ -549,7 +549,6 @@ BOOST_AUTO_TEST_CASE(get_account_history_operations) {
 
       int asset_create_op_id = operation::tag<asset_create_operation>::value;
       int account_create_op_id = operation::tag<account_create_operation>::value;
-      int transfer_op_id = operation::tag<graphene::chain::transfer_operation>::value;
 
       //account_id_type() did 1 asset_create op
       vector<operation_history_object> histories = hist_api.get_account_history_operations(
@@ -594,7 +593,7 @@ BOOST_AUTO_TEST_CASE(get_account_history_operations) {
       // see https://github.com/bitshares/bitshares-core/issues/1490
       histories = hist_api.get_account_history_operations(
             "committee-account", account_create_op_id, operation_history_id_type(), operation_history_id_type(), 100);
-      BOOST_CHECK_EQUAL(histories.size(), 75);
+      BOOST_CHECK_EQUAL(histories.size(), 75u);
       if (histories.size() > 0)
          BOOST_CHECK_EQUAL(histories[0].op.which(), account_create_op_id);
       

--- a/tests/tests/market_rounding_tests.cpp
+++ b/tests/tests/market_rounding_tests.cpp
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE( trade_amount_equals_zero )
       fc::usleep(fc::milliseconds(200)); // sleep a while to execute callback in another thread
 
       auto result = get_market_order_history(core_id, test_id);
-      BOOST_CHECK_EQUAL(result.size(), 4);
+      BOOST_CHECK_EQUAL(result.size(), 4u);
       BOOST_CHECK(result[0].op.pays == core_id(db).amount(0));
       BOOST_CHECK(result[0].op.receives == test_id(db).amount(1));
       BOOST_CHECK(result[1].op.pays == test_id(db).amount(1));
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE( trade_amount_equals_zero_after_hf_184 )
       fc::usleep(fc::milliseconds(200)); // sleep a while to execute callback in another thread
 
       auto result = get_market_order_history(core_id, test_id);
-      BOOST_CHECK_EQUAL(result.size(), 2);
+      BOOST_CHECK_EQUAL(result.size(), 2u);
       BOOST_CHECK(result[0].op.pays == core_id(db).amount(1));
       BOOST_CHECK(result[0].op.receives == test_id(db).amount(2));
       BOOST_CHECK(result[1].op.pays == test_id(db).amount(2));

--- a/tests/tests/network_broadcast_api_tests.cpp
+++ b/tests/tests/network_broadcast_api_tests.cpp
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE( broadcast_transaction_with_callback_test ) {
 
       fc::usleep(fc::milliseconds(200)); // sleep a while to execute callback in another thread
 
-      BOOST_CHECK_EQUAL( called, 1 );
+      BOOST_CHECK_EQUAL( called, 1u );
 
    } FC_LOG_AND_RETHROW()
 }

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -1731,7 +1731,7 @@ BOOST_AUTO_TEST_CASE( witness_feeds )
       vector<account_id_type> active_witnesses;
       for( const witness_id_type& wit_id : global_props.active_witnesses )
          active_witnesses.push_back( wit_id(db).witness_account );
-      BOOST_REQUIRE_EQUAL(active_witnesses.size(), 10);
+      BOOST_REQUIRE_EQUAL(active_witnesses.size(), 10u);
 
       asset_publish_feed_operation op;
       op.publisher = active_witnesses[0];
@@ -1828,7 +1828,7 @@ BOOST_AUTO_TEST_CASE( witness_pay_test )
    const asset_object* core = &asset_id_type()(db);
    const account_object* nathan = &get_account("nathan");
    enable_fees();
-   BOOST_CHECK_GT(db.current_fee_schedule().get<account_upgrade_operation>().membership_lifetime_fee, 0);
+   BOOST_CHECK_GT(db.current_fee_schedule().get<account_upgrade_operation>().membership_lifetime_fee, 0u);
    // Based on the size of the reserve fund later in the test, the witness budget will be set to this value
    const uint64_t ref_budget =
       ((uint64_t( db.current_fee_schedule().get<account_upgrade_operation>().membership_lifetime_fee )
@@ -1838,10 +1838,10 @@ BOOST_AUTO_TEST_CASE( witness_pay_test )
       ) >> GRAPHENE_CORE_ASSET_CYCLE_RATE_BITS
       ;
    // change this if ref_budget changes
-   BOOST_CHECK_EQUAL( ref_budget, 594 );
+   BOOST_CHECK_EQUAL( ref_budget, 594u );
    const uint64_t witness_ppb = ref_budget * 10 / 23 + 1;
    // change this if ref_budget changes
-   BOOST_CHECK_EQUAL( witness_ppb, 259 );
+   BOOST_CHECK_EQUAL( witness_ppb, 259u );
    // following two inequalities need to hold for maximal code coverage
    BOOST_CHECK_LT( witness_ppb * 2, ref_budget );
    BOOST_CHECK_GT( witness_ppb * 3, ref_budget );
@@ -1887,28 +1887,28 @@ BOOST_AUTO_TEST_CASE( witness_pay_test )
       generate_block();
       BOOST_CHECK_EQUAL( last_witness_vbo_balance().value, 0 );
    }
-   BOOST_CHECK_EQUAL( db.head_block_time().sec_since_epoch() - pay_fee_time, 24 * block_interval );
+   BOOST_CHECK_EQUAL( db.head_block_time().sec_since_epoch() - pay_fee_time, 24u * block_interval );
 
    schedule_maint();
    // The 80% lifetime referral fee went to the committee account, which burned it. Check that it's here.
    BOOST_CHECK( core->reserved(db).value == 8000*prec );
    generate_block();
    BOOST_CHECK_EQUAL( core->reserved(db).value, 999999406 );
-   BOOST_CHECK_EQUAL( db.get_dynamic_global_properties().witness_budget.value, ref_budget );
+   BOOST_CHECK_EQUAL( db.get_dynamic_global_properties().witness_budget.value, (int64_t)ref_budget );
    // first witness paid from old budget (so no pay)
    BOOST_CHECK_EQUAL( last_witness_vbo_balance().value, 0 );
    // second witness finally gets paid!
    generate_block();
-   BOOST_CHECK_EQUAL( last_witness_vbo_balance().value, witness_ppb );
-   BOOST_CHECK_EQUAL( db.get_dynamic_global_properties().witness_budget.value, ref_budget - witness_ppb );
+   BOOST_CHECK_EQUAL( last_witness_vbo_balance().value, (int64_t)witness_ppb );
+   BOOST_CHECK_EQUAL( db.get_dynamic_global_properties().witness_budget.value, (int64_t)(ref_budget - witness_ppb) );
 
    generate_block();
-   BOOST_CHECK_EQUAL( last_witness_vbo_balance().value, witness_ppb );
-   BOOST_CHECK_EQUAL( db.get_dynamic_global_properties().witness_budget.value, ref_budget - 2 * witness_ppb );
+   BOOST_CHECK_EQUAL( last_witness_vbo_balance().value, (int64_t)witness_ppb );
+   BOOST_CHECK_EQUAL( db.get_dynamic_global_properties().witness_budget.value, (int64_t)(ref_budget - 2 * witness_ppb) );
 
    generate_block();
-   BOOST_CHECK_LT( last_witness_vbo_balance().value, witness_ppb );
-   BOOST_CHECK_EQUAL( last_witness_vbo_balance().value, ref_budget - 2 * witness_ppb );
+   BOOST_CHECK_LT( last_witness_vbo_balance().value, (int64_t)witness_ppb );
+   BOOST_CHECK_EQUAL( last_witness_vbo_balance().value, (int64_t)(ref_budget - 2 * witness_ppb) );
    BOOST_CHECK_EQUAL( db.get_dynamic_global_properties().witness_budget.value, 0 );
 
    generate_block();

--- a/tests/tests/operation_tests2.cpp
+++ b/tests/tests/operation_tests2.cpp
@@ -968,7 +968,7 @@ BOOST_AUTO_TEST_CASE( mia_feeds )
    }
    {
       const asset_bitasset_data_object& obj = bit_usd_id(db).bitasset_data(db);
-      BOOST_CHECK_EQUAL(obj.feeds.size(), 3);
+      BOOST_CHECK_EQUAL(obj.feeds.size(), 3u);
       BOOST_CHECK(obj.current_feed == price_feed());
    }
    {
@@ -1086,7 +1086,7 @@ BOOST_AUTO_TEST_CASE( witness_create )
    witness_id_type nathan_witness_id = create_witness(nathan_id, nathan_private_key, skip).id;
 
    // nathan should be in the cache
-   BOOST_CHECK_EQUAL( caching_witnesses.count(nathan_witness_id), 1 );
+   BOOST_CHECK_EQUAL( caching_witnesses.count(nathan_witness_id), 1u );
 
    // nathan's key in the cache should still be null before a new block is generated
    auto nathan_itr = wit_key_cache.find( nathan_witness_id );

--- a/tests/tests/smartcoin_tests.cpp
+++ b/tests/tests/smartcoin_tests.cpp
@@ -132,17 +132,17 @@ BOOST_AUTO_TEST_CASE(bsip36)
 
       // Check current default witnesses, default chain is configured with 10 witnesses
       auto witnesses = db.get_global_properties().active_witnesses;
-      BOOST_CHECK_EQUAL(witnesses.size(), 10);
-      BOOST_CHECK_EQUAL(witnesses.begin()[0].instance.value, 1);
-      BOOST_CHECK_EQUAL(witnesses.begin()[1].instance.value, 2);
-      BOOST_CHECK_EQUAL(witnesses.begin()[2].instance.value, 3);
-      BOOST_CHECK_EQUAL(witnesses.begin()[3].instance.value, 4);
-      BOOST_CHECK_EQUAL(witnesses.begin()[4].instance.value, 5);
-      BOOST_CHECK_EQUAL(witnesses.begin()[5].instance.value, 6);
-      BOOST_CHECK_EQUAL(witnesses.begin()[6].instance.value, 7);
-      BOOST_CHECK_EQUAL(witnesses.begin()[7].instance.value, 8);
-      BOOST_CHECK_EQUAL(witnesses.begin()[8].instance.value, 9);
-      BOOST_CHECK_EQUAL(witnesses.begin()[9].instance.value, 10);
+      BOOST_CHECK_EQUAL(witnesses.size(), 10u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[0].instance.value, 1u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[1].instance.value, 2u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[2].instance.value, 3u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[3].instance.value, 4u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[4].instance.value, 5u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[5].instance.value, 6u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[6].instance.value, 7u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[7].instance.value, 8u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[8].instance.value, 9u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[9].instance.value, 10u);
 
       // We need to activate 11 witnesses by voting for each of them.
       // Each witness is voted with incremental stake so last witness created will be the ones with more votes
@@ -172,18 +172,18 @@ BOOST_AUTO_TEST_CASE(bsip36)
 
       // Check my witnesses are now in control of the system
       witnesses = db.get_global_properties().active_witnesses;
-      BOOST_CHECK_EQUAL(witnesses.size(), 11);
-      BOOST_CHECK_EQUAL(witnesses.begin()[0].instance.value, 11);
-      BOOST_CHECK_EQUAL(witnesses.begin()[1].instance.value, 12);
-      BOOST_CHECK_EQUAL(witnesses.begin()[2].instance.value, 13);
-      BOOST_CHECK_EQUAL(witnesses.begin()[3].instance.value, 14);
-      BOOST_CHECK_EQUAL(witnesses.begin()[4].instance.value, 15);
-      BOOST_CHECK_EQUAL(witnesses.begin()[5].instance.value, 16);
-      BOOST_CHECK_EQUAL(witnesses.begin()[6].instance.value, 17);
-      BOOST_CHECK_EQUAL(witnesses.begin()[7].instance.value, 18);
-      BOOST_CHECK_EQUAL(witnesses.begin()[8].instance.value, 19);
-      BOOST_CHECK_EQUAL(witnesses.begin()[9].instance.value, 20);
-      BOOST_CHECK_EQUAL(witnesses.begin()[10].instance.value, 21);
+      BOOST_CHECK_EQUAL(witnesses.size(), 11u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[0].instance.value, 11u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[1].instance.value, 12u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[2].instance.value, 13u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[3].instance.value, 14u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[4].instance.value, 15u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[5].instance.value, 16u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[6].instance.value, 17u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[7].instance.value, 18u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[8].instance.value, 19u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[9].instance.value, 20u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[10].instance.value, 21u);
 
       // Adding 2 feeds with witnesses 0 and 1, checking if they get inserted
       const asset_object &core = asset_id_type()(db);
@@ -192,18 +192,18 @@ BOOST_AUTO_TEST_CASE(bsip36)
       publish_feed(bit_usd_id(db), witness0_id(db), feed);
 
       asset_bitasset_data_object bitasset_data = bit_usd_id(db).bitasset_data(db);
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 1);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 1u);
       auto itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 16);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 16u);
 
       feed.settlement_price = bit_usd_id(db).amount(2) / core.amount(5);
       publish_feed(bit_usd_id(db), witness1_id(db), feed);
 
       bitasset_data = bit_usd_id(db).bitasset_data(db);
       itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 2);
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 16);
-      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 17);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 2u);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 16u);
+      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 17u);
 
       // Activate witness11 with voting stake, will kick the witness with less votes(witness0) out of the active list
       transfer(committee_account, witness11_id, asset(121));
@@ -228,32 +228,32 @@ BOOST_AUTO_TEST_CASE(bsip36)
 
       // Check active witness list now
       witnesses = db.get_global_properties().active_witnesses;
-      BOOST_CHECK_EQUAL(witnesses.begin()[0].instance.value, 12);
-      BOOST_CHECK_EQUAL(witnesses.begin()[1].instance.value, 13);
-      BOOST_CHECK_EQUAL(witnesses.begin()[2].instance.value, 14);
-      BOOST_CHECK_EQUAL(witnesses.begin()[3].instance.value, 15);
-      BOOST_CHECK_EQUAL(witnesses.begin()[4].instance.value, 16);
-      BOOST_CHECK_EQUAL(witnesses.begin()[5].instance.value, 17);
-      BOOST_CHECK_EQUAL(witnesses.begin()[6].instance.value, 18);
-      BOOST_CHECK_EQUAL(witnesses.begin()[7].instance.value, 19);
-      BOOST_CHECK_EQUAL(witnesses.begin()[8].instance.value, 20);
-      BOOST_CHECK_EQUAL(witnesses.begin()[9].instance.value, 21);
-      BOOST_CHECK_EQUAL(witnesses.begin()[10].instance.value, 22);
+      BOOST_CHECK_EQUAL(witnesses.begin()[0].instance.value, 12u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[1].instance.value, 13u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[2].instance.value, 14u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[3].instance.value, 15u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[4].instance.value, 16u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[5].instance.value, 17u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[6].instance.value, 18u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[7].instance.value, 19u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[8].instance.value, 20u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[9].instance.value, 21u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[10].instance.value, 22u);
 
       // witness0 has been removed but it was a feeder before
       // Feed persist in the blockchain, this reproduces the issue
       bitasset_data = bit_usd_id(db).bitasset_data(db);
       itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 2);
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 16);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 2u);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 16u);
 
       // Feed persist after expiration
       const auto feed_lifetime = bit_usd_id(db).bitasset_data(db).options.feed_lifetime_sec;
       generate_blocks(db.head_block_time() + feed_lifetime + 1);
       bitasset_data = bit_usd_id(db).bitasset_data(db);
       itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 2);
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 16);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 2u);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 16u);
 
       // Other witnesses add more feeds
       feed.settlement_price = bit_usd_id(db).amount(4) / core.amount(5);
@@ -264,14 +264,14 @@ BOOST_AUTO_TEST_CASE(bsip36)
       // But the one from witness0 is never removed
       bitasset_data = bit_usd_id(db).bitasset_data(db);
       itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 4);
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 16);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 4u);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 16u);
 
       // Feed from witness1 is also expired but never deleted
       // All feeds should be deleted at this point
       const auto minimum_feeds = bit_usd_id(db).bitasset_data(db).options.minimum_feeds;
-      BOOST_CHECK_EQUAL(minimum_feeds, 1);
-      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 17);
+      BOOST_CHECK_EQUAL(minimum_feeds, 1u);
+      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 17u);
 
       // Advancing into HF time
       generate_blocks(HARDFORK_CORE_518_TIME);
@@ -281,15 +281,15 @@ BOOST_AUTO_TEST_CASE(bsip36)
 
       //  All expired feeds are deleted
       bitasset_data = bit_usd_id(db).bitasset_data(db);
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 0);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 0u);
 
       // witness1 start feed producing again
       feed.settlement_price = bit_usd_id(db).amount(1) / core.amount(5);
       publish_feed(bit_usd_id(db), witness1_id(db), feed);
       bitasset_data = bit_usd_id(db).bitasset_data(db);
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 1);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 1u);
       itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 17);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 17u);
 
       // generate some blocks up to expiration but feed will not be deleted yet as need next maint time
       generate_blocks(itr[0].second.first + feed_lifetime + 1);
@@ -298,10 +298,10 @@ BOOST_AUTO_TEST_CASE(bsip36)
       feed.settlement_price = bit_usd_id(db).amount(1) / core.amount(5);
       publish_feed(bit_usd_id(db), witness2_id(db), feed);
       bitasset_data = bit_usd_id(db).bitasset_data(db);
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 2);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 2u);
       itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 17);
-      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 18);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 17u);
+      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 18u);
 
       // make the first feed expire
       generate_blocks(itr[0].second.first + feed_lifetime + 1);
@@ -309,23 +309,23 @@ BOOST_AUTO_TEST_CASE(bsip36)
 
       // feed from witness0 expires and gets deleted, feed from witness is on time so persist
       bitasset_data = bit_usd_id(db).bitasset_data(db);
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 1);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 1u);
       itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 18);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 18u);
 
       // expire everything
       generate_blocks(itr[0].second.first + feed_lifetime + 1);
       generate_blocks(db.get_dynamic_global_properties().next_maintenance_time);
       bitasset_data = bit_usd_id(db).bitasset_data(db);
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 0);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 0u);
 
       // add new feed with witness1
       feed.settlement_price = bit_usd_id(db).amount(1) / core.amount(5);
       publish_feed(bit_usd_id(db), witness1_id(db), feed);
       bitasset_data = bit_usd_id(db).bitasset_data(db);
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 1);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 1u);
       itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 17);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 17u);
 
       // Reactivate witness0
       transfer(committee_account, witness0_id, asset(100));
@@ -350,29 +350,29 @@ BOOST_AUTO_TEST_CASE(bsip36)
 
       // Checking
       witnesses = db.get_global_properties().active_witnesses;
-      BOOST_CHECK_EQUAL(witnesses.begin()[0].instance.value, 11);
-      BOOST_CHECK_EQUAL(witnesses.begin()[1].instance.value, 13);
-      BOOST_CHECK_EQUAL(witnesses.begin()[2].instance.value, 14);
-      BOOST_CHECK_EQUAL(witnesses.begin()[3].instance.value, 15);
-      BOOST_CHECK_EQUAL(witnesses.begin()[4].instance.value, 16);
-      BOOST_CHECK_EQUAL(witnesses.begin()[5].instance.value, 17);
-      BOOST_CHECK_EQUAL(witnesses.begin()[6].instance.value, 18);
-      BOOST_CHECK_EQUAL(witnesses.begin()[7].instance.value, 19);
-      BOOST_CHECK_EQUAL(witnesses.begin()[8].instance.value, 20);
-      BOOST_CHECK_EQUAL(witnesses.begin()[9].instance.value, 21);
-      BOOST_CHECK_EQUAL(witnesses.begin()[10].instance.value, 22);
+      BOOST_CHECK_EQUAL(witnesses.begin()[0].instance.value, 11u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[1].instance.value, 13u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[2].instance.value, 14u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[3].instance.value, 15u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[4].instance.value, 16u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[5].instance.value, 17u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[6].instance.value, 18u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[7].instance.value, 19u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[8].instance.value, 20u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[9].instance.value, 21u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[10].instance.value, 22u);
 
       // feed from witness1 is still here as the witness is no longer a producer but the feed is not yet expired
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 1);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 1u);
       itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 17);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 17u);
 
       // make feed from witness1 expire
       generate_blocks(itr[0].second.first + feed_lifetime + 1);
       generate_blocks(db.get_dynamic_global_properties().next_maintenance_time);
 
       bitasset_data = bit_usd_id(db).bitasset_data(db);
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 0);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 0u);
 
    } FC_LOG_AND_RETHROW()
 }
@@ -418,11 +418,11 @@ BOOST_AUTO_TEST_CASE(bsip36_update_feed_producers)
       // Bitshares will create entries in the field feed after feed producers are added
       auto bitasset_data = bit_usd_id(db).bitasset_data(db);
 
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 3);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 3u);
       auto itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 16);
-      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 17);
-      BOOST_CHECK_EQUAL(itr[2].first.instance.value, 18);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 16u);
+      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 17u);
+      BOOST_CHECK_EQUAL(itr[2].first.instance.value, 18u);
 
       // Removing a feed producer
       {
@@ -439,19 +439,19 @@ BOOST_AUTO_TEST_CASE(bsip36_update_feed_producers)
 
       // Feed for removed producer is removed
       bitasset_data = bit_usd_id(db).bitasset_data(db);
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 2);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 2u);
       itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 17);
-      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 18);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 17u);
+      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 18u);
 
       // Feed persist after expiration
       const auto feed_lifetime = bit_usd_id(db).bitasset_data(db).options.feed_lifetime_sec;
       generate_blocks(db.head_block_time() + feed_lifetime + 1);
       bitasset_data = bit_usd_id(db).bitasset_data(db);
       itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 2);
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 17);
-      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 18);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 2u);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 17u);
+      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 18u);
 
       // Advancing into HF time
       generate_blocks(HARDFORK_CORE_518_TIME);
@@ -462,9 +462,9 @@ BOOST_AUTO_TEST_CASE(bsip36_update_feed_producers)
       // Expired feeds persist, no changes
       bitasset_data = bit_usd_id(db).bitasset_data(db);
       itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 2);
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 17);
-      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 18);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 2u);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 17u);
+      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 18u);
 
    } FC_LOG_AND_RETHROW()
 }
@@ -507,9 +507,9 @@ BOOST_AUTO_TEST_CASE(bsip36_additional)
       feed.settlement_price = bit_usd_id(db).amount(1) / core_id(db).amount(5);
       publish_feed(bit_usd_id(db), witness5_id(db), feed);
       auto bitasset_data = bit_usd_id(db).bitasset_data(db);
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 1);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 1u);
       auto itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 21);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 21u);
 
       generate_blocks(db.get_dynamic_global_properties().next_maintenance_time);
       generate_block();
@@ -517,10 +517,10 @@ BOOST_AUTO_TEST_CASE(bsip36_additional)
       feed.settlement_price = bit_usd_id(db).amount(1) / core_id(db).amount(5);
       publish_feed(bit_usd_id(db), witness6_id(db), feed);
       bitasset_data = bit_usd_id(db).bitasset_data(db);
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 2);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 2u);
       itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 21);
-      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 22);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 21u);
+      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 22u);
 
       generate_blocks(db.get_dynamic_global_properties().next_maintenance_time);
       generate_block();
@@ -528,11 +528,11 @@ BOOST_AUTO_TEST_CASE(bsip36_additional)
       feed.settlement_price = bit_usd_id(db).amount(1) / core_id(db).amount(5);
       publish_feed(bit_usd_id(db), witness7_id(db), feed);
       bitasset_data = bit_usd_id(db).bitasset_data(db);
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 3);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 3u);
       itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 21);
-      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 22);
-      BOOST_CHECK_EQUAL(itr[2].first.instance.value, 23);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 21u);
+      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 22u);
+      BOOST_CHECK_EQUAL(itr[2].first.instance.value, 23u);
 
       generate_blocks(db.get_dynamic_global_properties().next_maintenance_time);
       generate_block();
@@ -540,12 +540,12 @@ BOOST_AUTO_TEST_CASE(bsip36_additional)
       feed.settlement_price = bit_usd_id(db).amount(1) / core_id(db).amount(5);
       publish_feed(bit_usd_id(db), witness8_id(db), feed);
       bitasset_data = bit_usd_id(db).bitasset_data(db);
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 4);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 4u);
       itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 21);
-      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 22);
-      BOOST_CHECK_EQUAL(itr[2].first.instance.value, 23);
-      BOOST_CHECK_EQUAL(itr[3].first.instance.value, 24);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 21u);
+      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 22u);
+      BOOST_CHECK_EQUAL(itr[2].first.instance.value, 23u);
+      BOOST_CHECK_EQUAL(itr[3].first.instance.value, 24u);
 
       generate_blocks(db.get_dynamic_global_properties().next_maintenance_time);
       generate_block();
@@ -553,13 +553,13 @@ BOOST_AUTO_TEST_CASE(bsip36_additional)
       feed.settlement_price = bit_usd_id(db).amount(1) / core_id(db).amount(5);
       publish_feed(bit_usd_id(db), witness9_id(db), feed);
       bitasset_data = bit_usd_id(db).bitasset_data(db);
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 5);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 5u);
       itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 21);
-      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 22);
-      BOOST_CHECK_EQUAL(itr[2].first.instance.value, 23);
-      BOOST_CHECK_EQUAL(itr[3].first.instance.value, 24);
-      BOOST_CHECK_EQUAL(itr[4].first.instance.value, 25);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 21u);
+      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 22u);
+      BOOST_CHECK_EQUAL(itr[2].first.instance.value, 23u);
+      BOOST_CHECK_EQUAL(itr[3].first.instance.value, 24u);
+      BOOST_CHECK_EQUAL(itr[4].first.instance.value, 25u);
 
       generate_blocks(db.get_dynamic_global_properties().next_maintenance_time);
       generate_block();
@@ -567,27 +567,27 @@ BOOST_AUTO_TEST_CASE(bsip36_additional)
       feed.settlement_price = bit_usd_id(db).amount(1) / core_id(db).amount(5);
       publish_feed(bit_usd_id(db), witness10_id(db), feed);
       bitasset_data = bit_usd_id(db).bitasset_data(db);
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 6);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 6u);
       itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 21);
-      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 22);
-      BOOST_CHECK_EQUAL(itr[2].first.instance.value, 23);
-      BOOST_CHECK_EQUAL(itr[3].first.instance.value, 24);
-      BOOST_CHECK_EQUAL(itr[4].first.instance.value, 25);
-      BOOST_CHECK_EQUAL(itr[5].first.instance.value, 26);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 21u);
+      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 22u);
+      BOOST_CHECK_EQUAL(itr[2].first.instance.value, 23u);
+      BOOST_CHECK_EQUAL(itr[3].first.instance.value, 24u);
+      BOOST_CHECK_EQUAL(itr[4].first.instance.value, 25u);
+      BOOST_CHECK_EQUAL(itr[5].first.instance.value, 26u);
 
       // make the older feed expire
       generate_blocks(db.get_dynamic_global_properties().next_maintenance_time);
       generate_block();
 
       bitasset_data = bit_usd_id(db).bitasset_data(db);
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 5);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 5u);
       itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 22);
-      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 23);
-      BOOST_CHECK_EQUAL(itr[2].first.instance.value, 24);
-      BOOST_CHECK_EQUAL(itr[3].first.instance.value, 25);
-      BOOST_CHECK_EQUAL(itr[4].first.instance.value, 26);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 22u);
+      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 23u);
+      BOOST_CHECK_EQUAL(itr[2].first.instance.value, 24u);
+      BOOST_CHECK_EQUAL(itr[3].first.instance.value, 25u);
+      BOOST_CHECK_EQUAL(itr[4].first.instance.value, 26u);
 
       // make older 2 feeds expire
       generate_blocks(db.get_dynamic_global_properties().next_maintenance_time);
@@ -596,41 +596,41 @@ BOOST_AUTO_TEST_CASE(bsip36_additional)
       generate_block();
 
       bitasset_data = bit_usd_id(db).bitasset_data(db);
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 3);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 3u);
       itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 24);
-      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 25);
-      BOOST_CHECK_EQUAL(itr[2].first.instance.value, 26);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 24u);
+      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 25u);
+      BOOST_CHECK_EQUAL(itr[2].first.instance.value, 26u);
 
       // witness5 add new feed, feeds are sorted by witness_id not by feed_time
       feed.settlement_price = bit_usd_id(db).amount(1) / core_id(db).amount(5);
       publish_feed(bit_usd_id(db), witness5_id(db), feed);
       bitasset_data = bit_usd_id(db).bitasset_data(db);
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 4);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 4u);
       itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 21);
-      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 24);
-      BOOST_CHECK_EQUAL(itr[2].first.instance.value, 25);
-      BOOST_CHECK_EQUAL(itr[3].first.instance.value, 26);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 21u);
+      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 24u);
+      BOOST_CHECK_EQUAL(itr[2].first.instance.value, 25u);
+      BOOST_CHECK_EQUAL(itr[3].first.instance.value, 26u);
 
       // another feed expires
       generate_blocks(db.get_dynamic_global_properties().next_maintenance_time);
       generate_block();
       bitasset_data = bit_usd_id(db).bitasset_data(db);
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 3);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 3u);
       itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 21);
-      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 25);
-      BOOST_CHECK_EQUAL(itr[2].first.instance.value, 26);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 21u);
+      BOOST_CHECK_EQUAL(itr[1].first.instance.value, 25u);
+      BOOST_CHECK_EQUAL(itr[2].first.instance.value, 26u);
 
       // another feed expires
       generate_blocks(db.get_dynamic_global_properties().next_maintenance_time);
       generate_block();
       bitasset_data = bit_usd_id(db).bitasset_data(db);
-      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 2);
+      BOOST_CHECK_EQUAL(bitasset_data.feeds.size(), 2u);
       itr = bitasset_data.feeds.begin();
-      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 21);
-      BOOST_CHECK_EQUAL(itr[2].first.instance.value, 26);
+      BOOST_CHECK_EQUAL(itr[0].first.instance.value, 21u);
+      BOOST_CHECK_EQUAL(itr[2].first.instance.value, 26u);
 
       // and so on
 

--- a/tests/tests/swan_tests.cpp
+++ b/tests/tests/swan_tests.cpp
@@ -368,13 +368,13 @@ BOOST_AUTO_TEST_CASE( recollateralize )
       graphene::app::database_api db_api(db);
       GRAPHENE_REQUIRE_THROW( db_api.get_collateral_bids(back().id, 100, 0), fc::assert_exception );
       vector<collateral_bid_object> bids = db_api.get_collateral_bids(_swan, 100, 1);
-      BOOST_CHECK_EQUAL( 1, bids.size() );
+      BOOST_CHECK_EQUAL( 1u, bids.size() );
       FC_ASSERT( _borrower2 == bids[0].bidder );
       bids = db_api.get_collateral_bids(_swan, 1, 0);
-      BOOST_CHECK_EQUAL( 1, bids.size() );
+      BOOST_CHECK_EQUAL( 1u, bids.size() );
       FC_ASSERT( _borrower == bids[0].bidder );
       bids = db_api.get_collateral_bids(_swan, 100, 0);
-      BOOST_CHECK_EQUAL( 2, bids.size() );
+      BOOST_CHECK_EQUAL( 2u, bids.size() );
       FC_ASSERT( _borrower == bids[0].bidder );
       FC_ASSERT( _borrower2 == bids[1].bidder );
 

--- a/tests/tests/voting_tests.cpp
+++ b/tests/tests/voting_tests.cpp
@@ -129,17 +129,17 @@ BOOST_AUTO_TEST_CASE(put_my_witnesses)
 
       // Check current default witnesses, default chain is configured with 10 witnesses
       auto witnesses = db.get_global_properties().active_witnesses;
-      BOOST_CHECK_EQUAL(witnesses.size(), 10);
-      BOOST_CHECK_EQUAL(witnesses.begin()[0].instance.value, 1);
-      BOOST_CHECK_EQUAL(witnesses.begin()[1].instance.value, 2);
-      BOOST_CHECK_EQUAL(witnesses.begin()[2].instance.value, 3);
-      BOOST_CHECK_EQUAL(witnesses.begin()[3].instance.value, 4);
-      BOOST_CHECK_EQUAL(witnesses.begin()[4].instance.value, 5);
-      BOOST_CHECK_EQUAL(witnesses.begin()[5].instance.value, 6);
-      BOOST_CHECK_EQUAL(witnesses.begin()[6].instance.value, 7);
-      BOOST_CHECK_EQUAL(witnesses.begin()[7].instance.value, 8);
-      BOOST_CHECK_EQUAL(witnesses.begin()[8].instance.value, 9);
-      BOOST_CHECK_EQUAL(witnesses.begin()[9].instance.value, 10);
+      BOOST_CHECK_EQUAL(witnesses.size(), 10u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[0].instance.value, 1u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[1].instance.value, 2u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[2].instance.value, 3u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[3].instance.value, 4u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[4].instance.value, 5u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[5].instance.value, 6u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[6].instance.value, 7u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[7].instance.value, 8u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[8].instance.value, 9u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[9].instance.value, 10u);
 
       // Activate all witnesses
       // Each witness is voted with incremental stake so last witness created will be the ones with more votes
@@ -168,18 +168,18 @@ BOOST_AUTO_TEST_CASE(put_my_witnesses)
 
       // Check my witnesses are now in control of the system
       witnesses = db.get_global_properties().active_witnesses;
-      BOOST_CHECK_EQUAL(witnesses.size(), 11);
-      BOOST_CHECK_EQUAL(witnesses.begin()[0].instance.value, 14);
-      BOOST_CHECK_EQUAL(witnesses.begin()[1].instance.value, 15);
-      BOOST_CHECK_EQUAL(witnesses.begin()[2].instance.value, 16);
-      BOOST_CHECK_EQUAL(witnesses.begin()[3].instance.value, 17);
-      BOOST_CHECK_EQUAL(witnesses.begin()[4].instance.value, 18);
-      BOOST_CHECK_EQUAL(witnesses.begin()[5].instance.value, 19);
-      BOOST_CHECK_EQUAL(witnesses.begin()[6].instance.value, 20);
-      BOOST_CHECK_EQUAL(witnesses.begin()[7].instance.value, 21);
-      BOOST_CHECK_EQUAL(witnesses.begin()[8].instance.value, 22);
-      BOOST_CHECK_EQUAL(witnesses.begin()[9].instance.value, 23);
-      BOOST_CHECK_EQUAL(witnesses.begin()[10].instance.value, 24);
+      BOOST_CHECK_EQUAL(witnesses.size(), 11u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[0].instance.value, 14u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[1].instance.value, 15u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[2].instance.value, 16u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[3].instance.value, 17u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[4].instance.value, 18u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[5].instance.value, 19u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[6].instance.value, 20u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[7].instance.value, 21u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[8].instance.value, 22u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[9].instance.value, 23u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[10].instance.value, 24u);
 
    } FC_LOG_AND_RETHROW()
 }
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(track_votes_witnesses_enabled)
 
       const account_id_type witness1_id= get_account("witness1").id;
       auto witness1_object = db_api1.get_witness_by_account(witness1_id(db).name);
-      BOOST_CHECK_EQUAL(witness1_object->total_votes, 111);
+      BOOST_CHECK_EQUAL(witness1_object->total_votes, 111u);
 
    } FC_LOG_AND_RETHROW()
 }
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(track_votes_witnesses_disabled)
 
       const account_id_type witness1_id= get_account("witness1").id;
       auto witness1_object = db_api1.get_witness_by_account(witness1_id(db).name);
-      BOOST_CHECK_EQUAL(witness1_object->total_votes, 0);
+      BOOST_CHECK_EQUAL(witness1_object->total_votes, 0u);
 
    } FC_LOG_AND_RETHROW()
 }
@@ -306,17 +306,17 @@ BOOST_AUTO_TEST_CASE(put_my_committee_members)
       // Check current default witnesses, default chain is configured with 10 witnesses
       auto committee_members = db.get_global_properties().active_committee_members;
 
-      BOOST_CHECK_EQUAL(committee_members.size(), 10);
-      BOOST_CHECK_EQUAL(committee_members.begin()[0].instance.value, 0);
-      BOOST_CHECK_EQUAL(committee_members.begin()[1].instance.value, 1);
-      BOOST_CHECK_EQUAL(committee_members.begin()[2].instance.value, 2);
-      BOOST_CHECK_EQUAL(committee_members.begin()[3].instance.value, 3);
-      BOOST_CHECK_EQUAL(committee_members.begin()[4].instance.value, 4);
-      BOOST_CHECK_EQUAL(committee_members.begin()[5].instance.value, 5);
-      BOOST_CHECK_EQUAL(committee_members.begin()[6].instance.value, 6);
-      BOOST_CHECK_EQUAL(committee_members.begin()[7].instance.value, 7);
-      BOOST_CHECK_EQUAL(committee_members.begin()[8].instance.value, 8);
-      BOOST_CHECK_EQUAL(committee_members.begin()[9].instance.value, 9);
+      BOOST_CHECK_EQUAL(committee_members.size(), 10u);
+      BOOST_CHECK_EQUAL(committee_members.begin()[0].instance.value, 0u);
+      BOOST_CHECK_EQUAL(committee_members.begin()[1].instance.value, 1u);
+      BOOST_CHECK_EQUAL(committee_members.begin()[2].instance.value, 2u);
+      BOOST_CHECK_EQUAL(committee_members.begin()[3].instance.value, 3u);
+      BOOST_CHECK_EQUAL(committee_members.begin()[4].instance.value, 4u);
+      BOOST_CHECK_EQUAL(committee_members.begin()[5].instance.value, 5u);
+      BOOST_CHECK_EQUAL(committee_members.begin()[6].instance.value, 6u);
+      BOOST_CHECK_EQUAL(committee_members.begin()[7].instance.value, 7u);
+      BOOST_CHECK_EQUAL(committee_members.begin()[8].instance.value, 8u);
+      BOOST_CHECK_EQUAL(committee_members.begin()[9].instance.value, 9u);
 
       // Activate all committee
       // Each witness is voted with incremental stake so last witness created will be the ones with more votes
@@ -345,7 +345,7 @@ BOOST_AUTO_TEST_CASE(put_my_committee_members)
 
       // Check my witnesses are now in control of the system
       committee_members = db.get_global_properties().active_committee_members;
-      BOOST_CHECK_EQUAL(committee_members.size(), 11);
+      BOOST_CHECK_EQUAL(committee_members.size(), 11u);
 
       /* TODO we are not in full control, seems to committee members have votes by default
       BOOST_CHECK_EQUAL(committee_members.begin()[0].instance.value, 14);
@@ -373,7 +373,7 @@ BOOST_AUTO_TEST_CASE(track_votes_committee_enabled)
 
       const account_id_type committee1_id= get_account("committee1").id;
       auto committee1_object = db_api1.get_committee_member_by_account(committee1_id(db).name);
-      BOOST_CHECK_EQUAL(committee1_object->total_votes, 111);
+      BOOST_CHECK_EQUAL(committee1_object->total_votes, 111u);
 
    } FC_LOG_AND_RETHROW()
 }
@@ -388,7 +388,7 @@ BOOST_AUTO_TEST_CASE(track_votes_committee_disabled)
 
       const account_id_type committee1_id= get_account("committee1").id;
       auto committee1_object = db_api1.get_committee_member_by_account(committee1_id(db).name);
-      BOOST_CHECK_EQUAL(committee1_object->total_votes, 0);
+      BOOST_CHECK_EQUAL(committee1_object->total_votes, 0u);
 
    } FC_LOG_AND_RETHROW()
 }
@@ -426,7 +426,7 @@ BOOST_AUTO_TEST_CASE(last_voting_date)
       auto witness1 = witness_id_type(1)(db);
 
       auto stats_obj = db.get_account_stats_by_owner(alice_id);
-      BOOST_CHECK_EQUAL(stats_obj.last_vote_time.sec_since_epoch(), 0);
+      BOOST_CHECK_EQUAL(stats_obj.last_vote_time.sec_since_epoch(), 0u);
 
       // alice votes
       graphene::chain::account_update_operation op;
@@ -488,7 +488,6 @@ BOOST_AUTO_TEST_CASE(last_voting_date_proxy)
          PUSH_TX( db, trx, ~0 );
       }
       // last_vote_time is not updated
-      auto round2 = db.head_block_time().sec_since_epoch();
       alice_stats_obj = db.get_account_stats_by_owner(alice_id);
       BOOST_CHECK_EQUAL(alice_stats_obj.last_vote_time.sec_since_epoch(), round1);
 


### PR DESCRIPTION
This is a partial fix for #1246

Newer compilers throw many more warnings. These commits minimize the warnings by:

- moving destructor implementation to the implemenation file
- ~~adding 2 -Wno-xxxx to the compiler options~~
- fixing many signed/unsigned comparison in tests

Moving the destructor to the implementation file still causes a warning, but it is at compile of the .cpp, not each time the .hpp is included (Update: this also is fixed, see below).

Adding the compiler options (-Wno-class-memaccess -Wno-parentheses) squelches warnings that are caused by (1) boost and (2) a non-trivial copy. This eliminates the warnings, but of course hides the problems. This change has been reverted.

~~There are still warnings about destructors throwing. I believe we should be using exit() instead of throwing, if we truly want to end the program, but these are sometimes within libraries. So I am unsure of the side effects (i.e. who all are using them, even outside the project).~~ Destructors no longer throw.