### PR TITLE
make cli_wallet rpc logging work

### DIFF
--- a/programs/cli_wallet/main.cpp
+++ b/programs/cli_wallet/main.cpp
@@ -116,28 +116,27 @@ int main( int argc, char** argv )
          return 0;
       }
 
+      // set up logging
       fc::path data_dir;
       fc::logging_config cfg;
       fc::path log_dir = data_dir / "logs";
-
       fc::file_appender::config ac;
-      ac.filename             = log_dir / "rpc" / "rpc.log";
+      ac.filename             = log_dir / "cli_rpc" / "rpc.log";
       ac.flush                = true;
       ac.rotate               = true;
       ac.rotation_interval    = fc::hours( 1 );
       ac.rotation_limit       = fc::days( 1 );
-
-      std::cout << "Logging RPC to file: " << (data_dir / ac.filename).preferred_string() << "\n";
-
       cfg.appenders.push_back(fc::appender_config( "default", "console", fc::variant(fc::console_appender::config(), 20)));
       cfg.appenders.push_back(fc::appender_config( "rpc", "file", fc::variant(ac, 5)));
-
       cfg.loggers = { fc::logger_config("default"), fc::logger_config( "rpc") };
       cfg.loggers.front().level = fc::log_level::info;
       cfg.loggers.front().appenders = {"default"};
       cfg.loggers.back().level = fc::log_level::debug;
       cfg.loggers.back().appenders = {"rpc"};
+      std::cout << "Logging RPC to file: " << (data_dir / ac.filename).preferred_string() << "\n";
+      fc::configure_logging( cfg );
 
+      // key generation
       fc::ecc::private_key committee_private_key = fc::ecc::private_key::regenerate(fc::sha256::hash(string("null_key")));
 
       idump( (key_to_wif( committee_private_key ) ) );

--- a/programs/cli_wallet/main.cpp
+++ b/programs/cli_wallet/main.cpp
@@ -117,24 +117,36 @@ int main( int argc, char** argv )
       }
 
       // set up logging
-      fc::path data_dir;
       fc::logging_config cfg;
-      fc::path log_dir = data_dir / "logs";
+      // console logger
+      fc::console_appender::config console_appender_config;
+      console_appender_config.level_colors.emplace_back(
+            fc::console_appender::level_color(fc::log_level::debug,
+            fc::console_appender::color::green));
+      console_appender_config.level_colors.emplace_back(
+            fc::console_appender::level_color(fc::log_level::warn,
+            fc::console_appender::color::brown));
+      console_appender_config.level_colors.emplace_back(
+            fc::console_appender::level_color(fc::log_level::error,
+            fc::console_appender::color::red));
+      cfg.appenders.push_back(fc::appender_config( "default", "console", fc::variant(console_appender_config, 20)));
+      cfg.loggers = { fc::logger_config("default"), fc::logger_config( "rpc") };
+      cfg.loggers.front().level = fc::log_level::info;
+      cfg.loggers.front().appenders = {"default"};
+      // file logger
+      fc::path data_dir;
+      fc::path log_dir = data_dir / "cli_wallet_logs";
       fc::file_appender::config ac;
-      ac.filename             = log_dir / "cli_rpc" / "rpc.log";
+      ac.filename             = log_dir / "rpc.log";
       ac.flush                = true;
       ac.rotate               = true;
       ac.rotation_interval    = fc::hours( 1 );
       ac.rotation_limit       = fc::days( 1 );
-      cfg.appenders.push_back(fc::appender_config( "default", "console", fc::variant(fc::console_appender::config(), 20)));
       cfg.appenders.push_back(fc::appender_config( "rpc", "file", fc::variant(ac, 5)));
-      cfg.loggers = { fc::logger_config("default"), fc::logger_config( "rpc") };
-      cfg.loggers.front().level = fc::log_level::info;
-      cfg.loggers.front().appenders = {"default"};
       cfg.loggers.back().level = fc::log_level::debug;
       cfg.loggers.back().appenders = {"rpc"};
