### PR TITLE
Added human-readable message to assert

### DIFF
--- a/libraries/chain/market_evaluator.cpp
+++ b/libraries/chain/market_evaluator.cpp
@@ -49,9 +49,11 @@ void_result limit_order_create_evaluator::do_evaluate(const limit_order_create_o
    _receive_asset = &op.min_to_receive.asset_id(d);
 
    if( _sell_asset->options.whitelist_markets.size() )
-      FC_ASSERT( _sell_asset->options.whitelist_markets.find(_receive_asset->id) != _sell_asset->options.whitelist_markets.end() );
+      FC_ASSERT( _sell_asset->options.whitelist_markets.find(_receive_asset->id) != _sell_asset->options.whitelist_markets.end(),
+            "This market has not been whitelisted." );
    if( _sell_asset->options.blacklist_markets.size() )
-      FC_ASSERT( _sell_asset->options.blacklist_markets.find(_receive_asset->id) == _sell_asset->options.blacklist_markets.end() );
+      FC_ASSERT( _sell_asset->options.blacklist_markets.find(_receive_asset->id) == _sell_asset->options.blacklist_markets.end(),
+            "This market has been blacklisted." );
 
    FC_ASSERT( is_authorized_asset( d, *_seller, *_sell_asset ) );
    FC_ASSERT( is_authorized_asset( d, *_seller, *_receive_asset ) );

--- a/libraries/chain/market_evaluator.cpp
+++ b/libraries/chain/market_evaluator.cpp
@@ -49,10 +49,12 @@ void_result limit_order_create_evaluator::do_evaluate(const limit_order_create_o
    _receive_asset = &op.min_to_receive.asset_id(d);
 
    if( _sell_asset->options.whitelist_markets.size() )
-      FC_ASSERT( _sell_asset->options.whitelist_markets.find(_receive_asset->id) != _sell_asset->options.whitelist_markets.end(),
+      FC_ASSERT( _sell_asset->options.whitelist_markets.find(_receive_asset->id) 
+            != _sell_asset->options.whitelist_markets.end(),
             "This market has not been whitelisted." );
    if( _sell_asset->options.blacklist_markets.size() )
-      FC_ASSERT( _sell_asset->options.blacklist_markets.find(_receive_asset->id) == _sell_asset->options.blacklist_markets.end(),
+      FC_ASSERT( _sell_asset->options.blacklist_markets.find(_receive_asset->id) 
+            == _sell_asset->options.blacklist_markets.end(),
             "This market has been blacklisted." );
 
    FC_ASSERT( is_authorized_asset( d, *_seller, *_sell_asset ) );


### PR DESCRIPTION
Fixes #1018 

This makes the FC_ASSERT related to whitelisting / blacklisting intelligible to the end user.

Note: There are plenty more of these to do. See #691 