### PR TITLE
Change format of get_htlc output

### DIFF
--- a/libraries/chain/db_notify.cpp
+++ b/libraries/chain/db_notify.cpp
@@ -369,8 +369,8 @@ void get_relevant_accounts( const object* obj, flat_set<account_id_type>& accoun
         } case htlc_object_type:{
               const auto& htlc_obj = dynamic_cast<const htlc_object*>(obj);
               FC_ASSERT( htlc_obj != nullptr );
-              accounts.insert( htlc_obj->from );
-              accounts.insert( htlc_obj->to );
+              accounts.insert( htlc_obj->transfer.from );
+              accounts.insert( htlc_obj->transfer.to );
               break;
         }
       }

--- a/libraries/chain/db_update.cpp
+++ b/libraries/chain/db_update.cpp
@@ -581,12 +581,12 @@ void database::clear_expired_htlcs()
 {
    const auto& htlc_idx = get_index_type<htlc_index>().indices().get<by_expiration>();
    while ( htlc_idx.begin() != htlc_idx.end()
-         && htlc_idx.begin()->expiration <= head_block_time() )
+         && htlc_idx.begin()->conditions.time_lock.expiration <= head_block_time() )
    {
       const htlc_object& obj = *htlc_idx.begin();
-      adjust_balance( obj.from, obj.amount );
+      adjust_balance( obj.transfer.from, asset(obj.transfer.amount, obj.transfer.asset_id) );
       // virtual op
-      htlc_refund_operation vop( obj.id, obj.from );
+      htlc_refund_operation vop( obj.id, obj.transfer.from );
       vop.htlc_id = htlc_idx.begin()->id;
       push_applied_operation( vop );
 

--- a/libraries/chain/htlc_evaluator.cpp
+++ b/libraries/chain/htlc_evaluator.cpp
@@ -56,12 +56,13 @@ namespace graphene {
             dbase.adjust_balance( o.from, -o.amount );
 
             const htlc_object& esc = db().create<htlc_object>([&dbase,&o]( htlc_object& esc ) {
-               esc.from                  = o.from;
-               esc.to                    = o.to;
-               esc.amount                = o.amount;
-               esc.preimage_hash         = o.preimage_hash;
-               esc.preimage_size         = o.preimage_size;
-               esc.expiration            = dbase.head_block_time() + o.claim_period_seconds;
+               esc.transfer.from                  = o.from;
+               esc.transfer.to                    = o.to;
+               esc.transfer.amount                = o.amount.amount;
+               esc.transfer.asset_id              = o.amount.asset_id;
+               esc.conditions.hash_lock.preimage_hash = o.preimage_hash;
+               esc.conditions.hash_lock.preimage_size = o.preimage_size;
+               esc.conditions.time_lock.expiration    = dbase.head_block_time() + o.claim_period_seconds;
             });
             return  esc.id;
 
@@ -89,19 +90,20 @@ namespace graphene {
       {
          htlc_obj = &db().get<htlc_object>(o.htlc_id);
 
-         FC_ASSERT(o.preimage.size() == htlc_obj->preimage_size, "Preimage size mismatch.");
+         FC_ASSERT(o.preimage.size() == htlc_obj->conditions.hash_lock.preimage_size, "Preimage size mismatch.");
 
          const htlc_redeem_visitor vtor( o.preimage );
-         FC_ASSERT( htlc_obj->preimage_hash.visit( vtor ), "Provided preimage does not generate correct hash.");
+         FC_ASSERT( htlc_obj->conditions.hash_lock.preimage_hash.visit( vtor ), "Provided preimage does not generate correct hash.");
 
          return void_result();
       }
 
       void_result htlc_redeem_evaluator::do_apply(const htlc_redeem_operation& o)
       {
-         db().adjust_balance(htlc_obj->to, htlc_obj->amount);
+         db().adjust_balance(htlc_obj->transfer.to, asset(htlc_obj->transfer.amount, htlc_obj->transfer.asset_id) );
          // notify related parties
-         htlc_redeemed_operation virt_op( htlc_obj->id, htlc_obj->from, htlc_obj->to, htlc_obj->amount );
+         htlc_redeemed_operation virt_op( htlc_obj->id, htlc_obj->transfer.from, htlc_obj->transfer.to, 
+               asset(htlc_obj->transfer.amount, htlc_obj->transfer.asset_id ) );
          db().push_applied_operation( virt_op );
          db().remove(*htlc_obj);
          return void_result();
@@ -116,7 +118,7 @@ namespace graphene {
       void_result htlc_extend_evaluator::do_apply(const htlc_extend_operation& o)
       {
          db().modify(*htlc_obj, [&o](htlc_object& db_obj) {
-            db_obj.expiration += o.seconds_to_add;
+            db_obj.conditions.time_lock.expiration += o.seconds_to_add;
          });
 
          return void_result();

--- a/libraries/chain/include/graphene/chain/config.hpp
+++ b/libraries/chain/include/graphene/chain/config.hpp
@@ -121,7 +121,7 @@
 #define GRAPHENE_RECENTLY_MISSED_COUNT_INCREMENT             4
 #define GRAPHENE_RECENTLY_MISSED_COUNT_DECREMENT             3
 
-#define GRAPHENE_CURRENT_DB_VERSION                          "BTS2.190225"
+#define GRAPHENE_CURRENT_DB_VERSION                          "20190319"
 
 #define GRAPHENE_IRREVERSIBLE_THRESHOLD                      (70 * GRAPHENE_1_PERCENT)
 

--- a/libraries/chain/include/graphene/chain/htlc_object.hpp
+++ b/libraries/chain/include/graphene/chain/htlc_object.hpp
@@ -45,12 +45,38 @@ namespace graphene { namespace chain {
          static const uint8_t space_id = protocol_ids;
          static const uint8_t type_id  = htlc_object_type;
 
-         account_id_type from;
-         account_id_type to;
-         asset amount;
-         fc::time_point_sec expiration;
-         htlc_hash preimage_hash;
-         uint16_t preimage_size;
+         struct transfer_info {
+            account_id_type from;
+            account_id_type to;
+            share_type amount;
+            asset_id_type asset_id;
+         } transfer;
+         struct condition_info {
+            struct hash_lock_info {  
+               htlc_hash preimage_hash;
+               uint16_t preimage_size;
+            } hash_lock;
+            struct time_lock_info {
+               fc::time_point_sec expiration;
+            } time_lock;
+         } conditions;
+
+      /****
+       * Index helper for timelock
+       */
+      struct timelock_extractor {
+         typedef fc::time_point_sec result_type;
+         const result_type& operator()(const htlc_object& o)const { return o.conditions.time_lock.expiration; }
+      };
+
+      /*****
+       * Index helper for from
+       */
+      struct from_extractor {
+         typedef account_id_type result_type;
+         const result_type& operator()(const htlc_object& o)const { return o.transfer.from; }
+      };
+
    };
 
    struct by_from_id;
@@ -61,13 +87,13 @@ namespace graphene { namespace chain {
             ordered_unique< tag< by_id >, member< object, object_id_type, &object::id > >,
 
             ordered_unique< tag< by_expiration >, 
-                  composite_key< htlc_object, 
-                  member< htlc_object, fc::time_point_sec, &htlc_object::expiration >,
+                  composite_key< htlc_object,
+                  htlc_object::timelock_extractor,
                   member< object, object_id_type, &object::id > > >,
 
             ordered_unique< tag< by_from_id >,
                   composite_key< htlc_object, 
-                  member< htlc_object, account_id_type,  &htlc_object::from >,
+                  htlc_object::from_extractor,
                   member< object, object_id_type, &object::id > > >
          >
 
@@ -77,6 +103,13 @@ namespace graphene { namespace chain {
 
 } } // namespace graphene::chain
 
+FC_REFLECT( graphene::chain::htlc_object::transfer_info, 
+   (from) (to) (amount) (asset_id) )
+FC_REFLECT( graphene::chain::htlc_object::condition_info::hash_lock_info,
+   (preimage_hash) (preimage_size) )
+FC_REFLECT( graphene::chain::htlc_object::condition_info::time_lock_info,
+   (expiration) )
+FC_REFLECT( graphene::chain::htlc_object::condition_info, 
+   (hash_lock)(time_lock) )
 FC_REFLECT_DERIVED( graphene::chain::htlc_object, (graphene::db::object),
-               (from)(to)(amount)(expiration)
-					(preimage_hash)(preimage_size) );
+               (transfer) (conditions) )

--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -495,7 +495,7 @@ class wallet_api
        * @param htlc_id the id of the HTLC object.
        * @returns the information about the HTLC object
        */
-      variant                           get_htlc(string htlc_id) const;
+      optional<variant>                 get_htlc(string htlc_id) const;
 
       /** Lookup the id of a named account.
        * @param account_name_or_id the name of the account to look up

--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -23,6 +23,8 @@
  */
 #pragma once
 
+#include <fc/optional.hpp>
+#include <graphene/chain/htlc_object.hpp>
 #include <graphene/app/api.hpp>
 #include <graphene/utilities/key_conversion.hpp>
 
@@ -495,7 +497,7 @@ class wallet_api
        * @param htlc_id the id of the HTLC object.
        * @returns the information about the HTLC object
        */
-      optional<variant>                 get_htlc(string htlc_id) const;
+      optional<htlc_object>             get_htlc(string htlc_id) const;
 
       /** Lookup the id of a named account.
        * @param account_name_or_id the name of the account to look up

--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -497,7 +497,7 @@ class wallet_api
        * @param htlc_id the id of the HTLC object.
        * @returns the information about the HTLC object
        */
-      optional<htlc_object>             get_htlc(string htlc_id) const;
+      fc::optional<fc::variant>             get_htlc(string htlc_id) const;
 
       /** Lookup the id of a named account.
        * @param account_name_or_id the name of the account to look up

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -3230,6 +3230,7 @@ fc::optional<fc::variant> wallet_api::get_htlc(std::string htlc_id) const
       htlc_lock["preimage_size"] = obj.conditions.hash_lock.preimage_size;
       fc::mutable_variant_object time_lock;
       time_lock["expiration"] = obj.conditions.time_lock.expiration;
+      time_lock["time_left"] = fc::get_approximate_relative_time_string(obj.conditions.time_lock.expiration);
       fc::mutable_variant_object conditions;
       conditions["htlc_lock"] = htlc_lock;
       conditions["time_lock"] = time_lock;

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -684,7 +684,7 @@ public:
       htlc_id_type id;
       fc::from_variant(htlc_id, id);
       auto obj = _remote_db->get_objects( { id }).front();
-      if (!obj.is_null())
+      if ( !obj.is_null() )
       {
          return fc::optional<htlc_object>(obj.template as<htlc_object>(GRAPHENE_MAX_NESTED_OBJECTS));
       }
@@ -3193,7 +3193,7 @@ signed_transaction wallet_api::htlc_create( string source, string destination, s
 fc::optional<fc::variant> wallet_api::get_htlc(std::string htlc_id) const
 {
    fc::optional<htlc_object> optional_obj = my->get_htlc(htlc_id);
-   if (optional_obj)
+   if ( optional_obj.valid() )
    {
       const htlc_object& obj = *optional_obj;
       // convert to formatted variant

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -63,6 +63,7 @@
 #include <fc/crypto/base58.hpp>
 
 #include <graphene/app/api.hpp>
+#include <graphene/app/util.hpp>
 #include <graphene/chain/asset_object.hpp>
 #include <graphene/chain/protocol/fee_schedule.hpp>
 #include <graphene/chain/htlc_object.hpp>
@@ -3203,7 +3204,7 @@ fc::optional<fc::variant> wallet_api::get_htlc(std::string htlc_id) const
       transfer["to"] = to.name;
       const auto& asset = my->get_asset( obj.transfer.asset_id );
       transfer["asset"] = asset.symbol;
-      transfer["amount"] = obj.transfer.amount.value;
+      transfer["amount"] = graphene::app::uint128_amount_to_string( obj.transfer.amount.value, asset.precision );
       class htlc_hash_to_variant_visitor
       {
          public:

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -680,7 +680,7 @@ BOOST_AUTO_TEST_CASE( cli_create_htlc )
       std::string preimage_string = "My Secret";
       fc::sha256 preimage_md = fc::sha256::hash(preimage_string);
       std::stringstream ss;
-      for(int i = 0; i < preimage_md.data_size(); i++)
+      for(size_t i = 0; i < preimage_md.data_size(); i++)
       {
          char d = preimage_md.data()[i];
          unsigned char uc = static_cast<unsigned char>(d);

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -318,7 +318,7 @@ void database_fixture::verify_asset_supplies( const database& db )
    const auto& htlc_idx = db.get_index_type< htlc_index >().indices().get< by_id >();
    for( auto itr = htlc_idx.begin(); itr != htlc_idx.end(); ++itr )
    {
-      total_balances[itr->amount.asset_id] += itr->amount.amount;
+      total_balances[itr->transfer.asset_id] += itr->transfer.amount;
    }
 
    for( const asset_object& asset_obj : db.get_index_type<asset_index>().indices() )


### PR DESCRIPTION
Fixes #1645 

The output of the get_htlc method was cryptic and difficult to parse. This cleans up the formatting of the results.