### PR TITLE
update full node specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ In order to run a full node with all the account history you need to remove `par
 | --- | --- | --- | ---
 | 100G HDD, 16G RAM | 640G SSD, 64G RAM * | 80G HDD, 4G RAM | 500G SSD, 32G RAM
 
-\* For this setup to work allocate all SSD space left(excluding OS and software) as Swap.
+\* For this setup, allocate at least 500GB of SSD as swap.
 
 After starting the witness node again, in a separate terminal you can run:
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ In order to run a full node with all the account history you need to remove `par
 
 | Default | Full | Minimal  | ElasticSearch 
 | --- | --- | --- | ---
-| 100G HDD, 16G RAM | 640 SSD, 64G RAM | 80G HDD, 4G RAM | 500G SSD, 32G RAM
+| 100G HDD, 16G RAM | 640G SSD, 64G RAM * | 80G HDD, 4G RAM | 500G SSD, 32G RAM
+
+\* For this setup to work allocate all SSD space left(excluding OS and software) as Swap.
 
 After starting the witness node again, in a separate terminal you can run:
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ In order to run a full node with all the account history you need to remove `par
 
 | Default | Full | Minimal  | ElasticSearch 
 | --- | --- | --- | ---
-| 100G HDD, 16G RAM | 200G HDD, 160G RAM | 80G HDD, 4G RAM | 500G SSD, 32G RAM
+| 100G HDD, 16G RAM | 640 SSD, 64G RAM | 80G HDD, 4G RAM | 500G SSD, 32G RAM
 
 After starting the witness node again, in a separate terminal you can run:
 


### PR DESCRIPTION
There was a discussion on what specs are needed to run a full node in the telegram.

The most realistic and affordable at the moment seems to be:

> 64GB ram and 640GB higher iops ssd are requirements for full API node as server
Node will use 102GB on disk for db, 30-40G for OS/software and will load 498GB to ram/swap

Thanks to @dls-cipher 