### PR TITLE
[Hardfork] Added disable_modify_max_supply flag

### DIFF
--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -266,7 +266,6 @@ void_result asset_update_evaluator::do_evaluate(const asset_update_operation& o)
    database& d = db();
 
    const asset_object& a = o.asset_to_update(d);
-   auto old_options = a.options;
    auto a_copy = a;
    a_copy.options = o.new_options;
    a_copy.validate();
@@ -290,16 +289,10 @@ void_result asset_update_evaluator::do_evaluate(const asset_update_operation& o)
              "Flag change is forbidden by issuer permissions");
 
    // TODO HARDFORKCHECK
-   // change of the disable_modify_max_supply flag; should only be set from 0 to 1
-   FC_ASSERT( ( old_options.flags & disable_modify_max_supply == o.new_options.flags & disable_modify_max_supply
-           || ( old_options.flags & disable_modify_max_supply ) == 0 ),
-           "The disable_modify_max_supply flag can not be deactivated." );
-
-   // TODO HARDFORKCHECK
    // maximum supply can only be changed if the disable_modify_max_supply flag is 0
-   FC_ASSERT( ( old_options.max_supply == o.new_options.max_supply
-           || ( old_options.flags & disable_modify_max_supply ) == 0 ),
-           "Modification of the maximum supply is forbidden by permission flag." );
+   FC_ASSERT( ( a.options.max_supply == o.new_options.max_supply
+           || ( a.options.flags & disable_modify_max_supply ) == 0 ),
+           "Modification of the maximum supply is forbidden" );
 
    asset_to_update = &a;
    FC_ASSERT( o.issuer == a.issuer,

--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -266,6 +266,7 @@ void_result asset_update_evaluator::do_evaluate(const asset_update_operation& o)
    database& d = db();
 
    const asset_object& a = o.asset_to_update(d);
+   auto old_options = a.options;
    auto a_copy = a;
    a_copy.options = o.new_options;
    a_copy.validate();
@@ -287,6 +288,18 @@ void_result asset_update_evaluator::do_evaluate(const asset_update_operation& o)
    // changed flags must be subset of old issuer permissions
    FC_ASSERT(!((o.new_options.flags ^ a.options.flags) & ~a.options.issuer_permissions),
              "Flag change is forbidden by issuer permissions");
+
+   // TODO HARDFORKCHECK
+   // change of the disable_modify_max_supply flag; should only be set from 0 to 1
+   FC_ASSERT( ( old_options.flags & disable_modify_max_supply == o.new_options.flags & disable_modify_max_supply
+           || ( old_options.flags & disable_modify_max_supply ) == 0 ),
+           "The disable_modify_max_supply flag can not be deactivated." );
+
+   // TODO HARDFORKCHECK
+   // maximum supply can only be changed if the disable_modify_max_supply flag is 0
+   FC_ASSERT( ( old_options.max_supply == o.new_options.max_supply
+           || ( old_options.flags & disable_modify_max_supply ) == 0 ),
+           "Modification of the maximum supply is forbidden by permission flag." );
 
    asset_to_update = &a;
    FC_ASSERT( o.issuer == a.issuer,

--- a/libraries/chain/include/graphene/chain/asset_object.hpp
+++ b/libraries/chain/include/graphene/chain/asset_object.hpp
@@ -96,6 +96,8 @@ namespace graphene { namespace chain {
          bool is_transfer_restricted()const { return options.flags & transfer_restricted; }
          bool can_override()const { return options.flags & override_authority; }
          bool allow_confidential()const { return !(options.flags & asset_issuer_permission_flags::disable_confidential); }
+         /// @return true if this asset can modify the max supply
+         bool can_modify_max_supply() const { return !(options.flags & asset_issuer_permission_flags::disable_modify_max_supply); }
 
          /// Helper function to get an asset object with the given amount in this asset's type
          asset amount(share_type a)const { return asset(a, id); }

--- a/libraries/chain/include/graphene/chain/protocol/types.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/types.hpp
@@ -98,11 +98,12 @@ namespace graphene { namespace chain {
       global_settle        = 0x20, /**< allow the bitasset issuer to force a global settling -- this may be set in permissions, but not flags */
       disable_confidential = 0x40, /**< allow the asset to be used with confidential transactions */
       witness_fed_asset    = 0x80, /**< allow the asset to be fed by witnesses */
-      committee_fed_asset  = 0x100 /**< allow the asset to be fed by the committee */
+      committee_fed_asset  = 0x100,/**< allow the asset to be fed by the committee */
+      disable_modify_max_supply = 0x200 /**< disable the modification of the maximum supply; can only be activated once */
    };
    const static uint32_t ASSET_ISSUER_PERMISSION_MASK = charge_market_fee|white_list|override_authority|transfer_restricted|disable_force_settle|global_settle|disable_confidential
-      |witness_fed_asset|committee_fed_asset;
-   const static uint32_t UIA_ASSET_ISSUER_PERMISSION_MASK = charge_market_fee|white_list|override_authority|transfer_restricted|disable_confidential;
+      |witness_fed_asset|committee_fed_asset|disable_modify_max_supply;
+   const static uint32_t UIA_ASSET_ISSUER_PERMISSION_MASK = charge_market_fee|white_list|override_authority|transfer_restricted|disable_confidential|disable_modify_max_supply;
 
    enum reserved_spaces
    {
@@ -417,4 +418,5 @@ FC_REFLECT_ENUM( graphene::chain::asset_issuer_permission_flags,
    (disable_confidential)
    (witness_fed_asset)
    (committee_fed_asset)
+   (disable_modify_max_supply)
    )


### PR DESCRIPTION
*This pull request collides with https://github.com/bitshares/bitshares-core/pull/1611 as it uses the same value for the flag.*

This feature introduces a flag that prevents issues from changing the max_supply of an asset.
Obviously, for this flag to make sense, the issuer would need to also disable the corresponding permission.

A BSIP for this PR will follow shortly
(paging @dimfred)