### PR TITLE
Avoid calling exit from inside library

### DIFF
--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -318,7 +318,7 @@ void application_impl::set_dbg_init_key( graphene::chain::genesis_state_type& ge
       genesis.initial_witness_candidates[i].block_signing_key = init_pubkey;
 }
 
-void application_impl::startup()
+bool application_impl::startup()
 { try {
    fc::create_directories(_data_dir / "blockchain");
 
@@ -454,7 +454,7 @@ void application_impl::startup()
       {
          elog("Failed to load file from ${path}",
             ("path", _options->at("api-access").as<boost::filesystem::path>().string()));
-         std::exit(EXIT_FAILURE);
+         return false;
       }
    }
    else
@@ -475,6 +475,7 @@ void application_impl::startup()
    reset_p2p_node(_data_dir);
    reset_websocket_server();
    reset_websocket_tls_server();
+   return true;
 } FC_LOG_AND_RETHROW() }
 
 optional< api_access_info > application_impl::get_api_access_info(const string& username)const
@@ -1000,7 +1001,7 @@ void application::set_program_options(boost::program_options::options_descriptio
    configuration_file_options.add(_cfg_options);
 }
 
-void application::initialize(const fc::path& data_dir, const boost::program_options::variables_map& options)
+bool application::initialize(const fc::path& data_dir, const boost::program_options::variables_map& options)
 {
    my->_data_dir = data_dir;
    my->_options = &options;
@@ -1018,7 +1019,7 @@ void application::initialize(const fc::path& data_dir, const boost::program_opti
                       << "\nWould you like to replace it? [y/N] ";
             char response = std::cin.get();
             if( toupper(response) != 'Y' )
-               return;
+               return false;
          }
 
          std::cerr << "Updating genesis state in file " << genesis_out.generic_string() << "\n";
@@ -1027,7 +1028,7 @@ void application::initialize(const fc::path& data_dir, const boost::program_opti
       }
       fc::json::save_to_file(genesis_state, genesis_out);
 
-      std::exit(EXIT_SUCCESS);
+      return false;
    }
 
    if ( options.count("io-threads") )
@@ -1058,16 +1059,17 @@ void application::initialize(const fc::path& data_dir, const boost::program_opti
 
       if(es_ah_conflict_counter > 1) {
          elog("Can't start program with elasticsearch and account_history plugin at the same time");
-         std::exit(EXIT_FAILURE);
+         return false;
       }
       if (!it.empty()) enable_plugin(it);
    }
+   return true;
 }
 
-void application::startup()
+bool application::startup()
 {
    try {
-   my->startup();
+      return my->startup();
    } catch ( const fc::exception& e ) {
       elog( "${e}", ("e",e.to_detail_string()) );
       throw;

--- a/libraries/app/application_impl.hxx
+++ b/libraries/app/application_impl.hxx
@@ -42,7 +42,7 @@ class application_impl : public net::node_delegate
 
       void set_dbg_init_key( graphene::chain::genesis_state_type& genesis, const std::string& init_key );
 
-      void startup();
+      bool startup();
 
       fc::optional< api_access_info > get_api_access_info(const string& username)const;
 

--- a/libraries/app/include/graphene/app/application.hpp
+++ b/libraries/app/include/graphene/app/application.hpp
@@ -50,9 +50,17 @@ namespace graphene { namespace app {
 
          void set_program_options( boost::program_options::options_description& command_line_options,
                                    boost::program_options::options_description& configuration_file_options )const;
-         void initialize(const fc::path& data_dir, const boost::program_options::variables_map&options);
+         /**
+          * Initializes the application
+          * @returns true if the calling method should continue, false otherwise
+          */
+         bool initialize(const fc::path& data_dir, const boost::program_options::variables_map&options);
          void initialize_plugins( const boost::program_options::variables_map& options );
-         void startup();
+         /***
+          * Performs startup
+          * @returns true if the calling method should continue, false otherwise
+          */
+         bool startup();
          void shutdown();
          void startup_plugins();
          void shutdown_plugins();

--- a/libraries/chain/db_management.cpp
+++ b/libraries/chain/db_management.cpp
@@ -223,6 +223,9 @@ void database::open(
 
 void database::close(bool rewind)
 {
+   if (!_opened)
+      return;
+      
    // TODO:  Save pending tx's on close()
    clear_pending();
 

--- a/programs/delayed_node/main.cpp
+++ b/programs/delayed_node/main.cpp
@@ -163,10 +163,15 @@ int main(int argc, char** argv) {
       if( !options.count("plugins") )
          options.insert( std::make_pair( "plugins", bpo::variable_value(std::string("delayed_node account_history market_history"), true) ) );
 
-      node.initialize(data_dir, options);
+      if (!node.initialize(data_dir, options))
+         return 0;
+
       node.initialize_plugins( options );
 
-      node.startup();
+      if (!node.startup())
+      {
+         return 0;
+      }
       node.startup_plugins();
 
       fc::promise<int>::ptr exit_promise = new fc::promise<int>("UNIX Signal Handler");
@@ -180,6 +185,7 @@ int main(int argc, char** argv) {
       int signal = exit_promise->wait();
       ilog("Exiting from signal ${n}", ("n", signal));
       node.shutdown_plugins();
+      node.shutdown();
       return 0;
    } catch( const fc::exception& e ) {
       elog("Exiting with error:\n${e}", ("e", e.to_detail_string()));

--- a/programs/witness_node/main.cpp
+++ b/programs/witness_node/main.cpp
@@ -120,10 +120,18 @@ int main(int argc, char** argv) {
       app::load_configuration_options(data_dir, cfg_options, options);
 
       bpo::notify(options);
-      node->initialize(data_dir, options);
+      if (!node->initialize(data_dir, options))
+      {
+         delete node;
+         return 0;
+      }
       node->initialize_plugins( options );
 
-      node->startup();
+      if (!node->startup())
+      {
+         delete node;
+         return 0;
+      }
       node->startup_plugins();
 
       fc::promise<int>::ptr exit_promise = new fc::promise<int>("UNIX Signal Handler");


### PR DESCRIPTION
Fixes  #1110 

Calling ``exit`` from inside a library makes unit testing impossible. This fix uses return values to indicate if the application should end or continue.