-      std::cout << "Logging RPC to file: " << (data_dir / ac.filename).preferred_string() << "\n";
       fc::configure_logging( cfg );
+      ilog ( "Logging RPC to file: " + (data_dir / ac.filename).preferred_string() );
 
       // key generation
       fc::ecc::private_key committee_private_key = fc::ecc::private_key::regenerate(fc::sha256::hash(string("null_key")));

--- a/programs/cli_wallet/main.cpp
+++ b/programs/cli_wallet/main.cpp
@@ -132,11 +132,13 @@ int main( int argc, char** argv )
          ("server-rpc-user,u", bpo::value<string>(), "Server Username")
          ("server-rpc-password,p", bpo::value<string>(), "Server Password")
          ("rpc-endpoint,r", bpo::value<string>()->implicit_value("127.0.0.1:8091"),
-            "Endpoint for wallet websocket RPC to listen on (DEPRECATED, use rpc-http-endpoint instead)")
-         ("rpc-tls-endpoint,t", bpo::value<string>()->implicit_value("127.0.0.1:8092"), "Endpoint for wallet websocket TLS RPC to listen on")
-         ("rpc-tls-certificate,c", bpo::value<string>()->implicit_value("server.pem"), "PEM certificate for wallet websocket TLS RPC")
+               "Endpoint for wallet websocket RPC to listen on (DEPRECATED, use rpc-http-endpoint instead)")
+         ("rpc-tls-endpoint,t", bpo::value<string>()->implicit_value("127.0.0.1:8092"),
+               "Endpoint for wallet websocket TLS RPC to listen on")
+         ("rpc-tls-certificate,c", bpo::value<string>()->implicit_value("server.pem"),
+               "PEM certificate for wallet websocket TLS RPC")
          ("rpc-http-endpoint,H", bpo::value<string>()->implicit_value("127.0.0.1:8093"),
-            "Endpoint for wallet HTTP and websocket RPC to listen on")
+               "Endpoint for wallet HTTP and websocket RPC to listen on")
          ("daemon,d", "Run the wallet in daemon mode" )
          ("wallet-file,w", bpo::value<string>()->implicit_value("wallet.json"), "wallet to load")
          ("chain-id", bpo::value<string>(), "chain ID to connect to")

--- a/programs/cli_wallet/main.cpp
+++ b/programs/cli_wallet/main.cpp
@@ -66,6 +66,47 @@ using namespace graphene::wallet;
 using namespace std;
 namespace bpo = boost::program_options;
 
