### PR TITLE
support for Boost 1.69

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ We recommend building on Ubuntu 16.04 LTS (64-bit)
     git submodule sync --recursive
     git submodule update --init --recursive
 
-**NOTE:** BitShares requires a [Boost](http://www.boost.org/) version in the range [1.57 - 1.65.1]. Versions earlier than
-1.57 or newer than 1.65.1 are NOT supported. If your system's Boost version is newer, then you will need to manually build
+**NOTE:** BitShares requires a [Boost](http://www.boost.org/) version in the range [1.57 - 1.69]. Versions earlier than
+1.57 or newer than 1.69 are NOT supported. If your system's Boost version is newer, then you will need to manually build
 an older version of Boost and specify it to CMake using `DBOOST_ROOT`.
 
 **NOTE:** BitShares requires a 64-bit operating system to build, and will not build on a 32-bit OS.

--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ We recommend building on Ubuntu 16.04 LTS (64-bit)
     git submodule sync --recursive
     git submodule update --init --recursive
 
-**NOTE:** BitShares requires a [Boost](http://www.boost.org/) version in the range [1.57 - 1.69]. Versions earlier than
-1.57 or newer than 1.69 are NOT supported. If your system's Boost version is newer, then you will need to manually build
-an older version of Boost and specify it to CMake using `DBOOST_ROOT`.
+**NOTE:** Versions of [Boost](http://www.boost.org/) 1.57 through 1.69 are supported. Newer versions may work, but
+have not been tested. If your system came pre-installed with a version of Boost that you do not wish to use, you may
+manually build your preferred version and use it with BitShares by specifying it on the CMake command line (e.g.
+``cmake -DBOOST_ROOT=/path/to/boost .``.
 
 **NOTE:** BitShares requires a 64-bit operating system to build, and will not build on a 32-bit OS.
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ We recommend building on Ubuntu 16.04 LTS (64-bit)
 
 **NOTE:** Versions of [Boost](http://www.boost.org/) 1.57 through 1.69 are supported. Newer versions may work, but
 have not been tested. If your system came pre-installed with a version of Boost that you do not wish to use, you may
-manually build your preferred version and use it with BitShares by specifying it on the CMake command line (e.g.
-``cmake -DBOOST_ROOT=/path/to/boost .``.
+manually build your preferred version and use it with BitShares by specifying it on the CMake command line.
+
+Example: ``cmake -DBOOST_ROOT=/path/to/boost .``
 
 **NOTE:** BitShares requires a 64-bit operating system to build, and will not build on a 32-bit OS.
 


### PR DESCRIPTION
Fixes documentation for #1557 

This adjusts the documentation to show that Bitshares is now supported with compiled with Boost versions in the range of 1.57 - 1.69.

The wiki should be updated when this rolls into production. Pages that need adjusted:
https://github.com/bitshares/bitshares-core/wiki
https://github.com/bitshares/bitshares-core/wiki/BUILD_UBUNTU
https://github.com/bitshares/bitshares-core/wiki/BUILD_WIN32
https://github.com/bitshares/bitshares-core/wiki/Building-on-OS-X