### PR TITLE
prevent throw in destructor

### DIFF
--- a/libraries/db/include/graphene/db/undo_database.hpp
+++ b/libraries/db/include/graphene/db/undo_database.hpp
@@ -59,7 +59,7 @@ namespace graphene { namespace db {
                {
                   mv._apply_undo = false;
                }
-               ~session(); // defined in implementation file to prevent repeated compiler warnings
+               ~session();
                void commit() { _apply_undo = false; _db.commit();  }
                void undo()   { if( _apply_undo ) _db.undo(); _apply_undo = false; }
                void merge()  { if( _apply_undo ) _db.merge(); _apply_undo = false; }

--- a/libraries/db/undo_database.cpp
+++ b/libraries/db/undo_database.cpp
@@ -38,7 +38,7 @@ undo_database::session::~session()
    catch ( const fc::exception& e )
    {
       elog( "${e}", ("e",e.to_detail_string() ) );
-      throw; // maybe crash..
+      std::terminate();
    }
    if( _disable_on_exit ) _db.disable();
 }

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -208,16 +208,20 @@ database_fixture::database_fixture()
 }
 
 database_fixture::~database_fixture()
-{ try {
-   // If we're unwinding due to an exception, don't do any more checks.
-   // This way, boost test's last checkpoint tells us approximately where the error was.
-   if( !std::uncaught_exception() )
-   {
-      verify_asset_supplies(db);
-      BOOST_CHECK( db.get_node_properties().skip_flags == database::skip_nothing );
+{ 
+   try {
+      // If we're unwinding due to an exception, don't do any more checks.
+      // This way, boost test's last checkpoint tells us approximately where the error was.
+      if( !std::uncaught_exception() )
+      {
+         verify_asset_supplies(db);
+         BOOST_CHECK( db.get_node_properties().skip_flags == database::skip_nothing );
+      }
+      return;
+   } catch (fc::exception& ex) {
+      BOOST_FAIL( ex.to_detail_string() );
    }
-   return;
-} FC_CAPTURE_AND_RETHROW() }
+} 
 
 fc::ecc::private_key database_fixture::generate_private_key(string seed)
 {


### PR DESCRIPTION
This is an improvement for Issue #1246.

PR https://github.com/bitshares/bitshares-core/pull/1510 lowered the number of warnings, but did not eliminate the cause.

I created this PR as an adjunct to https://github.com/bitshares/bitshares-core/pull/1510 so that we can determine the goods and bads of this approach. I look forward to your comments.