### PR TITLE
add es-objects-start-es-after-block option

### DIFF
--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -59,7 +59,7 @@ class elasticsearch_plugin_impl
       std::string _elasticsearch_basic_auth = "";
       std::string _elasticsearch_index_prefix = "bitshares-";
       bool _elasticsearch_operation_object = false;
-      uint32_t _elasticsearch_start_es_after_block = 0; // disabled
+      uint32_t _elasticsearch_start_es_after_block = 0;
       CURL *curl; // curl handler
       vector <string> bulk_lines; //  vector of op lines
       vector<std::string> prepare;
@@ -283,7 +283,7 @@ bool elasticsearch_plugin_impl::add_elasticsearch( const account_id_type account
    const auto &stats_obj = getStatsObject(account_id);
    const auto &ath = addNewEntry(stats_obj, account_id, oho);
    growStats(stats_obj, ath);
-   if(_elasticsearch_start_es_after_block == 0 || block_number > _elasticsearch_start_es_after_block)  {
+   if(block_number > _elasticsearch_start_es_after_block)  {
       createBulkLine(ath);
       prepareBulk(ath.id);
    }

--- a/libraries/plugins/es_objects/es_objects.cpp
+++ b/libraries/plugins/es_objects/es_objects.cpp
@@ -63,7 +63,7 @@ class es_objects_plugin_impl
       bool _es_objects_limit_orders = true;
       bool _es_objects_asset_bitasset = true;
       std::string _es_objects_index_prefix = "objects-";
-      uint32_t _es_objects_start_es_after_block = 0; // disabled
+      uint32_t _es_objects_start_es_after_block = 0;
       CURL *curl; // curl handler
       vector <std::string> bulk;
       vector<std::string> prepare;
@@ -85,7 +85,7 @@ bool es_objects_plugin_impl::index_database( const vector<object_id_type>& ids, 
    block_time = db.head_block_time();
    block_number = db.head_block_num();
 
-   if(_es_objects_start_es_after_block == 0 || block_number > _es_objects_start_es_after_block) {
+   if(block_number > _es_objects_start_es_after_block) {
 
       // check if we are in replay or in sync and change number of bulk documents accordingly
       uint32_t limit_documents = 0;


### PR DESCRIPTION
Adds `es-objects-start-es-after-block` to **es-objects** plugin which is similar to `elasticsearch-start-es-after-block` for **elasticsearch**.

Nodes can have crashes or other issues, this option is a time saver as it allow to skip blocks until we want, speeding up for example a reindex process.