### PR TITLE
Add fee_schedule::exists<op_type>()

### DIFF
--- a/libraries/chain/include/graphene/chain/protocol/fee_schedule.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/fee_schedule.hpp
@@ -140,6 +140,12 @@ namespace graphene { namespace chain {
       {
          return fee_helper<Operation>().get(parameters);
       }
+      template<typename Operation>
+      const bool exists()const
+      {
+         auto itr = parameters.find(typename Operation::fee_parameters_type());
+         return itr != parameters.end();
+      }
 
       /**
        *  @note must be sorted by fee_parameters.which() and have no duplicates


### PR DESCRIPTION
I pulled this out of a2192ec21e9d95372dc5e3d790bbc698bfb32a0c because I needed it separated from the rest of that commit. I am submitting it alone in a PR since it is generally applicable, not specific to any particular issue, and should not cause any trouble.