### PR TITLE
Fix some macOS warnings

### DIFF
--- a/libraries/app/application_impl.hxx
+++ b/libraries/app/application_impl.hxx
@@ -66,7 +66,7 @@ class application_impl : public net::node_delegate
 
       virtual void handle_transaction(const graphene::net::trx_message& transaction_message) override;
 
-      void handle_message(const graphene::net::message& message_to_process);
+      void handle_message(const graphene::net::message& message_to_process) override;
 
       bool is_included_block(const graphene::chain::block_id_type& block_id);
 

--- a/libraries/chain/include/graphene/chain/evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/evaluator.hpp
@@ -29,7 +29,7 @@
 namespace graphene { namespace chain {
 
    class database;
-   struct signed_transaction;
+   class signed_transaction;
    class generic_evaluator;
    class transaction_evaluation_state;
 

--- a/libraries/chain/include/graphene/chain/protocol/transaction.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/transaction.hpp
@@ -128,6 +128,7 @@ namespace graphene { namespace chain {
    public:
       signed_transaction( const transaction& trx = transaction() )
          : transaction(trx){}
+      virtual ~signed_transaction() = default;
 
       /** signs and appends to signatures */
       const signature_type& sign( const private_key_type& key, const chain_id_type& chain_id );
@@ -206,6 +207,7 @@ namespace graphene { namespace chain {
       precomputable_transaction() {}
       precomputable_transaction( const signed_transaction& tx ) : signed_transaction(tx) {};
       precomputable_transaction( signed_transaction&& tx ) : signed_transaction( std::move(tx) ) {};
+      virtual ~precomputable_transaction() = default;
 
       virtual const transaction_id_type&       id()const override;
       virtual void                             validate()const override;
@@ -239,6 +241,7 @@ namespace graphene { namespace chain {
    {
       processed_transaction( const signed_transaction& trx = signed_transaction() )
          : precomputable_transaction(trx){}
+      virtual ~processed_transaction() = default;
 
       vector<operation_result> operation_results;
 

--- a/libraries/chain/include/graphene/chain/protocol/transaction.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/transaction.hpp
@@ -65,6 +65,7 @@ namespace graphene { namespace chain {
    class transaction
    {
    public:
+      virtual ~transaction() = default;
       /**
        * Least significant 16 bits from the reference block number. If @ref relative_expiration is zero, this field
        * must be zero as well.

--- a/libraries/chain/include/graphene/chain/transaction_evaluation_state.hpp
+++ b/libraries/chain/include/graphene/chain/transaction_evaluation_state.hpp
@@ -26,7 +26,7 @@
 
 namespace graphene { namespace chain {
    class database;
-   struct signed_transaction;
+   class signed_transaction;
 
    /**
     *  Place holder for state tracked while processing a transaction. This class provides helper methods that are

--- a/libraries/chain/protocol/fee_schedule.cpp
+++ b/libraries/chain/protocol/fee_schedule.cpp
@@ -27,13 +27,21 @@
 
 namespace fc
 {
-   template<> bool smart_ref<graphene::chain::fee_schedule>::operator !()const { throw std::logic_error("Not Implemented"); }
-   template class smart_ref<graphene::chain::fee_schedule>;
+   // explicitly instantiate the smart_ref, gcc fails to instantiate it in some release builds
+   //template graphene::chain::fee_schedule& smart_ref<graphene::chain::fee_schedule>::operator=(smart_ref<graphene::chain::fee_schedule>&&);
+   //template graphene::chain::fee_schedule& smart_ref<graphene::chain::fee_schedule>::operator=(U&&);
+   //template graphene::chain::fee_schedule& smart_ref<graphene::chain::fee_schedule>::operator=(const smart_ref&);
+   //template smart_ref<graphene::chain::fee_schedule>::smart_ref();
+   //template const graphene::chain::fee_schedule& smart_ref<graphene::chain::fee_schedule>::operator*() const;
 }
 
 #define MAX_FEE_STABILIZATION_ITERATION 4
 
 namespace graphene { namespace chain {
+
+   typedef fc::smart_ref<fee_schedule> smart_fee_schedule;
+
+   static smart_fee_schedule tmp;
 
    fee_schedule::fee_schedule()
    {

--- a/libraries/chain/protocol/fee_schedule.cpp
+++ b/libraries/chain/protocol/fee_schedule.cpp
@@ -27,21 +27,13 @@
 
 namespace fc
 {
-   // explicitly instantiate the smart_ref, gcc fails to instantiate it in some release builds
-   //template graphene::chain::fee_schedule& smart_ref<graphene::chain::fee_schedule>::operator=(smart_ref<graphene::chain::fee_schedule>&&);
-   //template graphene::chain::fee_schedule& smart_ref<graphene::chain::fee_schedule>::operator=(U&&);
-   //template graphene::chain::fee_schedule& smart_ref<graphene::chain::fee_schedule>::operator=(const smart_ref&);
-   //template smart_ref<graphene::chain::fee_schedule>::smart_ref();
-   //template const graphene::chain::fee_schedule& smart_ref<graphene::chain::fee_schedule>::operator*() const;
+   template<> bool smart_ref<graphene::chain::fee_schedule>::operator !()const { throw std::logic_error("Not Implemented"); }
+   template class smart_ref<graphene::chain::fee_schedule>;
 }
 
 #define MAX_FEE_STABILIZATION_ITERATION 4
 
 namespace graphene { namespace chain {
-
-   typedef fc::smart_ref<fee_schedule> smart_fee_schedule;
-
-   static smart_fee_schedule tmp;
 
    fee_schedule::fee_schedule()
    {

--- a/libraries/net/include/graphene/net/node.hpp
+++ b/libraries/net/include/graphene/net/node.hpp
@@ -193,7 +193,7 @@ namespace graphene { namespace net {
    {
       public:
         node(const std::string& user_agent);
-        ~node();
+        virtual ~node();
 
         void close();
 


### PR DESCRIPTION
Compiling on macOS generates a good number of warnings. These commits fix the following:
- an override of node::handle_message in application_impl that was not declared as such
- some classes were forward declared as structs
- some classes declared virtual methods without declaring a virtual destructor