### PR TITLE
Add plugin section headers to generated config.ini

### DIFF
--- a/libraries/app/config_util.cpp
+++ b/libraries/app/config_util.cpp
@@ -258,20 +258,24 @@ static void create_new_config_file(const fc::path& config_ini_path, const fc::pa
    };
    deduplicator dedup(modify_option_defaults);
    std::ofstream out_cfg(config_ini_path.preferred_string());
+   std::string plugin_header_surrounding( 78, '=' );
    for( const boost::shared_ptr<bpo::option_description> opt : cfg_options.options() )
    {
       const boost::shared_ptr<bpo::option_description> od = dedup.next(opt);
       if( !od ) continue;
 
-      if( !od->description().empty() )
-         out_cfg << "# " << od->description() << "\n";
-
-      if( od->long_name().find("plugin-cfg-header-") == 0 )
+      if( od->long_name().find("plugin-cfg-header-") == 0 ) // it's a plugin header
       {
+         out_cfg << "\n";
+         out_cfg << "# " << plugin_header_surrounding << "\n";
+         out_cfg << "# " << od->description() << "\n";
+         out_cfg << "# " << plugin_header_surrounding << "\n";
          out_cfg << "\n";
          continue;
       }
 
+      if( !od->description().empty() )
+         out_cfg << "# " << od->description() << "\n";
       boost::any store;
       if( !od->semantic()->apply_default(store) )
          out_cfg << "# " << od->long_name() << " = \n";
@@ -291,7 +295,10 @@ static void create_new_config_file(const fc::path& config_ini_path, const fc::pa
    }
 
    out_cfg << "\n"
-           << "# =============== logging options ===============\n"
+           << "# " << plugin_header_surrounding << "\n"
+           << "# logging options\n"
+           << "# " << plugin_header_surrounding << "\n"
+           << "#\n"
            << "# Logging configuration is loaded from logging.ini by default.\n"
            << "# If logging.ini exists, logging configuration added in this file will be ignored.\n";
    out_cfg.close();

--- a/libraries/app/config_util.cpp
+++ b/libraries/app/config_util.cpp
@@ -265,6 +265,13 @@ static void create_new_config_file(const fc::path& config_ini_path, const fc::pa
 
       if( !od->description().empty() )
          out_cfg << "# " << od->description() << "\n";
+
+      if( od->long_name().find("plugin-cfg-header-") == 0 )
+      {
+         out_cfg << "\n";
+         continue;
+      }
+
       boost::any store;
       if( !od->semantic()->apply_default(store) )
          out_cfg << "# " << od->long_name() << " = \n";
@@ -284,6 +291,7 @@ static void create_new_config_file(const fc::path& config_ini_path, const fc::pa
    }
 
    out_cfg << "\n"
+           << "# =============== logging options ===============\n"
            << "# Logging configuration is loaded from logging.ini by default.\n"
            << "# If logging.ini exists, logging configuration added in this file will be ignored.\n";
    out_cfg.close();

--- a/libraries/app/include/graphene/app/application.hpp
+++ b/libraries/app/include/graphene/app/application.hpp
@@ -62,13 +62,20 @@ namespace graphene { namespace app {
             auto plug = std::make_shared<PluginType>();
             plug->plugin_set_app(this);
 
-            boost::program_options::options_description plugin_cli_options(plug->plugin_name() + " plugin. " + plug->plugin_description() + "\nOptions"), plugin_cfg_options;
-            //boost::program_options::options_description plugin_cli_options("Options for plugin " + plug->plugin_name()), plugin_cfg_options;
+            string cli_plugin_desc = plug->plugin_name() + " plugin. " + plug->plugin_description() + "\nOptions";
+            boost::program_options::options_description plugin_cli_options( cli_plugin_desc ), plugin_cfg_options;
             plug->plugin_set_program_options(plugin_cli_options, plugin_cfg_options);
+
             if( !plugin_cli_options.options().empty() )
                _cli_options.add(plugin_cli_options);
+
             if( !plugin_cfg_options.options().empty() )
+            {
+               std::string header_name = "plugin-cfg-header-" + plug->plugin_name();
+               std::string header_desc = "=============== " + plug->plugin_name() + " plugin options ===============";
+               _cfg_options.add_options()(header_name.c_str(), header_desc.c_str());
                _cfg_options.add(plugin_cfg_options);
+            }
 
             add_available_plugin( plug );
 

--- a/libraries/app/include/graphene/app/application.hpp
+++ b/libraries/app/include/graphene/app/application.hpp
@@ -72,7 +72,7 @@ namespace graphene { namespace app {
             if( !plugin_cfg_options.options().empty() )
             {
                std::string header_name = "plugin-cfg-header-" + plug->plugin_name();
-               std::string header_desc = "=============== " + plug->plugin_name() + " plugin options ===============";
+               std::string header_desc = plug->plugin_name() + " plugin options";
                _cfg_options.add_options()(header_name.c_str(), header_desc.c_str());
                _cfg_options.add(plugin_cfg_options);
             }


### PR DESCRIPTION
PR for #1407.

Sample output:
```
...
# Whether to enable tracking of votes of standby witnesses and committee members. Set it to true to provide accurate data to API clients, set to false for slightly better performance.
# enable-standby-votes-tracking = 


# ==============================================================================
# witness plugin options
# ==============================================================================

# Enable block production, even if the chain is stale.
enable-stale-production = false

# Percent of witnesses (0-99) that must be participating in order to produce blocks
required-participation = false

# ID of witness controlled by this node (e.g. "1.6.5", quotes are required, may specify multiple times)
# witness-id = 

# Tuple of [PublicKey, WIF private key] (may specify multiple times)
private-key = ["BTS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV","5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3"]


# ==============================================================================
# debug_witness plugin options
# ==============================================================================

# Tuple of [PublicKey, WIF private key] (may specify multiple times)
debug-private-key = ["BTS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV","5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3"]


# ==============================================================================
# account_history plugin options
# ==============================================================================

# Account ID to track history for (may specify multiple times)
# track-account = 

...
```