### PR TITLE
fix plugins option in config file

### DIFF
--- a/programs/delayed_node/main.cpp
+++ b/programs/delayed_node/main.cpp
@@ -93,7 +93,7 @@ int main(int argc, char** argv) {
       }
 
       cfg_options.add_options()
-              ("plugins", bpo::value<std::string>()->default_value(options.at("plugins").as<std::string>()),
+              ("plugins", bpo::value<std::string>()->default_value("delayed_node account_history market_history"),
                "Space-separated list of plugins to activate");
 
       auto delayed_plug = node.register_plugin<delayed_node::delayed_node_plugin>();

--- a/programs/delayed_node/main.cpp
+++ b/programs/delayed_node/main.cpp
@@ -72,10 +72,6 @@ int main(int argc, char** argv) {
 
       bpo::variables_map options;
 
-      auto delayed_plug = node.register_plugin<delayed_node::delayed_node_plugin>();
-      auto history_plug = node.register_plugin<account_history::account_history_plugin>();
-      auto market_history_plug = node.register_plugin<market_history::market_history_plugin>();
-
       try
       {
          bpo::options_description cli, cfg;
@@ -95,6 +91,19 @@ int main(int argc, char** argv) {
          std::cout << app_options << "\n";
          return 0;
       }
+
+      cfg_options.add_options()
+              ("plugins", bpo::value<std::string>()->default_value(options.at("plugins").as<std::string>()),
+               "Space-separated list of plugins to activate");
+
+      auto delayed_plug = node.register_plugin<delayed_node::delayed_node_plugin>();
+      auto history_plug = node.register_plugin<account_history::account_history_plugin>();
+      auto market_history_plug = node.register_plugin<market_history::market_history_plugin>();
+
+      // add plugin options to config
+      bpo::options_description cli, cfg;
+      node.set_program_options(cli, cfg);
+      cfg_options.add(cfg);
 
       fc::path data_dir;
       if( options.count("data-dir") )

--- a/programs/witness_node/main.cpp
+++ b/programs/witness_node/main.cpp
@@ -97,6 +97,19 @@ int main(int argc, char** argv) {
          return 1;
       }
 
+      cfg_options.add_options()
+              ("plugins", bpo::value<std::string>()->default_value(options.at("plugins").as<std::string>()),
+               "Space-separated list of plugins to activate");
+
+      fc::path data_dir;
+      if( options.count("data-dir") )
+      {
+         data_dir = options["data-dir"].as<boost::filesystem::path>();
+         if( data_dir.is_relative() )
+            data_dir = fc::current_path() / data_dir;
+      }
+      app::load_configuration_options(data_dir, cfg_options, options);
+
       std::set<std::string> plugins;
       boost::split(plugins, options.at("plugins").as<std::string>(), [](char c){return c == ' ';});
 
@@ -110,7 +123,7 @@ int main(int argc, char** argv) {
             node->enable_plugin(plug);
          }
       });
-      
+
       if( options.count("help") )
       {
          std::cout << app_options << "\n";
@@ -126,15 +139,6 @@ int main(int argc, char** argv) {
          std::cout << "Websocket++: " << websocketpp::major_version << "." << websocketpp::minor_version << "." << websocketpp::patch_version << "\n";
          return 0;
       }
-
-      fc::path data_dir;
-      if( options.count("data-dir") )
-      {
-         data_dir = options["data-dir"].as<boost::filesystem::path>();
-         if( data_dir.is_relative() )
-            data_dir = fc::current_path() / data_dir;
-      }
-      app::load_configuration_options(data_dir, cfg_options, options);
 
       bpo::notify(options);
 

--- a/programs/witness_node/main.cpp
+++ b/programs/witness_node/main.cpp
@@ -97,6 +97,22 @@ int main(int argc, char** argv) {
          return 1;
       }
 
+      if( options.count("help") )
+      {
+         std::cout << app_options << "\n";
+         return 0;
+      }
+      if( options.count("version") )
+      {
+         std::cout << "Version: " << graphene::utilities::git_revision_description << "\n";
+         std::cout << "SHA: " << graphene::utilities::git_revision_sha << "\n";
+         std::cout << "Timestamp: " << fc::get_approximate_relative_time_string(fc::time_point_sec(graphene::utilities::git_revision_unix_timestamp)) << "\n";
+         std::cout << "SSL: " << OPENSSL_VERSION_TEXT << "\n";
+         std::cout << "Boost: " << boost::replace_all_copy(std::string(BOOST_LIB_VERSION), "_", ".") << "\n";
+         std::cout << "Websocket++: " << websocketpp::major_version << "." << websocketpp::minor_version << "." << websocketpp::patch_version << "\n";
+         return 0;
+      }
+
       cfg_options.add_options()
               ("plugins", bpo::value<std::string>()->default_value(options.at("plugins").as<std::string>()),
                "Space-separated list of plugins to activate");
@@ -123,22 +139,6 @@ int main(int argc, char** argv) {
             node->enable_plugin(plug);
          }
       });
