### PR TITLE
refactor template instantiation

### DIFF
--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -37,7 +37,6 @@
 #include <graphene/chain/worker_object.hpp>
 
 #include <fc/crypto/hex.hpp>
-#include <fc/smart_ref_impl.hpp>
 #include <fc/thread/future.hpp>
 
 namespace graphene { namespace app {

--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -39,8 +39,6 @@
 #include <graphene/utilities/key_conversion.hpp>
 #include <graphene/chain/worker_evaluator.hpp>
 
-#include <fc/smart_ref_impl.hpp>
-
 #include <fc/asio.hpp>
 #include <fc/io/fstream.hpp>
 #include <fc/rpc/api_connection.hpp>

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -27,7 +27,6 @@
 #include <graphene/chain/get_config.hpp>
 
 #include <fc/bloom_filter.hpp>
-#include <fc/smart_ref_impl.hpp>
 
 #include <fc/crypto/hex.hpp>
 #include <fc/uint128.hpp>

--- a/libraries/chain/account_evaluator.cpp
+++ b/libraries/chain/account_evaluator.cpp
@@ -22,8 +22,6 @@
  * THE SOFTWARE.
  */
 
-#include <fc/smart_ref_impl.hpp>
-
 #include <graphene/chain/account_evaluator.hpp>
 #include <graphene/chain/buyback.hpp>
 #include <graphene/chain/buyback_object.hpp>

--- a/libraries/chain/block_database.cpp
+++ b/libraries/chain/block_database.cpp
@@ -24,7 +24,6 @@
 #include <graphene/chain/block_database.hpp>
 #include <graphene/chain/protocol/fee_schedule.hpp>
 #include <fc/io/raw.hpp>
-#include <fc/smart_ref_impl.hpp>
 
 namespace graphene { namespace chain {
 

--- a/libraries/chain/committee_member_evaluator.cpp
+++ b/libraries/chain/committee_member_evaluator.cpp
@@ -29,8 +29,6 @@
 #include <graphene/chain/protocol/vote.hpp>
 #include <graphene/chain/transaction_evaluation_state.hpp>
 
-#include <fc/smart_ref_impl.hpp>
-
 namespace graphene { namespace chain {
 
 void_result committee_member_create_evaluator::do_evaluate( const committee_member_create_operation& op )

--- a/libraries/chain/confidential_evaluator.cpp
+++ b/libraries/chain/confidential_evaluator.cpp
@@ -29,8 +29,6 @@
 #include <graphene/chain/fba_accumulator_id.hpp>
 #include <graphene/chain/hardfork.hpp>
 
-#include <fc/smart_ref_impl.hpp>
-
 namespace graphene { namespace chain {
 
 void_result transfer_to_blind_evaluator::do_evaluate( const transfer_to_blind_operation& o )

--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#include <fc/smart_ref_impl.hpp>
 #include "db_balance.cpp"
 #include "db_block.cpp"
 #include "db_debug.cpp"

--- a/libraries/chain/db_block.cpp
+++ b/libraries/chain/db_block.cpp
@@ -38,7 +38,6 @@
 #include <graphene/chain/evaluator.hpp>
 
 #include <fc/thread/parallel.hpp>
-#include <fc/smart_ref_impl.hpp>
 
 namespace graphene { namespace chain {
 

--- a/libraries/chain/db_getter.cpp
+++ b/libraries/chain/db_getter.cpp
@@ -28,8 +28,6 @@
 #include <graphene/chain/chain_property_object.hpp>
 #include <graphene/chain/global_property_object.hpp>
 
-#include <fc/smart_ref_impl.hpp>
-
 namespace graphene { namespace chain {
 
 const asset_object& database::get_core_asset() const

--- a/libraries/chain/db_init.cpp
+++ b/libraries/chain/db_init.cpp
@@ -64,7 +64,6 @@
 
 #include <graphene/chain/protocol/fee_schedule.hpp>
 
-#include <fc/smart_ref_impl.hpp>
 #include <fc/uint128.hpp>
 #include <fc/crypto/digest.hpp>
 

--- a/libraries/chain/db_maint.cpp
+++ b/libraries/chain/db_maint.cpp
@@ -24,7 +24,6 @@
 
 #include <boost/multiprecision/integer.hpp>
 
-#include <fc/smart_ref_impl.hpp>
 #include <fc/uint128.hpp>
 
 #include <graphene/chain/database.hpp>

--- a/libraries/chain/db_management.cpp
+++ b/libraries/chain/db_management.cpp
@@ -31,7 +31,6 @@
 #include <graphene/chain/protocol/fee_schedule.hpp>
 
 #include <fc/io/fstream.hpp>
-#include <fc/smart_ref_impl.hpp>
 
 #include <fstream>
 #include <functional>

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -24,8 +24,6 @@
 #include <graphene/chain/fork_database.hpp>
 #include <graphene/chain/exceptions.hpp>
 
-#include <fc/smart_ref_impl.hpp>
-
 namespace graphene { namespace chain {
 fork_database::fork_database()
 {

--- a/libraries/chain/genesis_state.cpp
+++ b/libraries/chain/genesis_state.cpp
@@ -24,8 +24,7 @@
 
 #include <graphene/chain/genesis_state.hpp>
 
-// these are required to serialize a genesis_state
-#include <fc/smart_ref_impl.hpp>   // required for gcc in release mode
+// this is required to serialize a genesis_state
 #include <graphene/chain/protocol/fee_schedule.hpp>
 
 namespace graphene { namespace chain {

--- a/libraries/chain/include/graphene/chain/protocol/fee_schedule.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/fee_schedule.hpp
@@ -22,6 +22,7 @@
  * THE SOFTWARE.
  */
 #pragma once
+#include <fc/smart_ref_impl.hpp>
 #include <graphene/chain/protocol/operations.hpp>
 
 namespace graphene { namespace chain {

--- a/libraries/chain/market_evaluator.cpp
+++ b/libraries/chain/market_evaluator.cpp
@@ -35,7 +35,6 @@
 #include <graphene/chain/protocol/market.hpp>
 
 #include <fc/uint128.hpp>
-#include <fc/smart_ref_impl.hpp>
 
 namespace graphene { namespace chain {
 void_result limit_order_create_evaluator::do_evaluate(const limit_order_create_operation& op)

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -26,8 +26,6 @@
 #include <graphene/chain/proposal_object.hpp>
 #include <graphene/chain/hardfork.hpp>
 
-#include <fc/smart_ref_impl.hpp>
-
 namespace graphene { namespace chain {
 
 

--- a/libraries/chain/protocol/fee_schedule.cpp
+++ b/libraries/chain/protocol/fee_schedule.cpp
@@ -27,22 +27,19 @@
 
 namespace fc
 {
-   // explicitly instantiate the smart_ref, gcc fails to instantiate it in some release builds
-   //template graphene::chain::fee_schedule& smart_ref<graphene::chain::fee_schedule>::operator=(smart_ref<graphene::chain::fee_schedule>&&);
-   //template graphene::chain::fee_schedule& smart_ref<graphene::chain::fee_schedule>::operator=(U&&);
-   //template graphene::chain::fee_schedule& smart_ref<graphene::chain::fee_schedule>::operator=(const smart_ref&);
-   //template smart_ref<graphene::chain::fee_schedule>::smart_ref();
-   //template const graphene::chain::fee_schedule& smart_ref<graphene::chain::fee_schedule>::operator*() const;
-   template smart_ref<graphene::chain::fee_schedule>::smart_ref(smart_ref<graphene::chain::fee_schedule> const&);
+   // these are required on certain platforms in Release mode
+   template<> 
+   bool smart_ref<graphene::chain::fee_schedule>::operator !()const
+   {
+      throw std::logic_error("Not Implemented"); 
+   }
+
+   template class smart_ref<graphene::chain::fee_schedule>;
 }
 
 #define MAX_FEE_STABILIZATION_ITERATION 4
 
 namespace graphene { namespace chain {
-
-   typedef fc::smart_ref<fee_schedule> smart_fee_schedule;
-
-   static smart_fee_schedule tmp;
 
    fee_schedule::fee_schedule()
    {

--- a/libraries/chain/protocol/fee_schedule.cpp
+++ b/libraries/chain/protocol/fee_schedule.cpp
@@ -33,6 +33,7 @@ namespace fc
    //template graphene::chain::fee_schedule& smart_ref<graphene::chain::fee_schedule>::operator=(const smart_ref&);
    //template smart_ref<graphene::chain::fee_schedule>::smart_ref();
    //template const graphene::chain::fee_schedule& smart_ref<graphene::chain::fee_schedule>::operator*() const;
+   template smart_ref<graphene::chain::fee_schedule>::smart_ref(smart_ref<graphene::chain::fee_schedule> const&);
 }
 
 #define MAX_FEE_STABILIZATION_ITERATION 4

--- a/libraries/chain/protocol/fee_schedule.cpp
+++ b/libraries/chain/protocol/fee_schedule.cpp
@@ -23,7 +23,6 @@
  */
 #include <algorithm>
 #include <graphene/chain/protocol/fee_schedule.hpp>
-#include <fc/smart_ref_impl.hpp>
 
 namespace fc
 {

--- a/libraries/chain/protocol/proposal.cpp
+++ b/libraries/chain/protocol/proposal.cpp
@@ -23,7 +23,6 @@
  */
 #include <graphene/chain/protocol/operations.hpp>
 #include <graphene/chain/protocol/fee_schedule.hpp>
-#include <fc/smart_ref_impl.hpp>
 
 namespace graphene { namespace chain {
 

--- a/libraries/chain/protocol/transaction.cpp
+++ b/libraries/chain/protocol/transaction.cpp
@@ -26,7 +26,6 @@
 #include <graphene/chain/protocol/block.hpp>
 #include <fc/io/raw.hpp>
 #include <fc/bitutil.hpp>
-#include <fc/smart_ref_impl.hpp>
 #include <algorithm>
 
 namespace graphene { namespace chain {

--- a/libraries/db/include/graphene/db/index.hpp
+++ b/libraries/db/include/graphene/db/index.hpp
@@ -210,7 +210,7 @@ namespace graphene { namespace db {
       // private
          static const size_t MAX_HOLE = 100;
          static const size_t _mask = ((1 << chunkbits) - 1);
-         size_t next = 0;
+         uint64_t next = 0;
          vector< vector< const Object* > > content;
          std::stack< object_id_type > ids_being_modified;
 

--- a/libraries/egenesis/embed_genesis.cpp
+++ b/libraries/egenesis/embed_genesis.cpp
@@ -30,7 +30,6 @@
 #include <boost/algorithm/string.hpp>
 
 #include <fc/filesystem.hpp>
-#include <fc/smart_ref_impl.hpp>   // required for gcc in release mode
 #include <fc/string.hpp>
 #include <fc/io/fstream.hpp>
 #include <fc/io/json.hpp>

--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -69,7 +69,6 @@
 #include <fc/crypto/rand.hpp>
 #include <fc/network/rate_limiting.hpp>
 #include <fc/network/ip.hpp>
-#include <fc/smart_ref_impl.hpp>
 
 #include <graphene/net/node.hpp>
 #include <graphene/net/peer_database.hpp>

--- a/libraries/plugins/account_history/account_history_plugin.cpp
+++ b/libraries/plugins/account_history/account_history_plugin.cpp
@@ -34,7 +34,6 @@
 #include <graphene/chain/operation_history_object.hpp>
 #include <graphene/chain/transaction_evaluation_state.hpp>
 
-#include <fc/smart_ref_impl.hpp>
 #include <fc/thread/thread.hpp>
 
 namespace graphene { namespace account_history {

--- a/libraries/plugins/debug_witness/debug_api.cpp
+++ b/libraries/plugins/debug_witness/debug_api.cpp
@@ -2,7 +2,6 @@
 #include <fc/filesystem.hpp>
 #include <fc/optional.hpp>
 #include <fc/variant_object.hpp>
-#include <fc/smart_ref_impl.hpp>
 
 #include <graphene/app/application.hpp>
 

--- a/libraries/plugins/debug_witness/debug_witness.cpp
+++ b/libraries/plugins/debug_witness/debug_witness.cpp
@@ -28,7 +28,6 @@
 
 #include <graphene/utilities/key_conversion.hpp>
 
-#include <fc/smart_ref_impl.hpp>
 #include <fc/thread/thread.hpp>
 
 #include <iostream>

--- a/libraries/plugins/delayed_node/delayed_node_plugin.cpp
+++ b/libraries/plugins/delayed_node/delayed_node_plugin.cpp
@@ -30,8 +30,6 @@
 #include <fc/network/http/websocket.hpp>
 #include <fc/rpc/websocket_api.hpp>
 #include <fc/api.hpp>
-#include <fc/smart_ref_impl.hpp>
-
 
 namespace graphene { namespace delayed_node {
 namespace bpo = boost::program_options;

--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -25,7 +25,6 @@
 #include <graphene/elasticsearch/elasticsearch_plugin.hpp>
 #include <graphene/chain/impacted.hpp>
 #include <graphene/chain/account_evaluator.hpp>
-#include <fc/smart_ref_impl.hpp>
 #include <curl/curl.h>
 #include <graphene/utilities/elasticsearch.hpp>
 

--- a/libraries/plugins/es_objects/es_objects.cpp
+++ b/libraries/plugins/es_objects/es_objects.cpp
@@ -24,8 +24,6 @@
 
 #include <graphene/es_objects/es_objects.hpp>
 
-#include <fc/smart_ref_impl.hpp>
-
 #include <curl/curl.h>
 #include <graphene/chain/proposal_object.hpp>
 #include <graphene/chain/balance_object.hpp>

--- a/libraries/plugins/market_history/market_history_plugin.cpp
+++ b/libraries/plugins/market_history/market_history_plugin.cpp
@@ -34,7 +34,6 @@
 #include <graphene/chain/protocol/fee_schedule.hpp>
 
 #include <fc/thread/thread.hpp>
-#include <fc/smart_ref_impl.hpp>
 
 namespace graphene { namespace market_history {
 

--- a/libraries/plugins/witness/witness.cpp
+++ b/libraries/plugins/witness/witness.cpp
@@ -28,7 +28,6 @@
 
 #include <graphene/utilities/key_conversion.hpp>
 
-#include <fc/smart_ref_impl.hpp>
 #include <fc/thread/thread.hpp>
 
 #include <iostream>

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -72,7 +72,6 @@
 #include <graphene/wallet/api_documentation.hpp>
 #include <graphene/wallet/reflect_util.hpp>
 #include <graphene/debug_witness/debug_api.hpp>
-#include <fc/smart_ref_impl.hpp>
 
 #ifndef WIN32
 # include <sys/types.h>

--- a/programs/build_helpers/member_enumerator.cpp
+++ b/programs/build_helpers/member_enumerator.cpp
@@ -28,7 +28,6 @@
 #include <graphene/chain/account_object.hpp>
 #include <graphene/chain/balance_object.hpp>
 #include <graphene/chain/committee_member_object.hpp>
-#include <fc/smart_ref_impl.hpp>
 #include <iostream>
 
 using namespace graphene::chain;

--- a/programs/cli_wallet/main.cpp
+++ b/programs/cli_wallet/main.cpp
@@ -34,7 +34,6 @@
 #include <fc/rpc/cli.hpp>
 #include <fc/rpc/http_api.hpp>
 #include <fc/rpc/websocket_api.hpp>
-#include <fc/smart_ref_impl.hpp>
 
 #include <graphene/app/api.hpp>
 #include <graphene/chain/config.hpp>

--- a/programs/genesis_util/genesis_update.cpp
+++ b/programs/genesis_util/genesis_update.cpp
@@ -30,7 +30,6 @@
 #include <fc/io/fstream.hpp>
 #include <fc/io/json.hpp>
 #include <fc/io/stdio.hpp>
-#include <fc/smart_ref_impl.hpp>
 
 #include <graphene/app/api.hpp>
 #include <graphene/chain/protocol/address.hpp>

--- a/programs/js_operation_serializer/main.cpp
+++ b/programs/js_operation_serializer/main.cpp
@@ -37,7 +37,6 @@
 #include <graphene/chain/witness_object.hpp>
 #include <graphene/chain/worker_object.hpp>
 
-#include <fc/smart_ref_impl.hpp>
 #include <iostream>
 
 using namespace graphene::chain;

--- a/programs/size_checker/main.cpp
+++ b/programs/size_checker/main.cpp
@@ -23,7 +23,6 @@
  */
 
 #include <fc/io/json.hpp>
-#include <fc/smart_ref_impl.hpp>
 #include <fc/variant.hpp>
 #include <fc/variant_object.hpp>
 

--- a/tests/app/main.cpp
+++ b/tests/app/main.cpp
@@ -35,7 +35,6 @@
 #include <graphene/grouped_orders/grouped_orders_plugin.hpp>
 
 #include <fc/thread/thread.hpp>
-#include <fc/smart_ref_impl.hpp>
 #include <fc/log/appender.hpp>
 #include <fc/log/logger.hpp>
 

--- a/tests/benchmarks/genesis_allocation.cpp
+++ b/tests/benchmarks/genesis_allocation.cpp
@@ -26,7 +26,6 @@
 #include <graphene/utilities/tempdir.hpp>
 
 #include <fc/crypto/digest.hpp>
-#include <fc/smart_ref_impl.hpp>
 
 #include <boost/test/auto_unit_test.hpp>
 

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -33,7 +33,6 @@
 #include <graphene/wallet/wallet.hpp>
 
 #include <fc/thread/thread.hpp>
-#include <fc/smart_ref_impl.hpp>
 #include <fc/network/http/websocket.hpp>
 #include <fc/rpc/websocket_api.hpp>
 #include <fc/rpc/cli.hpp>

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -41,7 +41,6 @@
 #include <graphene/utilities/tempdir.hpp>
 
 #include <fc/crypto/digest.hpp>
-#include <fc/smart_ref_impl.hpp>
 
 #include <iomanip>
 

--- a/tests/common/database_fixture.hpp
+++ b/tests/common/database_fixture.hpp
@@ -27,7 +27,6 @@
 #include <graphene/chain/database.hpp>
 #include <graphene/chain/protocol/types.hpp>
 #include <fc/io/json.hpp>
-#include <fc/smart_ref_impl.hpp>
 
 #include <graphene/chain/operation_history_object.hpp>
 #include <graphene/market_history/market_history_plugin.hpp>

--- a/tests/generate_empty_blocks/main.cpp
+++ b/tests/generate_empty_blocks/main.cpp
@@ -30,7 +30,6 @@
 #include <fc/io/fstream.hpp>
 #include <fc/io/json.hpp>
 #include <fc/io/stdio.hpp>
-#include <fc/smart_ref_impl.hpp>
 
 #include <graphene/app/api.hpp>
 #include <graphene/egenesis/egenesis.hpp>

--- a/tests/tests/fee_tests.cpp
+++ b/tests/tests/fee_tests.cpp
@@ -22,7 +22,6 @@
  * THE SOFTWARE.
  */
 
-#include <fc/smart_ref_impl.hpp>
 #include <fc/uint128.hpp>
 
 #include <graphene/chain/hardfork.hpp>


### PR DESCRIPTION
This is another way to fix #1504 that works for macOS, and probably others.

Instead of including fc/smart_ref_impl.hpp, this fix permits the template to generate the specific copy constructor that is needed.

I am unable to test on the originally reported platform (openSUSE 15.04) , as I do not have that environment. 