### PR TITLE
bump database to last release date

### DIFF
--- a/libraries/chain/include/graphene/chain/config.hpp
+++ b/libraries/chain/include/graphene/chain/config.hpp
@@ -121,7 +121,7 @@
 #define GRAPHENE_RECENTLY_MISSED_COUNT_INCREMENT             4
 #define GRAPHENE_RECENTLY_MISSED_COUNT_DECREMENT             3
 
-#define GRAPHENE_CURRENT_DB_VERSION                          "BTS2.181221"
+#define GRAPHENE_CURRENT_DB_VERSION                          "20190219"
 
 #define GRAPHENE_IRREVERSIBLE_THRESHOLD                      (70 * GRAPHENE_1_PERCENT)
 


### PR DESCRIPTION
Due to merge conflicts the last release didn't had a database bump resulting in no forced replay, witness_nodes were crashing when updating without replaying. 

This pull updates the database using a date stamp as proposed https://github.com/bitshares/bitshares-core/issues/1618#issuecomment-468768460

This should close  https://github.com/bitshares/bitshares-core/issues/1618 if accepted and project should start using that format from now on which is easier to resolve conflicts.