-
-      if( options.count("help") )
-      {
-         std::cout << app_options << "\n";
-         return 0;
-      }
-      if( options.count("version") )
-      {
-         std::cout << "Version: " << graphene::utilities::git_revision_description << "\n";
-         std::cout << "SHA: " << graphene::utilities::git_revision_sha << "\n";
-         std::cout << "Timestamp: " << fc::get_approximate_relative_time_string(fc::time_point_sec(graphene::utilities::git_revision_unix_timestamp)) << "\n";
-         std::cout << "SSL: " << OPENSSL_VERSION_TEXT << "\n";
-         std::cout << "Boost: " << boost::replace_all_copy(std::string(BOOST_LIB_VERSION), "_", ".") << "\n";
-         std::cout << "Websocket++: " << websocketpp::major_version << "." << websocketpp::minor_version << "." << websocketpp::patch_version << "\n";
-         return 0;
-      }
 
       bpo::notify(options);
 

--- a/programs/witness_node/main.cpp
+++ b/programs/witness_node/main.cpp
@@ -104,7 +104,7 @@ int main(int argc, char** argv) {
       }
 
       cfg_options.add_options()
-              ("plugins", bpo::value<std::string>()->default_value(options.at("plugins").as<std::string>()),
+              ("plugins", bpo::value<std::string>()->default_value("witness account_history market_history grouped_orders"),
                "Space-separated list of plugins to activate");
 
       auto witness_plug = node->register_plugin<witness_plugin::witness_plugin>();

--- a/programs/witness_node/main.cpp
+++ b/programs/witness_node/main.cpp
@@ -73,16 +73,6 @@ int main(int argc, char** argv) {
 
       bpo::variables_map options;
 
-      auto witness_plug = node->register_plugin<witness_plugin::witness_plugin>();
-      auto debug_witness_plug = node->register_plugin<debug_witness_plugin::debug_witness_plugin>();
-      auto history_plug = node->register_plugin<account_history::account_history_plugin>();
-      auto elasticsearch_plug = node->register_plugin<elasticsearch::elasticsearch_plugin>();
-      auto market_history_plug = node->register_plugin<market_history::market_history_plugin>();
-      auto delayed_plug = node->register_plugin<delayed_node::delayed_node_plugin>();
-      auto snapshot_plug = node->register_plugin<snapshot_plugin::snapshot_plugin>();
-      auto es_objects_plug = node->register_plugin<es_objects::es_objects_plugin>();
-      auto grouped_orders_plug = node->register_plugin<grouped_orders::grouped_orders_plugin>();
-
       try
       {
          bpo::options_description cli, cfg;
@@ -116,6 +106,21 @@ int main(int argc, char** argv) {
       cfg_options.add_options()
               ("plugins", bpo::value<std::string>()->default_value(options.at("plugins").as<std::string>()),
                "Space-separated list of plugins to activate");
+
+      auto witness_plug = node->register_plugin<witness_plugin::witness_plugin>();
+      auto debug_witness_plug = node->register_plugin<debug_witness_plugin::debug_witness_plugin>();
+      auto history_plug = node->register_plugin<account_history::account_history_plugin>();
+      auto elasticsearch_plug = node->register_plugin<elasticsearch::elasticsearch_plugin>();
+      auto market_history_plug = node->register_plugin<market_history::market_history_plugin>();
+      auto delayed_plug = node->register_plugin<delayed_node::delayed_node_plugin>();
+      auto snapshot_plug = node->register_plugin<snapshot_plugin::snapshot_plugin>();
+      auto es_objects_plug = node->register_plugin<es_objects::es_objects_plugin>();
+      auto grouped_orders_plug = node->register_plugin<grouped_orders::grouped_orders_plugin>();
+
+      // add plugin options to config
+      bpo::options_description cli, cfg;
+      node->set_program_options(cli, cfg);
+      cfg_options.add(cfg);
 
       fc::path data_dir;
       if( options.count("data-dir") )


### PR DESCRIPTION
For issue https://github.com/bitshares/bitshares-core/issues/1637

This is option 1 of https://github.com/bitshares/bitshares-core/issues/1637#issuecomment-471018834 which i think is the way  to go.

It works, plugins added to the config are not ignored with patch, command line haves preference when `plugins` is on both places, that looks ok to me.

The problem is that the plugins option is added at the end of the file, just before the loggers. 

Ill keep researching to see if there is a way to add it in an arbitrary place. 