### PR TITLE
[HARDFORK] Feature/asset disable limit order create flag

### DIFF
--- a/libraries/chain/include/graphene/chain/asset_object.hpp
+++ b/libraries/chain/include/graphene/chain/asset_object.hpp
@@ -96,6 +96,8 @@ namespace graphene { namespace chain {
          bool is_transfer_restricted()const { return options.flags & transfer_restricted; }
          bool can_override()const { return options.flags & override_authority; }
          bool allow_confidential()const { return !(options.flags & asset_issuer_permission_flags::disable_confidential); }
+         /// @return true if limit orders can only be created by the issuer
+         bool only_issuer_limit_orders_allowed()const {return options.flags & asset_issuer_permission_flags::only_issuer_limit_orders_allowed; }
 
          /// Helper function to get an asset object with the given amount in this asset's type
          asset amount(share_type a)const { return asset(a, id); }

--- a/libraries/chain/include/graphene/chain/is_authorized_asset.hpp
+++ b/libraries/chain/include/graphene/chain/is_authorized_asset.hpp
@@ -42,10 +42,6 @@ bool _is_authorized_asset(const database& d, const account_object& acct, const a
 
 inline bool is_authorized_asset(const database& d, const account_object& acct, const asset_object& asset_obj)
 {
-   // the issuer is allowed to create limit orders with his own asset
-   if( acct.get_id() == asset_obj.issuer )
-      return true;
-
    bool fast_check = !(asset_obj.options.flags & white_list);
    fast_check &= !(acct.allowed_assets.valid());
    fast_check &= !(asset_obj.options.flags & only_issuer_limit_orders_allowed);

--- a/libraries/chain/include/graphene/chain/is_authorized_asset.hpp
+++ b/libraries/chain/include/graphene/chain/is_authorized_asset.hpp
@@ -44,7 +44,6 @@ inline bool is_authorized_asset(const database& d, const account_object& acct, c
 {
    bool fast_check = !(asset_obj.options.flags & white_list);
    fast_check &= !(acct.allowed_assets.valid());
-   fast_check &= !(asset_obj.options.flags & only_issuer_limit_orders_allowed);
 
    if( fast_check )
       return true;

--- a/libraries/chain/include/graphene/chain/is_authorized_asset.hpp
+++ b/libraries/chain/include/graphene/chain/is_authorized_asset.hpp
@@ -42,8 +42,13 @@ bool _is_authorized_asset(const database& d, const account_object& acct, const a
 
 inline bool is_authorized_asset(const database& d, const account_object& acct, const asset_object& asset_obj)
 {
+   // the issuer is allowed to create limit orders with his own asset
+   if( acct.get_id() == asset_obj.issuer )
+      return true;
+
    bool fast_check = !(asset_obj.options.flags & white_list);
    fast_check &= !(acct.allowed_assets.valid());
+   fast_check &= !(asset_obj.options.flags & only_issuer_limit_orders_allowed);
 
    if( fast_check )
       return true;

--- a/libraries/chain/include/graphene/chain/protocol/types.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/types.hpp
@@ -98,11 +98,12 @@ namespace graphene { namespace chain {
       global_settle        = 0x20, /**< allow the bitasset issuer to force a global settling -- this may be set in permissions, but not flags */
       disable_confidential = 0x40, /**< allow the asset to be used with confidential transactions */
       witness_fed_asset    = 0x80, /**< allow the asset to be fed by witnesses */
-      committee_fed_asset  = 0x100 /**< allow the asset to be fed by the committee */
+      committee_fed_asset  = 0x100,/**< allow the asset to be fed by the committee */
+      only_issuer_limit_orders_allowed = 0x200/**< allow limit orders only to be created by the issuer */
    };
    const static uint32_t ASSET_ISSUER_PERMISSION_MASK = charge_market_fee|white_list|override_authority|transfer_restricted|disable_force_settle|global_settle|disable_confidential
-      |witness_fed_asset|committee_fed_asset;
-   const static uint32_t UIA_ASSET_ISSUER_PERMISSION_MASK = charge_market_fee|white_list|override_authority|transfer_restricted|disable_confidential;
+      |witness_fed_asset|committee_fed_asset|only_issuer_limit_orders_allowed;
+   const static uint32_t UIA_ASSET_ISSUER_PERMISSION_MASK = charge_market_fee|white_list|override_authority|transfer_restricted|disable_confidential|only_issuer_limit_orders_allowed;
 
    enum reserved_spaces
    {
@@ -417,4 +418,5 @@ FC_REFLECT_ENUM( graphene::chain::asset_issuer_permission_flags,
    (disable_confidential)
    (witness_fed_asset)
    (committee_fed_asset)
+   (only_issuer_limit_orders_allowed)
    )

--- a/libraries/chain/is_authorized_asset.cpp
+++ b/libraries/chain/is_authorized_asset.cpp
@@ -49,6 +49,9 @@ bool _is_authorized_asset(
       if( asset_obj.options.blacklist_authorities.find(id) != asset_obj.options.blacklist_authorities.end() )
          return false;
    }
+   
+   if( asset_obj.options.flags & only_issuer_limit_orders_allowed )
+      return false;
 
    if( d.head_block_time() > HARDFORK_415_TIME )
    {

--- a/libraries/chain/is_authorized_asset.cpp
+++ b/libraries/chain/is_authorized_asset.cpp
@@ -49,7 +49,6 @@ bool _is_authorized_asset(
       if( asset_obj.options.blacklist_authorities.find(id) != asset_obj.options.blacklist_authorities.end() )
          return false;
    }
-   
    if( d.head_block_time() > HARDFORK_415_TIME )
    {
       if( asset_obj.options.whitelist_authorities.size() == 0 )

--- a/libraries/chain/is_authorized_asset.cpp
+++ b/libraries/chain/is_authorized_asset.cpp
@@ -50,9 +50,6 @@ bool _is_authorized_asset(
          return false;
    }
    
-   if( asset_obj.options.flags & only_issuer_limit_orders_allowed )
-      return false;
-
    if( d.head_block_time() > HARDFORK_415_TIME )
    {
       if( asset_obj.options.whitelist_authorities.size() == 0 )

--- a/libraries/chain/market_evaluator.cpp
+++ b/libraries/chain/market_evaluator.cpp
@@ -55,6 +55,9 @@ void_result limit_order_create_evaluator::do_evaluate(const limit_order_create_o
       FC_ASSERT( _sell_asset->options.blacklist_markets.find(_receive_asset->id) 
             == _sell_asset->options.blacklist_markets.end(),
             "This market has been blacklisted." );
+   
+   if( _sell_asset->options.flags & only_issuer_limit_orders_allowed && _seller->get_id() != _sell_asset->issuer )
+      FC_ASSERT( false, "limit order forbidden by asset permission flag" );
 
    FC_ASSERT( is_authorized_asset( d, *_seller, *_sell_asset ) );
    FC_ASSERT( is_authorized_asset( d, *_seller, *_receive_asset ) );

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -2357,6 +2357,116 @@ BOOST_AUTO_TEST_CASE( vesting_balance_withdraw_test )
    // TODO:  Test with non-core asset and Bob account
 } FC_LOG_AND_RETHROW() }
 
+BOOST_AUTO_TEST_CASE( asset_only_issuer_limit_orders_allowed_test )
+{
+    ACTORS( (alice) (bob) );
+
+    signed_transaction trx;
+    asset_object       test_asset;
+    asset_id_type      test_asset_id;
+
+    generate_blocks( HARDFORK_572_TIME + fc::seconds(20) );
+    generate_block();
+
+    #define EDUMP(X) edump((X));
+
+    EDUMP( "creating a test asset with only_issuer_limit_orders_allowed" );
+    {
+        asset_options a_opt;
+        a_opt.max_supply         = 1000;
+        a_opt.core_exchange_rate = price( asset( 4, asset_id_type(1) ), asset( 4, asset_id_type() ) );
+        a_opt.flags              = only_issuer_limit_orders_allowed;
+
+        asset_create_operation acop;
+        acop.fee            = asset(0);
+        acop.issuer         = alice_id;
+        acop.symbol         = "TST";
+        acop.common_options = a_opt;
+
+        set_expiration( db, trx );
+        trx.operations.push_back( acop );
+        PUSH_TX( db, trx, ~0 );
+
+        test_asset    = *db.get_index_type<asset_index>().indices().get<by_symbol>().find("TST");
+        test_asset_id = test_asset.get_id();
+
+        BOOST_CHECK( test_asset.only_issuer_limit_orders_allowed() );
+    }
+
+    EDUMP( "creating a limit order with alice acc" );
+    {
+        // issue the asset
+        asset_issue_operation aiop;
+        aiop.fee              = asset(0);
+        aiop.issuer           = alice_id;
+        aiop.issue_to_account = alice_id;
+        aiop.asset_to_issue   = asset( test_asset.options.max_supply, test_asset_id );
+    
+        trx = signed_transaction();
+        set_expiration( db, trx );
+        trx.operations.push_back( aiop );
+        PUSH_TX( db, trx, ~0 );
+
+        // create limit order
+        limit_order_create_operation locop;
+        locop.fee            = asset(0);
+        locop.seller         = alice_id;
+        locop.amount_to_sell = asset( 100, test_asset_id ); 
+        locop.min_to_receive = asset( 100 );
+
+        trx = signed_transaction();
+        set_expiration( db, trx );
+        trx.operations.push_back( locop );
+        
+        try {
+            PUSH_TX( db, trx, ~0 );
+        }
+        catch( fc::assert_exception &e ) {
+            EDUMP( e.to_detail_string() );
+        }
+
+    }
+
+    EDUMP( "creating a limit order with bob acc" );
+    {
+        // transfer test_asset to bob
+        transfer_operation top;
+        top.fee    = asset(0);
+        top.amount = asset( 200, test_asset_id );
+        top.from   = alice_id;
+        top.to     = bob_id;
+
+        trx = signed_transaction();
+        set_expiration( db, trx );
+        trx.operations.push_back( top );
+        try{
+            PUSH_TX( db, trx, ~0 );
+        }
+        catch(fc::assert_exception &e) {
+            EDUMP( e.to_detail_string() );
+        }
+        // create limit order
+        limit_order_create_operation locop;
+        locop.fee            = asset(0);
+        locop.seller         = bob_id;
+        locop.amount_to_sell = asset( 100, test_asset_id ); 
+        locop.min_to_receive = asset(100);
+
+        trx = signed_transaction();
+        set_expiration( db, trx );
+        trx.operations.push_back( locop );
+        GRAPHENE_REQUIRE_THROW( PUSH_TX( db, trx, ~0 ), fc::assert_exception );
+
+        /*
+        try{
+            PUSH_TX( db, trx, ~0 );
+        }
+        catch(fc::assert_exception &e) {
+            EDUMP( e.to_detail_string() );
+        }
+        */
+    }
+}
 // TODO:  Write linear VBO tests
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -2418,13 +2418,7 @@ BOOST_AUTO_TEST_CASE( asset_only_issuer_limit_orders_allowed_test )
         set_expiration( db, trx );
         trx.operations.push_back( locop );
         
-        try {
-            PUSH_TX( db, trx, ~0 );
-        }
-        catch( fc::assert_exception &e ) {
-            EDUMP( e.to_detail_string() );
-        }
-
+        PUSH_TX( db, trx, ~0 );
     }
 
     EDUMP( "creating a limit order with bob acc" );
@@ -2439,32 +2433,21 @@ BOOST_AUTO_TEST_CASE( asset_only_issuer_limit_orders_allowed_test )
         trx = signed_transaction();
         set_expiration( db, trx );
         trx.operations.push_back( top );
-        try{
-            PUSH_TX( db, trx, ~0 );
-        }
-        catch(fc::assert_exception &e) {
-            EDUMP( e.to_detail_string() );
-        }
+        
+        PUSH_TX( db, trx, ~0 );
+ 
         // create limit order
         limit_order_create_operation locop;
         locop.fee            = asset(0);
         locop.seller         = bob_id;
         locop.amount_to_sell = asset( 100, test_asset_id ); 
-        locop.min_to_receive = asset(100);
+        locop.min_to_receive = asset( 100 );
 
         trx = signed_transaction();
         set_expiration( db, trx );
         trx.operations.push_back( locop );
-        GRAPHENE_REQUIRE_THROW( PUSH_TX( db, trx, ~0 ), fc::assert_exception );
 
-        /*
-        try{
-            PUSH_TX( db, trx, ~0 );
-        }
-        catch(fc::assert_exception &e) {
-            EDUMP( e.to_detail_string() );
-        }
-        */
+        GRAPHENE_REQUIRE_THROW( PUSH_TX( db, trx, ~0 ), fc::assert_exception );
     }
 }
 // TODO:  Write linear VBO tests


### PR DESCRIPTION
This pull request introduces code that allows to set a new flag for an asset. This flag `only_issuer_limit_orders_allowed 0x200` can be used to prevent other market participants from placing orders in the market. The feature is particularly useful in case of an ICO with multiple stages where only the issue should be able to sell tokens and prevent previous participants from making instant profits.

A corresponding BSIP will follow