### PR TITLE
Improve fee_schedule::calculate_fee() performance

### DIFF
--- a/libraries/chain/include/graphene/chain/protocol/fee_schedule.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/fee_schedule.hpp
@@ -118,9 +118,18 @@ namespace graphene { namespace chain {
 
       /**
        *  Finds the appropriate fee parameter struct for the operation
-       *  and then calculates the appropriate fee.
+       *  and then calculates the appropriate fee in CORE asset.
        */
-      asset calculate_fee( const operation& op, const price& core_exchange_rate = price::unit_price() )const;
+      asset calculate_fee( const operation& op )const;
+      /**
+       *  Finds the appropriate fee parameter struct for the operation
+       *  and then calculates the appropriate fee in an asset specified
+       *  implicitly by core_exchange_rate.
+       */
+      asset calculate_fee( const operation& op, const price& core_exchange_rate )const;
+      /**
+       *  Updates the operation with appropriate fee and returns the fee.
+       */
       asset set_fee( operation& op, const price& core_exchange_rate = price::unit_price() )const;
 
       void zero_all_fees();

--- a/libraries/chain/protocol/fee_schedule.cpp
+++ b/libraries/chain/protocol/fee_schedule.cpp
@@ -115,21 +115,23 @@ namespace graphene { namespace chain {
       this->scale = 0;
    }
 
+   asset fee_schedule::calculate_fee( const operation& op )const
+   {
+      uint64_t required_fee = op.visit( calc_fee_visitor( *this, op ) );
+      if( scale != GRAPHENE_100_PERCENT )
+      {
+         auto scaled = fc::uint128(required_fee) * scale;
+         scaled /= GRAPHENE_100_PERCENT;
+         FC_ASSERT( scaled <= GRAPHENE_MAX_SHARE_SUPPLY,
+                    "Required fee after scaling would exceed maximum possible supply" );
+         required_fee = scaled.to_uint64();
+      }
+      return asset( required_fee );
+   }
+
    asset fee_schedule::calculate_fee( const operation& op, const price& core_exchange_rate )const
    {
-      auto base_value = op.visit( calc_fee_visitor( *this, op ) );
-      auto scaled = fc::uint128(base_value) * scale;
-      scaled /= GRAPHENE_100_PERCENT;
-      FC_ASSERT( scaled <= GRAPHENE_MAX_SHARE_SUPPLY );
-      //idump( (base_value)(scaled)(core_exchange_rate) );
-      auto result = asset( scaled.to_uint64(), asset_id_type(0) ) * core_exchange_rate;
-      //FC_ASSERT( result * core_exchange_rate >= asset( scaled.to_uint64()) );
-
-      while( result * core_exchange_rate < asset( scaled.to_uint64()) )
-        result.amount++;
-
-      FC_ASSERT( result.amount <= GRAPHENE_MAX_SHARE_SUPPLY );
-      return result;
+      return calculate_fee( op ).multiply_and_round_up( core_exchange_rate );
    }
 
    asset fee_schedule::set_fee( operation& op, const price& core_exchange_rate )const


### PR DESCRIPTION
Do fewer 128-bit computations.

#1660 is some related, but this PR doesn't resolve it.