+/***
+ * @brief sets up basic logging
+ * 
+ * Sends most logging messages (up to level "info") to the console and RPC messages 
+ * (including level "debug")to a file
+ */
+void setup_logging()
+{
+      // set up logging
+      fc::logging_config cfg;
+      // console logger
+      fc::console_appender::config console_appender_config;
+      console_appender_config.level_colors.emplace_back(
+            fc::console_appender::level_color(fc::log_level::debug,
+            fc::console_appender::color::green));
+      console_appender_config.level_colors.emplace_back(
+            fc::console_appender::level_color(fc::log_level::warn,
+            fc::console_appender::color::brown));
+      console_appender_config.level_colors.emplace_back(
+            fc::console_appender::level_color(fc::log_level::error,
+            fc::console_appender::color::red));
+      cfg.appenders.push_back(fc::appender_config( "default", "console", fc::variant(console_appender_config, 20)));
+      cfg.loggers = { fc::logger_config("default"), fc::logger_config( "rpc") };
+      cfg.loggers.front().level = fc::log_level::info;
+      cfg.loggers.front().appenders = {"default"};
+      // file logger
+      fc::path data_dir;
+      fc::path log_dir = data_dir / "cli_wallet_logs";
+      fc::file_appender::config ac;
+      ac.filename             = log_dir / "rpc.log";
+      ac.flush                = true;
+      ac.rotate               = true;
+      ac.rotation_interval    = fc::hours( 1 );
+      ac.rotation_limit       = fc::days( 1 );
+      cfg.appenders.push_back(fc::appender_config( "rpc", "file", fc::variant(ac, 5)));
+      cfg.loggers.back().level = fc::log_level::debug;
+      cfg.loggers.back().appenders = {"rpc"};
+      fc::configure_logging( cfg );
+      ilog ( "Logging RPC to file: " + (ac.filename).preferred_string() );
+}
+
 int main( int argc, char** argv )
 {
    try {
@@ -116,37 +157,7 @@ int main( int argc, char** argv )
          return 0;
       }
 
-      // set up logging
-      fc::logging_config cfg;
-      // console logger
-      fc::console_appender::config console_appender_config;
-      console_appender_config.level_colors.emplace_back(
-            fc::console_appender::level_color(fc::log_level::debug,
-            fc::console_appender::color::green));
-      console_appender_config.level_colors.emplace_back(
-            fc::console_appender::level_color(fc::log_level::warn,
-            fc::console_appender::color::brown));
-      console_appender_config.level_colors.emplace_back(
-            fc::console_appender::level_color(fc::log_level::error,
-            fc::console_appender::color::red));
-      cfg.appenders.push_back(fc::appender_config( "default", "console", fc::variant(console_appender_config, 20)));
-      cfg.loggers = { fc::logger_config("default"), fc::logger_config( "rpc") };
-      cfg.loggers.front().level = fc::log_level::info;
-      cfg.loggers.front().appenders = {"default"};
-      // file logger
-      fc::path data_dir;
-      fc::path log_dir = data_dir / "cli_wallet_logs";
-      fc::file_appender::config ac;
-      ac.filename             = log_dir / "rpc.log";
-      ac.flush                = true;
-      ac.rotate               = true;
-      ac.rotation_interval    = fc::hours( 1 );
-      ac.rotation_limit       = fc::days( 1 );
-      cfg.appenders.push_back(fc::appender_config( "rpc", "file", fc::variant(ac, 5)));
-      cfg.loggers.back().level = fc::log_level::debug;
-      cfg.loggers.back().appenders = {"rpc"};
-      fc::configure_logging( cfg );
-      ilog ( "Logging RPC to file: " + (data_dir / ac.filename).preferred_string() );
+      setup_logging();
 
       // key generation
       fc::ecc::private_key committee_private_key = fc::ecc::private_key::regenerate(fc::sha256::hash(string("null_key")));

--- a/programs/cli_wallet/main.cpp
+++ b/programs/cli_wallet/main.cpp
@@ -74,37 +74,38 @@ namespace bpo = boost::program_options;
  */
 void setup_logging()
 {
-      // set up logging
-      fc::logging_config cfg;
-      // console logger
-      fc::console_appender::config console_appender_config;
-      console_appender_config.level_colors.emplace_back(
-            fc::console_appender::level_color(fc::log_level::debug,
-            fc::console_appender::color::green));
-      console_appender_config.level_colors.emplace_back(
-            fc::console_appender::level_color(fc::log_level::warn,
-            fc::console_appender::color::brown));
-      console_appender_config.level_colors.emplace_back(
-            fc::console_appender::level_color(fc::log_level::error,
-            fc::console_appender::color::red));
-      cfg.appenders.push_back(fc::appender_config( "default", "console", fc::variant(console_appender_config, 20)));
-      cfg.loggers = { fc::logger_config("default"), fc::logger_config( "rpc") };
-      cfg.loggers.front().level = fc::log_level::info;
-      cfg.loggers.front().appenders = {"default"};
-      // file logger
-      fc::path data_dir;
-      fc::path log_dir = data_dir / "cli_wallet_logs";
-      fc::file_appender::config ac;
-      ac.filename             = log_dir / "rpc.log";
-      ac.flush                = true;
-      ac.rotate               = true;
-      ac.rotation_interval    = fc::hours( 1 );
-      ac.rotation_limit       = fc::days( 1 );
-      cfg.appenders.push_back(fc::appender_config( "rpc", "file", fc::variant(ac, 5)));
-      cfg.loggers.back().level = fc::log_level::debug;
-      cfg.loggers.back().appenders = {"rpc"};
-      fc::configure_logging( cfg );
-      ilog ( "Logging RPC to file: " + (ac.filename).preferred_string() );
+   fc::logging_config cfg;
+
+   // console logger
+   fc::console_appender::config console_appender_config;
+   console_appender_config.level_colors.emplace_back(
+         fc::console_appender::level_color(fc::log_level::debug,
+         fc::console_appender::color::green));
+   console_appender_config.level_colors.emplace_back(
+         fc::console_appender::level_color(fc::log_level::warn,
+         fc::console_appender::color::brown));
+   console_appender_config.level_colors.emplace_back(
+         fc::console_appender::level_color(fc::log_level::error,
+         fc::console_appender::color::red));
+   cfg.appenders.push_back(fc::appender_config( "default", "console", fc::variant(console_appender_config, 20)));
+   cfg.loggers = { fc::logger_config("default"), fc::logger_config( "rpc") };
+   cfg.loggers.front().level = fc::log_level::info;
+   cfg.loggers.front().appenders = {"default"};
+
+   // file logger
+   fc::path data_dir;
+   fc::path log_dir = data_dir / "cli_wallet_logs";
+   fc::file_appender::config ac;
+   ac.filename             = log_dir / "rpc.log";
+   ac.flush                = true;
+   ac.rotate               = true;
+   ac.rotation_interval    = fc::hours( 1 );
+   ac.rotation_limit       = fc::days( 1 );
+   cfg.appenders.push_back(fc::appender_config( "rpc", "file", fc::variant(ac, 5)));
+   cfg.loggers.back().level = fc::log_level::debug;
+   cfg.loggers.back().appenders = {"rpc"};
+   fc::configure_logging( cfg );
+   ilog ( "Logging RPC to file: " + (ac.filename).preferred_string() );
 }
 
 int main( int argc, char** argv )

--- a/programs/cli_wallet/main.cpp
+++ b/programs/cli_wallet/main.cpp
@@ -79,6 +79,8 @@ fc::log_level string_to_level(string level)
       result = fc::log_level::error;
    else if(level == "all")
       result = fc::log_level::all;
+   else
+      FC_THROW("Log level not allowed. Allowed levels are info, debug, warn, error and all.");
 
    return result;
 }
