### PR TITLE
Fix compiler warnings

### DIFF
--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -917,7 +917,7 @@ const call_order_object* database_fixture::borrow( const account_object& who, as
 { try {
    set_expiration( db, trx );
    trx.operations.clear();
-   call_order_update_operation update;
+   call_order_update_operation update = {};
    update.funding_account = who.id;
    update.delta_collateral = collateral;
    update.delta_debt = what;
@@ -942,7 +942,7 @@ void database_fixture::cover(const account_object& who, asset what, asset collat
 { try {
    set_expiration( db, trx );
    trx.operations.clear();
-   call_order_update_operation update;
+   call_order_update_operation update = {};
    update.funding_account = who.id;
    update.delta_collateral = -collateral;
    update.delta_debt = -what;


### PR DESCRIPTION
This PR will fix these warnings:
```
/tests/common/database_fixture.cpp: In member function ‘const graphene::chain::call_order_object* graphene::chain::database_fixture::borrow(const graphene::chain::account_object&, graphene::chain::asset, graphene::chain::asset, fc::optional<short unsigned int>)’:
/tests/common/database_fixture.cpp:938:32: warning: ‘*((void*)& update +56)’ may be used uninitialized in this function [-Wmaybe-uninitialized]
    call_order_update_operation update;
                                ^
/tests/common/database_fixture.cpp: In member function ‘void graphene::chain::database_fixture::cover(const graphene::chain::account_object&, graphene::chain::asset, graphene::chain::asset, fc::optional<short unsigned int>)’:
/tests/common/database_fixture.cpp:963:32: warning: ‘*((void*)& update +56)’ may be used uninitialized in this function [-Wmaybe-uninitialized]
    call_order_update_operation update;
                                ^
```