### PR TITLE
Switch uin8_t for char for clearer serialization

### DIFF
--- a/libraries/chain/htlc_evaluator.cpp
+++ b/libraries/chain/htlc_evaluator.cpp
@@ -71,11 +71,11 @@ namespace graphene {
       class htlc_redeem_visitor
       {
       //private:
-         const std::vector<uint8_t>& data;
+         const std::vector<char>& data;
       public:
          typedef bool result_type;
 
-         htlc_redeem_visitor( const std::vector<uint8_t>& preimage )
+         htlc_redeem_visitor( const std::vector<char>& preimage )
             : data( preimage ) {}
 
          template<typename T>

--- a/libraries/chain/include/graphene/chain/protocol/htlc.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/htlc.hpp
@@ -98,7 +98,7 @@ namespace graphene {
          // who is attempting to update the transaction
          account_id_type redeemer;
          // the preimage (not used if after epoch timeout)
-         std::vector<uint8_t> preimage;
+         std::vector<char> preimage;
          // for future expansion
          extensions_type extensions; 
 

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -1812,7 +1812,7 @@ public:
             (preimage_hash)(preimage_size)(claim_period_seconds)(broadcast) ) 
    }
 
-   signed_transaction htlc_redeem( string htlc_id, string issuer, const std::vector<uint8_t>& preimage, bool broadcast )
+   signed_transaction htlc_redeem( string htlc_id, string issuer, const std::vector<char>& preimage, bool broadcast )
    {
       try 
       {
@@ -3201,7 +3201,7 @@ signed_transaction wallet_api::htlc_redeem( std::string htlc_id, std::string iss
       bool broadcast)
 {
 
-   return my->htlc_redeem(htlc_id, issuer, std::vector<uint8_t>(preimage.begin(), preimage.end()), broadcast);
+   return my->htlc_redeem(htlc_id, issuer, std::vector<char>(preimage.begin(), preimage.end()), broadcast);
 }
 
 signed_transaction wallet_api::htlc_extend ( std::string htlc_id, std::string issuer, const uint32_t seconds_to_add,

--- a/tests/tests/htlc_tests.cpp
+++ b/tests/tests/htlc_tests.cpp
@@ -56,9 +56,9 @@ using namespace graphene::chain::test;
 
 BOOST_FIXTURE_TEST_SUITE( htlc_tests, database_fixture )
 
-void generate_random_preimage(uint16_t key_size, std::vector<uint8_t>& vec)
+void generate_random_preimage(uint16_t key_size, std::vector<char>& vec)
 {
-	std::independent_bits_engine<std::default_random_engine, CHAR_BIT, uint8_t> rbe;
+	std::independent_bits_engine<std::default_random_engine, CHAR_BIT, unsigned char> rbe;
 	std::generate(begin(vec), end(vec), std::ref(rbe));
 	return;
 }
@@ -69,7 +69,7 @@ void generate_random_preimage(uint16_t key_size, std::vector<uint8_t>& vec)
  * @returns a vector that cointains the sha256 hash of the preimage
  */
 template<typename H>
-H hash_it(std::vector<uint8_t> preimage)
+H hash_it(std::vector<char> preimage)
 {
    return H::hash( (char*)preimage.data(), preimage.size() );
 }
@@ -177,7 +177,7 @@ try {
    advance_past_hardfork(this);
 
    uint16_t preimage_size = 256;
-   std::vector<unsigned char> pre_image(256);
+   std::vector<char> pre_image(256);
    generate_random_preimage(preimage_size, pre_image);
 
    graphene::chain::htlc_id_type alice_htlc_id;
@@ -234,7 +234,7 @@ try {
    advance_past_hardfork(this);
    
    uint16_t preimage_size = 256;
-   std::vector<unsigned char> pre_image(preimage_size);
+   std::vector<char> pre_image(preimage_size);
    generate_random_preimage(preimage_size, pre_image);
 
    graphene::chain::htlc_id_type alice_htlc_id;
@@ -314,7 +314,7 @@ try {
    transfer( committee_account, alice_id, graphene::chain::asset(init_balance) );
 
    uint16_t preimage_size = 256;
-   std::vector<unsigned char> pre_image(256);
+   std::vector<char> pre_image(256);
    generate_random_preimage(preimage_size, pre_image);
 
    graphene::chain::htlc_id_type alice_htlc_id;
@@ -502,7 +502,7 @@ BOOST_AUTO_TEST_CASE( htlc_before_hardfork )
    transfer( committee_account, alice_id, graphene::chain::asset(init_balance) );
 
    uint16_t preimage_size = 256;
-   std::vector<unsigned char> pre_image(256);
+   std::vector<char> pre_image(256);
    generate_random_preimage(preimage_size, pre_image);
 
    graphene::chain::htlc_id_type alice_htlc_id;
@@ -607,15 +607,15 @@ BOOST_AUTO_TEST_CASE( fee_calculations )
       redeem_fee.fee = 2;
       htlc_redeem_operation redeem;
       // no preimage
-      redeem.preimage = std::vector<uint8_t>();
+      redeem.preimage = std::vector<char>();
       BOOST_CHECK_EQUAL( redeem.calculate_fee( redeem_fee ).value, 2 ) ;
       // exactly 1KB
       std::string test(1024, 'a');
-      redeem.preimage = std::vector<uint8_t>( test.begin(), test.end() );
+      redeem.preimage = std::vector<char>( test.begin(), test.end() );
       BOOST_CHECK_EQUAL( redeem.calculate_fee( redeem_fee ).value, 4 ) ;
       // just 1 byte over 1KB
       std::string larger(1025, 'a');
-      redeem.preimage = std::vector<uint8_t>( larger.begin(), larger.end() );
+      redeem.preimage = std::vector<char>( larger.begin(), larger.end() );
       BOOST_CHECK_EQUAL( redeem.calculate_fee( redeem_fee ).value, 6 ) ;
    }
    // extend


### PR DESCRIPTION
The HTLC redeem operation took a vector of uint8_t. This worked fine, but made de-serialization output list integers instead of (more obvious and easier to read) hex values. Switching to char instead of uint8_t resolves the issue.