### PR TITLE
cli_wallet lacks update_account command #163 & CLI & RPC methods to update owner/active/memo keys are missing #113

### DIFF
--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -1491,6 +1491,8 @@ class wallet_api
                                            bool approve,
                                            bool broadcast = false);
 
+      signed_transaction update_account( account_update_operation account_update_op, bool broadcast = false );
+
       /** Vote for a given witness.
        *
        * An account can publish a list of all witnesses they approve of.  This 
@@ -1815,6 +1817,7 @@ FC_API( graphene::wallet::wallet_api,
         (get_vesting_balances)
         (withdraw_vesting)
         (vote_for_committee_member)
+        (update_account)
         (vote_for_witness)
         (set_voting_proxy)
         (set_desired_witness_and_committee_member_count)

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -1917,6 +1917,16 @@ public:
       return sign_transaction( tx, broadcast );
    } FC_CAPTURE_AND_RETHROW( (voting_account)(committee_member)(approve)(broadcast) ) }
 
+   signed_transaction update_account( account_update_operation account_update_op, bool broadcast /* = false */ )
+   { try {
+      signed_transaction tx;
+      tx.operations.push_back( account_update_op );
+      set_operation_fees( tx, _remote_db->get_global_properties().parameters.current_fees);
+      tx.validate();
+
+      return sign_transaction( tx, broadcast );
+   } FC_CAPTURE_AND_RETHROW( (account_update_op)(broadcast) ) }
+
    signed_transaction vote_for_witness(string voting_account,
                                         string witness,
                                         bool approve,
@@ -3784,6 +3794,11 @@ signed_transaction wallet_api::vote_for_committee_member(string voting_account,
                                                  bool broadcast /* = false */)
 {
    return my->vote_for_committee_member(voting_account, witness, approve, broadcast);
+}
+
+signed_transaction wallet_api::update_account( account_update_operation account_update_op, bool broadcast /* = false */ )
+{
+   return my->update_account(account_update_op, broadcast);
 }
 
 signed_transaction wallet_api::vote_for_witness(string voting_account,


### PR DESCRIPTION
This PR is to fix both issues at the same time:

1. `cli_wallet` lacks `update_account` command #163
2. CLI & RPC methods to update owner/active/memo keys are missing #113