### PR TITLE
remove boost signals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,6 @@ LIST(APPEND BOOST_COMPONENTS thread
                              system
                              filesystem
                              program_options
-                             signals
                              serialization
                              chrono
                              unit_test_framework


### PR DESCRIPTION
We no longer use boost signals, but apparently the requirement was left in CMakeFiles.txt. Removing it will allow compiling BitShares with Boost 1.69 (which no longer ships with boost::signals)

Fixes #1512 