@@ -143,9 +145,11 @@ int main( int argc, char** argv )
          ("wallet-file,w", bpo::value<string>()->implicit_value("wallet.json"), "wallet to load")
          ("chain-id", bpo::value<string>(), "chain ID to connect to")
          ("suggest-brain-key", "Suggest a safe brain key to use for creating your account")
-         ("logs-rpc-console-level", bpo::value<string>()->default_value("info"), "Level of console logging")
-         ("logs-rpc-file", bpo::value<bool>()->default_value(true), "Turn on/off file logging")
-         ("logs-rpc-file-level", bpo::value<string>()->default_value("debug"), "Level of file logging")
+         ("logs-rpc-console-level", bpo::value<string>()->default_value("info"),
+               "Level of console logging. Allowed levels: info, debug, warn, error, all")
+         ("logs-rpc-file", bpo::value<bool>()->default_value(false), "Turn on/off file logging")
+         ("logs-rpc-file-level", bpo::value<string>()->default_value("debug"),
+               "Level of file logging. Allowed levels: info, debug, warn, error, all")
          ("logs-rpc-file-name", bpo::value<string>()->default_value("rpc.log"), "File name for file rpc logs")
          ("version,v", "Display version information");
 


### PR DESCRIPTION
Fixes #1149 and #1567.

Although the cli_wallet said it was logging RPC messages to a log file, it was not. This change fixes the problem.

This fix also names the log file directory slightly differently to prevent conflicts (i.e cli_wallet is run along with witness_node).