### PR TITLE
Fixed saving keys in wallet

### DIFF
--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -265,9 +265,10 @@ public:
 private:
    void claim_registered_account(const account_object& account)
    {
+      std::vector<std::string> import_keys;
       auto it = _wallet.pending_account_registrations.find( account.name );
       FC_ASSERT( it != _wallet.pending_account_registrations.end() );
-      for (const std::string& wif_key : it->second)
+      for (const std::string& wif_key : it->second) {
          if( !import_key( account.name, wif_key ) )
          {
             // somebody else beat our pending registration, there is
@@ -280,8 +281,22 @@ private:
             //    possibility of migrating to a fork where the
             //    name is available, the user can always
             //    manually re-register)
+         } else {
+            import_keys.push_back( wif_key );
          }
+      }
       _wallet.pending_account_registrations.erase( it );
+
+      for( const auto& k : import_keys ) {
+         fc::optional<fc::ecc::private_key> optional_private_key = wif_to_key( k );
+         if (!optional_private_key)
+            FC_THROW("Invalid private key");
+         string shorthash = detail::address_to_shorthash(optional_private_key->get_public_key());
+         copy_wallet_file( "before-import-key-" + shorthash );
+
+         save_wallet_file();
+         copy_wallet_file( "after-import-key-" + shorthash );
+      }
    }
 
    // after a witness registration succeeds, this saves the private key in the wallet permanently

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -265,7 +265,7 @@ public:
 private:
    void claim_registered_account(const account_object& account)
    {
-      std::vector<std::string> import_keys;
+      bool import_keys = false;
       auto it = _wallet.pending_account_registrations.find( account.name );
       FC_ASSERT( it != _wallet.pending_account_registrations.end() );
       for (const std::string& wif_key : it->second) {
@@ -282,20 +282,13 @@ private:
             //    name is available, the user can always
             //    manually re-register)
          } else {
-            import_keys.push_back( wif_key );
+            import_keys = true;
          }
       }
       _wallet.pending_account_registrations.erase( it );
 
-      for( const auto& k : import_keys ) {
-         fc::optional<fc::ecc::private_key> optional_private_key = wif_to_key( k );
-         if (!optional_private_key)
-            FC_THROW("Invalid private key");
-         string shorthash = detail::address_to_shorthash(optional_private_key->get_public_key());
-         copy_wallet_file( "before-import-key-" + shorthash );
-
+      if( import_keys ) {
          save_wallet_file();
-         copy_wallet_file( "after-import-key-" + shorthash );
       }
    }
 

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -37,6 +37,8 @@
 #include <fc/rpc/websocket_api.hpp>
 #include <fc/rpc/cli.hpp>
 
+#include <fc/crypto/aes.hpp>
+
 #ifdef _WIN32
    #ifndef _WIN32_WINNT
       #define _WIN32_WINNT 0x0501
@@ -564,4 +566,42 @@ BOOST_FIXTURE_TEST_CASE( account_history_pagination, cli_fixture )
       edump((e.to_detail_string()));
       throw;
    }
+}
+
+graphene::wallet::plain_keys decrypt_keys( const std::string& password, const vector<char>& cipher_keys )
+{
+   auto pw = fc::sha512::hash( password.c_str(), password.size() );
+   vector<char> decrypted = fc::aes_decrypt( pw, cipher_keys );
+   return fc::raw::unpack<graphene::wallet::plain_keys>( decrypted );
+}
+
+BOOST_AUTO_TEST_CASE( saving_keys_wallet_test ) {
+   cli_fixture cli;
+
+   cli.con.wallet_api_ptr->import_balance( "nathan", cli.nathan_keys, true );
+   cli.con.wallet_api_ptr->upgrade_account( "nathan", true );
+   std::string brain_key( "FICTIVE WEARY MINIBUS LENS HAWKIE MAIDISH MINTY GLYPH GYTE KNOT COCKSHY LENTIGO PROPS BIFORM KHUTBAH BRAZIL" );
+   cli.con.wallet_api_ptr->create_account_with_brain_key( brain_key, "account1", "nathan", "nathan", true );
+
+   BOOST_CHECK_NO_THROW( cli.con.wallet_api_ptr->transfer( "nathan", "account1", "9000", "1.3.0", "", true ) );
+
+   std::string path( cli.app_dir.path().generic_string() + "/wallet.json" );
+   graphene::wallet::wallet_data wallet = fc::json::from_file( path ).as<graphene::wallet::wallet_data>( 2 * GRAPHENE_MAX_NESTED_OBJECTS );
+   BOOST_CHECK( wallet.extra_keys.size() == 1 ); // nathan
+   BOOST_CHECK( wallet.pending_account_registrations.size() == 1 ); // account1
+   BOOST_CHECK( wallet.pending_account_registrations["account1"].size() == 2 ); // account1 active key + account1 memo key
+
+   graphene::wallet::plain_keys pk = decrypt_keys( "supersecret", wallet.cipher_keys );
+   BOOST_CHECK( pk.keys.size() == 1 ); // nathan key
+
+   BOOST_CHECK( generate_block( cli.app1 ) );
+   fc::usleep( fc::seconds(1) );
+
+   wallet = fc::json::from_file( path ).as<graphene::wallet::wallet_data>( 2 * GRAPHENE_MAX_NESTED_OBJECTS );
+   BOOST_CHECK( wallet.extra_keys.size() == 2 ); // nathan + account1
+   BOOST_CHECK( wallet.pending_account_registrations.empty() );
+   BOOST_CHECK_NO_THROW( cli.con.wallet_api_ptr->transfer( "account1", "nathan", "1000", "1.3.0", "", true ) );
+
+   pk = decrypt_keys( "supersecret", wallet.cipher_keys );
+   BOOST_CHECK( pk.keys.size() == 3 ); // nathan key + account1 active key + account1 memo key
 }


### PR DESCRIPTION
When a new account is created, its private keys must be added to a wallet. Key addition must happen only after the account is created on the blockchain.

Problem:

After an account is created, its keys are put into a temporary data structure (pending_account_registrations), stored in the wallet. After this, the wallet (in JSON format) is recorded into a file (wallet.json). Once a new block is added, a check is performed on whether the account was created on the blockchain. If it was created, its keys are put into _keys data structure, which is stored in the wallet. However, these keys are not re-recorded into the wallet file (wallet.json) in the encoded format (variable cipher_keys) and are not removed from the temporary data structure (pending_account_registrations). Because of this, if the wallet is stopped and restarted, new keys are not added to data structure _keys, stored in the wallet. Which leads to the new account not being able to sign transactions.
The fix is presented in the request.