### PR TITLE
initialize percent_change in market_ticker constructor

### DIFF
--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -425,8 +425,8 @@ market_ticker::market_ticker(const fc::time_point_sec& now,
                              const asset_object& asset_quote)
 {
    time = now;
-   base = base;
-   quote = quote;
+   base = asset_base.symbol;
+   quote = asset_quote.symbol;
    latest = "0";
    lowest_ask = "0";
    highest_bid = "0";

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -420,6 +420,20 @@ market_ticker::market_ticker(const market_ticker_object& mto,
    if(!orders.bids.empty())
       highest_bid = orders.bids[0].price;
 }
+market_ticker::market_ticker(const fc::time_point_sec& now,
+                             const asset_object& asset_base,
+                             const asset_object& asset_quote)
+{
+   time = now;
+   base = base;
+   quote = quote;
+   latest = "0";
+   lowest_ask = "0";
+   highest_bid = "0";
+   percent_change = "0";
+   base_volume = "0";
+   quote_volume = "0";
+}
 
 //////////////////////////////////////////////////////////////////////
 //                                                                  //
@@ -1434,7 +1448,7 @@ market_ticker database_api_impl::get_ticker( const string& base, const string& q
       return market_ticker(*itr, now, *assets[0], *assets[1], orders);
    }
    // if no ticker is found for this market we return an empty ticker
-   market_ticker empty_result;
+   market_ticker empty_result(now, *assets[0], *assets[1]);
    return empty_result;
 }
 

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -388,6 +388,9 @@ market_ticker::market_ticker(const market_ticker_object& mto,
    base = asset_base.symbol;
    quote = asset_quote.symbol;
    percent_change = "0";
+   lowest_ask = "0";
+   highest_bid = "0";
+
    fc::uint128 bv;
    fc::uint128 qv;
    price latest_price = asset( mto.latest_base, mto.base ) / asset( mto.latest_quote, mto.quote );

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -387,6 +387,7 @@ market_ticker::market_ticker(const market_ticker_object& mto,
    time = now;
    base = asset_base.symbol;
    quote = asset_quote.symbol;
+   percent_change = "0";
    fc::uint128 bv;
    fc::uint128 qv;
    price latest_price = asset( mto.latest_base, mto.base ) / asset( mto.latest_quote, mto.quote );

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -97,6 +97,9 @@ struct market_ticker
                  const asset_object& asset_base,
                  const asset_object& asset_quote,
                  const order_book& orders);
+   market_ticker(const fc::time_point_sec& now,
+                 const asset_object& asset_base,
+                 const asset_object& asset_quote);
 };
 
 struct market_volume


### PR DESCRIPTION
Fix for https://github.com/bitshares/bitshares-core/issues/1620

Didn't created a test case but tested in the mainnet live and it is fixed. 

Before fix:

```
$ curl --silent -d '{"id":1,"method":"call","params":["database","get_ticker",["BROWNIE.PTS", "BTS"]]}' http://127.0.0.1:8090/ws | jq
{
  "id": 1,
  "jsonrpc": "2.0",
  "result": {
    "time": "2015-10-25T09:58:21",
    "base": "BROWNIE.PTS",
    "quote": "BTS",
    "latest": "0.133333333333333333",
    "lowest_ask": "0.199999600000799998",
    "highest_bid": "0.066666666666666666",
    "percent_change": "",
    "base_volume": "4333.3334",
    "quote_volume": "32500.0005"
  }
}

```

After:

```
$ curl --silent -d '{"id":1,"method":"call","params":["database","get_ticker",["BROWNIE.PTS", "BTS"]]}' http://127.0.0.1:8090/ws | jq
{
  "id": 1,
  "jsonrpc": "2.0",
  "result": {
    "time": "2015-10-26T20:28:15",
    "base": "BROWNIE.PTS",
    "quote": "BTS",
    "latest": "0.133333333333333333",
    "lowest_ask": "0.190476190476190476",
    "highest_bid": "0.1",
    "percent_change": "0",
    "base_volume": "0",
    "quote_volume": "0"
  }
}
```