### PR TITLE
Fix Windows Build Errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ if( WIN32 )
     set(CRYPTO_LIB)
 
     if( MSVC )
+	add_definitions(-DWIN32_LEAN_AND_MEAN)
         #looks like this flag can have different default on some machines.
         SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /SAFESEH:NO")
         SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SAFESEH:NO")

--- a/libraries/chain/db_maint.cpp
+++ b/libraries/chain/db_maint.cpp
@@ -311,7 +311,7 @@ void database::update_active_committee_members()
    if( stake_target > 0 )
    {
       while( (committee_member_count < _committee_count_histogram_buffer.size() - 1)
-             && (stake_tally <= stake_target) )
+             && (stake_tally <= stake_target.value) )
       {
          stake_tally += _committee_count_histogram_buffer[++committee_member_count];
       }


### PR DESCRIPTION
This is a partial fix for #1593 

1) Evidently recent Boost versions include WinSock.h, which is not protected from being included more than once. The fix is to use the LEAN_AND_MEAN precompiler directive.

2) The compiler could not determine the way to compare an uint64_t and a safe<int64_t>. The fix is to pull the value from its "safe" wrapper and compare that.