### PR TITLE
update active witness object vector only at maint time

### DIFF
--- a/libraries/chain/db_init.cpp
+++ b/libraries/chain/db_init.cpp
@@ -683,8 +683,6 @@ void database::init_genesis(const genesis_state_type& genesis_state)
       }
    });
 
-   update_active_witnesses( false );
-
    // Enable fees
    modify(get_global_properties(), [&genesis_state](global_property_object& p) {
       p.parameters.current_fees = genesis_state.initial_parameters.current_fees;

--- a/libraries/chain/db_init.cpp
+++ b/libraries/chain/db_init.cpp
@@ -683,6 +683,8 @@ void database::init_genesis(const genesis_state_type& genesis_state)
       }
    });
 
+   update_active_witnesses( false );
+
    // Enable fees
    modify(get_global_properties(), [&genesis_state](global_property_object& p) {
       p.parameters.current_fees = genesis_state.initial_parameters.current_fees;

--- a/libraries/chain/db_management.cpp
+++ b/libraries/chain/db_management.cpp
@@ -206,6 +206,7 @@ void database::open(
          _p_chain_property_obj = &get( chain_property_id_type() );
          _p_dyn_global_prop_obj = &get( dynamic_global_property_id_type() );
          _p_witness_schedule_obj = &get( witness_schedule_id_type() );
+         update_active_witnesses( false );
       }
 
       fc::optional<block_id_type> last_block = _block_id_to_block.last_id();

--- a/libraries/chain/db_management.cpp
+++ b/libraries/chain/db_management.cpp
@@ -206,9 +206,10 @@ void database::open(
          _p_chain_property_obj = &get( chain_property_id_type() );
          _p_dyn_global_prop_obj = &get( dynamic_global_property_id_type() );
          _p_witness_schedule_obj = &get( witness_schedule_id_type() );
-         update_active_witnesses( false );
       }
 
+      update_active_witnesses( false );
+      
       fc::optional<block_id_type> last_block = _block_id_to_block.last_id();
       if( last_block.valid() )
       {

--- a/libraries/chain/include/graphene/chain/database.hpp
+++ b/libraries/chain/include/graphene/chain/database.hpp
@@ -499,7 +499,7 @@ namespace graphene { namespace chain {
          void process_budget();
          void pay_workers( share_type& budget );
          void perform_chain_maintenance(const signed_block& next_block, const global_property_object& global_props);
-         void update_active_witnesses();
+         void update_active_witnesses( bool reshuffle = true);
          void update_active_committee_members();
          void update_worker_votes();
          void process_bids( const asset_bitasset_data_object& bad );
@@ -574,6 +574,8 @@ namespace graphene { namespace chain {
          const chain_property_object*           _p_chain_property_obj      = nullptr;
          const witness_schedule_object*         _p_witness_schedule_obj    = nullptr;
          ///@}
+         // a list of active witnesses, updated every maintenance interval
+         vector<const witness_object*> _active_witnesses;
    };
 
    namespace detail


### PR DESCRIPTION
This fixes #1105 

The vector of active witness objects used in the method that calculates the last irreversible block was created each time the method was called.

This change creates the vector when the database is opened, or if the active witnesses change (at maintenance intervals), and then stores the vector as part of the database object.