### PR TITLE
Feature/account statistics object voting weight

### DIFF
--- a/libraries/chain/db_maint.cpp
+++ b/libraries/chain/db_maint.cpp
@@ -1113,7 +1113,7 @@ void database::perform_chain_maintenance(const signed_block& next_block, const g
             // set the voting weight of the given account
             d.modify( stats, [voting_stake, has_proxy](account_statistics_object& aso) {
                aso.voting_statistics.has_proxy = has_proxy;
-               aso.voting_statistics.self_voting_power = voting_stake;
+               aso.voting_statistics.self_voting_stake = voting_stake;
             });
             
             if( has_proxy )

--- a/libraries/chain/include/graphene/chain/account_object.hpp
+++ b/libraries/chain/include/graphene/chain/account_object.hpp
@@ -103,14 +103,19 @@ namespace graphene { namespace chain {
           */
          struct voting_stat
          {
+            /// whether this account has a proxy account set or not
             bool has_proxy;
-            uint64_t self_voting_power;
+            /// the voting stake of this account
+            uint64_t self_voting_stake;
+            /// map of accounts which have this account set as proxy, together 
+            /// with the stake they are giving this account
             flat_map<account_id_type, uint64_t> proxy_for;
 
-            const uint64_t get_total_voting_power() const
+            /// returns the total stake with which this account is actually voting
+            const uint64_t get_total_voting_stake() const
             {
                if( !has_proxy ) {
-                  uint64_t total = self_voting_power;
+                  uint64_t total = self_voting_stake;
                   for( const auto& pair : proxy_for )
                      total += pair.second;
                   return total;
@@ -494,6 +499,6 @@ FC_REFLECT_DERIVED( graphene::chain::account_statistics_object,
 
 FC_REFLECT( graphene::chain::account_statistics_object::voting_stat,
             (has_proxy)
-            (self_voting_power)
+            (self_voting_stake)
             (proxy_for)
           )

--- a/libraries/chain/include/graphene/chain/account_object.hpp
+++ b/libraries/chain/include/graphene/chain/account_object.hpp
@@ -98,6 +98,29 @@ namespace graphene { namespace chain {
           */
          share_type pending_vested_fees;
 
+         /**
+          * Specifies the total voting weight of this account (set in maintenance interval)
+          */
+         struct voting_stat
+         {
+            bool has_proxy;
+            uint64_t self_voting_power;
+            flat_map<account_id_type, uint64_t> proxy_for;
+
+            const uint64_t get_total_voting_power() const
+            {
+               if( !has_proxy ) {
+                  uint64_t total = self_voting_power;
+                  for( const auto& pair : proxy_for )
+                     total += pair.second;
+                  return total;
+               }
+               return 0;
+            }
+         };
+         
+         voting_stat voting_statistics;
+
          /// Whether this account has pending fees, no matter vested or not
          inline bool has_pending_fees() const { return pending_fees > 0 || pending_vested_fees > 0; }
 
@@ -466,5 +489,11 @@ FC_REFLECT_DERIVED( graphene::chain::account_statistics_object,
                     (last_vote_time)
                     (lifetime_fees_paid)
                     (pending_fees)(pending_vested_fees)
+                    (voting_statistics)
                   )
 
+FC_REFLECT( graphene::chain::account_statistics_object::voting_stat,
+            (has_proxy)
+            (self_voting_power)
+            (proxy_for)
+          )

--- a/tests/tests/database_tests.cpp
+++ b/tests/tests/database_tests.cpp
@@ -236,15 +236,15 @@ BOOST_AUTO_TEST_CASE( voting_weight_maintenance_test )
    generate_blocks( next_maintenance );
    generate_block();
    
-   edump((alice_stat_id(db).voting_statistics.self_voting_power)(alice_stat_id(db).voting_statistics.get_total_voting_power())
+   edump((alice_stat_id(db).voting_statistics.self_voting_stake)(alice_stat_id(db).voting_statistics.get_total_voting_stake())
       (alice_stat_id(db).voting_statistics.has_proxy));
 
-   BOOST_CHECK( alice_stat_id(db).voting_statistics.self_voting_power == 10000 
-      && alice_stat_id(db).voting_statistics.get_total_voting_power() == 10000
+   BOOST_CHECK( alice_stat_id(db).voting_statistics.self_voting_stake == 10000 
+      && alice_stat_id(db).voting_statistics.get_total_voting_stake() == 10000
       && alice_stat_id(db).voting_statistics.has_proxy == false
    );
-   BOOST_CHECK( bob_stat_id(db).voting_statistics.self_voting_power == 5000
-      && bob_stat_id(db).voting_statistics.get_total_voting_power() == 5000
+   BOOST_CHECK( bob_stat_id(db).voting_statistics.self_voting_stake == 5000
+      && bob_stat_id(db).voting_statistics.get_total_voting_stake() == 5000
       && bob_stat_id(db).voting_statistics.has_proxy == false 
    );
 
@@ -256,12 +256,12 @@ BOOST_AUTO_TEST_CASE( voting_weight_maintenance_test )
    generate_blocks( next_maintenance );
    generate_block();
 
-   BOOST_CHECK( alice_stat_id(db).voting_statistics.self_voting_power == 20000
-      && alice_stat_id(db).voting_statistics.get_total_voting_power() == 20000
+   BOOST_CHECK( alice_stat_id(db).voting_statistics.self_voting_stake == 20000
+      && alice_stat_id(db).voting_statistics.get_total_voting_stake() == 20000
       && alice_stat_id(db).voting_statistics.has_proxy == false
    );
-   BOOST_CHECK( bob_stat_id(db).voting_statistics.self_voting_power == 5000
-      && bob_stat_id(db).voting_statistics.get_total_voting_power() == 5000
+   BOOST_CHECK( bob_stat_id(db).voting_statistics.self_voting_stake == 5000
+      && bob_stat_id(db).voting_statistics.get_total_voting_stake() == 5000
       && bob_stat_id(db).voting_statistics.has_proxy == false
    );
 
@@ -283,12 +283,12 @@ BOOST_AUTO_TEST_CASE( voting_weight_maintenance_test )
    generate_blocks( next_maintenance );
    generate_block();
 
-   BOOST_CHECK( alice_stat_id(db).voting_statistics.self_voting_power == 20000
-      && alice_stat_id(db).voting_statistics.get_total_voting_power() == 0
+   BOOST_CHECK( alice_stat_id(db).voting_statistics.self_voting_stake == 20000
+      && alice_stat_id(db).voting_statistics.get_total_voting_stake() == 0
       && alice_stat_id(db).voting_statistics.has_proxy == true
    );
-   BOOST_CHECK( bob_stat_id(db).voting_statistics.self_voting_power == 5000
-      && bob_stat_id(db).voting_statistics.get_total_voting_power() == 25000
+   BOOST_CHECK( bob_stat_id(db).voting_statistics.self_voting_stake == 5000
+      && bob_stat_id(db).voting_statistics.get_total_voting_stake() == 25000
       && bob_stat_id(db).voting_statistics.has_proxy == false
    );
 }


### PR DESCRIPTION
This is initial work to add voting statistics to the account statistics object. It stores the following additional data in the object:

```
            /// whether this account has a proxy account set or not
            bool has_proxy;
            /// the voting stake of this account
            uint64_t self_voting_stake;
            /// map of accounts which have this account set as proxy, together 
            /// with the stake they are giving this account
            flat_map<account_id_type, uint64_t> proxy_for;
```

Given RAM requirements, I would like to discuss if `proxy_for` (which potentially stores a long map) is feasible.


Original development by Blockchain Projects BV with initial pull request located here:
https://github.com/blockchainprojects/bitshares-core/pull/2