### PR TITLE
Do not allow supply to exceed MAX_SUPPLY

### DIFF
--- a/libraries/chain/hardfork.d/CORE_1465.hf
+++ b/libraries/chain/hardfork.d/CORE_1465.hf
@@ -1,4 +1,5 @@
 // bitshares-core issue #1465 check max_supply before processing call_order_update
 #ifndef HARDFORK_CORE_1465_TIME
 #define HARDFORK_CORE_1465_TIME (fc::time_point_sec( 1600000000 )) // 2020-09-13 12:26:40
+#define SOFTFORK_CORE_1465_TIME (fc::time_point_sec( 1545350400 )) // 2018-12-21 00:00:00
 #endif

--- a/libraries/chain/market_evaluator.cpp
+++ b/libraries/chain/market_evaluator.cpp
@@ -181,7 +181,7 @@ void_result call_order_update_evaluator::do_evaluate(const call_order_update_ope
    if (next_maintenance_time <= SOFTFORK_CORE_1465_TIME)
    {
       if ( _dynamic_data_obj->current_supply + o.delta_debt.amount <= _debt_asset->options.max_supply )
-         ilog("Issue 1465... Borrowing and exceeding MAX_SUPPLY. Will be corrected at hardfork time.")
+         ilog("Issue 1465... Borrowing and exceeding MAX_SUPPLY. Will be corrected at hardfork time.");
    }
    else
    {

--- a/libraries/chain/market_evaluator.cpp
+++ b/libraries/chain/market_evaluator.cpp
@@ -170,10 +170,25 @@ void_result call_order_update_evaluator::do_evaluate(const call_order_update_ope
               ("sym", _debt_asset->symbol) );
 
    _dynamic_data_obj = &_debt_asset->dynamic_asset_data_id(d);
-   FC_ASSERT( next_maintenance_time <= HARDFORK_CORE_1465_TIME 
-         || _dynamic_data_obj->current_supply + o.delta_debt.amount <= _debt_asset->options.max_supply,
-      "Borrowing this quantity would exceed MAX_SUPPLY" );
 
+   /***
+    * We have softfork code already in production to prevent exceeding MAX_SUPPLY between 2018-12-21 until HF 1465.
+    * But we must allow this in replays until 2018-12-21. The HF 1465 code will correct the problem.
+    * After HF 1465, we MAY be able to remove the cleanup code IF it never executes. We MAY be able to clean
+    * up the softfork code IF it never executes. We MAY be able to turn the hardfork code into regular code IF
+    * noone ever attempted this before HF 1465.
+    */
+   if (next_maintenance_time <= SOFTFORK_CORE_1465_TIME)
+   {
+      if ( _dynamic_data_obj->current_supply + o.delta_debt.amount <= _debt_asset->options.max_supply )
+         ilog("Issue 1465... Borrowing and exceeding MAX_SUPPLY. Will be corrected at hardfork time.")
+   }
+   else
+   {
+      FC_ASSERT( _dynamic_data_obj->current_supply + o.delta_debt.amount <= _debt_asset->options.max_supply,
+            "Borrowing this quantity would exceed MAX_SUPPLY" );
+   }
+   
    FC_ASSERT( _dynamic_data_obj->current_supply + o.delta_debt.amount >= 0,
          "This transaction would bring current supply below zero.");
 

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -51,10 +51,11 @@ struct proposal_operation_hardfork_visitor
    void operator()(const graphene::chain::call_order_update_operation &v) const {
 
       // TODO If this never ASSERTs before HF 1465, it can be removed
-      FC_ASSERT( block_time > SOFTFORK_CORE_1465_TIME && block_time < HARDFORK_CORE_1465_TIME
-            && v.delta_debt.amount > 0 && v.delta_debt.asset_id != asset_id_type(113) // CNY
-            && v.delta_debt.asset_id( db ).bitasset_data_id
-            && !(*( v.delta_debt.asset_id( db ).bitasset_data_id))( db ).is_prediction_market
+      FC_ASSERT( block_time > HARDFORK_CORE_1465_TIME
+            || v.delta_debt.asset_id == asset_id_type(113) // CNY
+            || v.delta_debt.amount < 0 
+            || (v.delta_debt.asset_id( db ).bitasset_data_id
+            && (*(v.delta_debt.asset_id( db ).bitasset_data_id))( db ).is_prediction_market )
             , "Soft fork - preventing proposal with call_order_update!" );
    
       // TODO review and cleanup code below after hard fork

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -38,18 +38,27 @@ namespace detail {
 struct proposal_operation_hardfork_visitor
 {
    typedef void result_type;
+   const database& db;
    const fc::time_point_sec block_time;
    const fc::time_point_sec next_maintenance_time;
 
-   proposal_operation_hardfork_visitor( const fc::time_point_sec bt, const fc::time_point_sec nmt )
-   : block_time(bt), next_maintenance_time(nmt) {}
+   proposal_operation_hardfork_visitor( const database& _db, const fc::time_point_sec bt )
+   : db( _db ), block_time(bt), next_maintenance_time( db.get_dynamic_global_properties().next_maintenance_time ) {}
 
    template<typename T>
    void operator()(const T &v) const {}
 
-   // TODO review and cleanup code below after hard fork
-   // hf_834
    void operator()(const graphene::chain::call_order_update_operation &v) const {
+
+      // TODO If this never ASSERTs before HF 1465, it can be removed
+      FC_ASSERT( block_time > SOFTFORK_CORE_1465_TIME && block_time < HARDFORK_CORE_1465_TIME
+            && v.delta_debt.amount > 0 && v.delta_debt.asset_id != asset_id_type(113) // CNY
+            && v.delta_debt.asset_id( db ).bitasset_data_id
+            && !(*( v.delta_debt.asset_id( db ).bitasset_data_id))( db ).is_prediction_market
+            , "Soft fork - preventing proposal with call_order_update!" );
+   
+      // TODO review and cleanup code below after hard fork
+      // hf_834
       if (next_maintenance_time <= HARDFORK_CORE_834_TIME) {
          FC_ASSERT( !v.extensions.value.target_collateral_ratio.valid(),
                     "Can not set target_collateral_ratio in call_order_update_operation before hardfork 834." );
@@ -171,8 +180,7 @@ void_result proposal_create_evaluator::do_evaluate(const proposal_create_operati
 
    // Calling the proposal hardfork visitor
    const fc::time_point_sec block_time = d.head_block_time();
-   const fc::time_point_sec next_maint_time = d.get_dynamic_global_properties().next_maintenance_time;
-   proposal_operation_hardfork_visitor vtor( block_time, next_maint_time );
+   proposal_operation_hardfork_visitor vtor( d, block_time );
    vtor( o );
    if( block_time < HARDFORK_CORE_214_TIME )
    { // cannot be removed after hf, unfortunately

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -51,7 +51,8 @@ struct proposal_operation_hardfork_visitor
    void operator()(const graphene::chain::call_order_update_operation &v) const {
 
       // TODO If this never ASSERTs before HF 1465, it can be removed
-      FC_ASSERT( block_time > HARDFORK_CORE_1465_TIME
+      FC_ASSERT( block_time < SOFTFORK_CORE_1465_TIME 
+            || block_time > HARDFORK_CORE_1465_TIME
             || v.delta_debt.asset_id == asset_id_type(113) // CNY
             || v.delta_debt.amount < 0 
             || (v.delta_debt.asset_id( db ).bitasset_data_id

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -664,7 +664,7 @@ BOOST_AUTO_TEST_CASE( call_order_update_target_cr_hardfork_time_test )
       GRAPHENE_REQUIRE_THROW( call_update_proposal( bob, alice, bitusd.amount(10), core.amount(40), 1750 ), fc::assert_exception );
       GRAPHENE_REQUIRE_THROW( call_update_proposal( bob, alice, bitusd.amount(10), core.amount(40), 65535 ), fc::assert_exception );
 
-      generate_blocks( db.get_dynamic_global_properties().next_maintenance_time );
+      generate_blocks( HARDFORK_CORE_1465_TIME + 10 );
       set_expiration( db, trx );
 
       BOOST_TEST_MESSAGE( "bob tries to propose a proposal with target_cr set, "

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -664,7 +664,7 @@ BOOST_AUTO_TEST_CASE( call_order_update_target_cr_hardfork_time_test )
       GRAPHENE_REQUIRE_THROW( call_update_proposal( bob, alice, bitusd.amount(10), core.amount(40), 1750 ), fc::assert_exception );
       GRAPHENE_REQUIRE_THROW( call_update_proposal( bob, alice, bitusd.amount(10), core.amount(40), 65535 ), fc::assert_exception );
 
-      generate_blocks( HARDFORK_CORE_1465_TIME + 10 );
+      generate_blocks( db.get_dynamic_global_properties().next_maintenance_time );
       set_expiration( db, trx );
 
       BOOST_TEST_MESSAGE( "bob tries to propose a proposal with target_cr set, "


### PR DESCRIPTION
Merges together patchd12 with hardfork Issue #1465.

Hardfork PR: #1498.

Essentially:
- Before softfork, let it happen (allow for replay)
- After softfork, stop it from happening
- At hardfork, clean up the mess (if there is one)
- After hardfork, softfork and hardfork code is the same.