### PR TITLE
Rename API param operation_id to operation_type

### DIFF
--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -345,7 +345,7 @@ namespace graphene { namespace app {
     }
 
     vector<operation_history_object> history_api::get_account_history_operations( const std::string account_id_or_name,
-                                                                       int operation_id,
+                                                                       int operation_type,
                                                                        operation_history_id_type start,
                                                                        operation_history_id_type stop,
                                                                        unsigned limit) const
@@ -368,7 +368,7 @@ namespace graphene { namespace app {
        {
           if( node->operation_id.instance.value <= start.instance.value ) {
 
-             if(node->operation_id(db).op.which() == operation_id)
+             if(node->operation_id(db).op.which() == operation_type)
                result.push_back( node->operation_id(db) );
           }
           if( node->next == account_transaction_history_id_type() )
@@ -377,7 +377,7 @@ namespace graphene { namespace app {
        }
        if( stop.instance.value == 0 && result.size() < limit ) {
           auto head = db.find(account_transaction_history_id_type());
-          if (head != nullptr && head->account == account && head->operation_id(db).op.which() == operation_id)
+          if (head != nullptr && head->account == account && head->operation_id(db).op.which() == operation_type)
             result.push_back(head->operation_id(db));
        }
        return result;

--- a/libraries/app/include/graphene/app/api.hpp
+++ b/libraries/app/include/graphene/app/api.hpp
@@ -153,7 +153,7 @@ namespace graphene { namespace app {
          /**
           * @brief Get only asked operations relevant to the specified account
           * @param account_id_or_name The account ID or name whose history should be queried
-          * @param operation_id The ID of the operation we want to get operations in the account
+          * @param operation_type The type of the operation we want to get operations in the account
           * ( 0 = transfer , 1 = limit order create, ...)
           * @param stop ID of the earliest operation to retrieve
           * @param limit Maximum number of operations to retrieve (must not exceed 100)
@@ -162,7 +162,7 @@ namespace graphene { namespace app {
           */
          vector<operation_history_object> get_account_history_operations(
             const std::string account_id_or_name,
-            int operation_id,
+            int operation_type,
             operation_history_id_type start = operation_history_id_type(),
             operation_history_id_type stop = operation_history_id_type(),
             unsigned limit = 100


### PR DESCRIPTION
in order to reduce confusion, because we usually use "operation_type"
to indicate the type of an operation, but use "operation_id" for
operation_history_id_type.