### PR TITLE
Fix tests for Windows builds

### DIFF
--- a/tests/app/main.cpp
+++ b/tests/app/main.cpp
@@ -21,6 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#ifdef _WINDOWS
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include <graphene/app/application.hpp>
 #include <graphene/app/plugin.hpp>
 #include <graphene/app/config_util.hpp>

--- a/tests/tests/htlc_tests.cpp
+++ b/tests/tests/htlc_tests.cpp
@@ -56,9 +56,9 @@ using namespace graphene::chain::test;
 
 BOOST_FIXTURE_TEST_SUITE( htlc_tests, database_fixture )
 
-void generate_random_preimage(uint16_t key_size, std::vector<char>& vec)
+void generate_random_preimage(std::vector<char>& vec)
 {
-	std::independent_bits_engine<std::default_random_engine, CHAR_BIT, unsigned char> rbe;
+	std::independent_bits_engine<std::default_random_engine, sizeof(unsigned), unsigned> rbe;
 	std::generate(begin(vec), end(vec), std::ref(rbe));
 	return;
 }
@@ -178,7 +178,7 @@ try {
 
    uint16_t preimage_size = 256;
    std::vector<char> pre_image(256);
-   generate_random_preimage(preimage_size, pre_image);
+   generate_random_preimage(pre_image);
 
    graphene::chain::htlc_id_type alice_htlc_id;
    // cler everything out
@@ -235,7 +235,7 @@ try {
    
    uint16_t preimage_size = 256;
    std::vector<char> pre_image(preimage_size);
-   generate_random_preimage(preimage_size, pre_image);
+   generate_random_preimage(pre_image);
 
    graphene::chain::htlc_id_type alice_htlc_id;
    // clear everything out
@@ -315,7 +315,7 @@ try {
 
    uint16_t preimage_size = 256;
    std::vector<char> pre_image(256);
-   generate_random_preimage(preimage_size, pre_image);
+   generate_random_preimage(pre_image);
 
    graphene::chain::htlc_id_type alice_htlc_id;
    // cler everything out
@@ -503,7 +503,7 @@ BOOST_AUTO_TEST_CASE( htlc_before_hardfork )
 
    uint16_t preimage_size = 256;
    std::vector<char> pre_image(256);
-   generate_random_preimage(preimage_size, pre_image);
+   generate_random_preimage(pre_image);
 
    graphene::chain::htlc_id_type alice_htlc_id;
    // clear everything out


### PR DESCRIPTION
Partial fix for #1593 

Tests in Windows will not build due to 3 errors:

1)  is in the fc submodule, and is not part of this PR
2) WinSock.h ends up being included twice due to Boost. Adding a compiler directive ``WIN32_LEAN_AND_MEAN`` corrects the problem, and seems to be the online consensus for fixing when this occurs.
3) Windows is picky on their template arguments for the ``std::independent_bits_engine``, and blame can be put on the c++11 spec. The work-around to the specification problem is to use unsigned integer instead of unsigned char.

