### PR TITLE
Build with c++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Defines BitShares library target.
 project( BitShares )
-cmake_minimum_required( VERSION 2.8.12 )
+cmake_minimum_required( VERSION 3.1 )
 
 set( BLOCKCHAIN_NAME "BitShares" )
 
@@ -8,6 +8,10 @@ set( CLI_CLIENT_EXECUTABLE_NAME graphene_client )
 set( GUI_CLIENT_EXECUTABLE_NAME BitShares )
 set( CUSTOM_URL_SCHEME "gcs" )
 set( INSTALLER_APP_ID "68ad7005-8eee-49c9-95ce-9eed97e5b347" )
+
+set( CMAKE_CXX_STANDARD 14 )
+set( CMAKE_CXX_STANDARD_REQUIRED ON )
+set( CMAKE_CXX_EXTENSIONS OFF )
 
 # http://stackoverflow.com/a/18369825
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,10 +73,6 @@ IF(NOT "${Boost_VERSION}" MATCHES "1.53(.*)")
    SET(Boost_LIBRARIES ${BOOST_LIBRARIES_TEMP} ${Boost_LIBRARIES})
 ENDIF()
 
-if( NOT CPP_STANDARD )
-  set( CPP_STANDARD "-std=c++11" )
-endif()
-
 if( WIN32 )
 
     message( STATUS "Configuring BitShares on WIN32")
@@ -118,11 +114,11 @@ else( WIN32 ) # Apple AND Linux
     if( APPLE )
         # Apple Specific Options Here
         message( STATUS "Configuring BitShares on OS X" )
-        set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${CPP_STANDARD} -stdlib=libc++ -Wall" )
+        set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -stdlib=libc++ -Wall" )
     else( APPLE )
         # Linux Specific Options Here
         message( STATUS "Configuring BitShares on Linux" )
-        set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${CPP_STANDARD} -Wall" )
+        set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -Wall" )
         if(USE_PROFILER)
             set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pg" )
         endif( USE_PROFILER )


### PR DESCRIPTION
Fixes #847 

The same change was made in the fc subproject at https://github.com/bitshares/bitshares-fc/pull/114 . Hence, fc should be bumped when it is merged in.

ToDo:

 - [ ] Update documentation to require CMake 3.1
 - [ ] Update documentation to require a compiler that supports c++14

**Note** c++14 has been marked "required" in the CMakeLists.txt. This requirement could be loosened, but would later break clients on very old compilers as soon as we use a c++14 feature. I do not know which is worse, finding those users now or later.

This has been tested on Ubuntu 16.04 / g++ 5.4.0 / cmake 3.5.1 (which are the default versions for Ubuntu 16.04).

This has been tested on macOS Mojave 10.14.3 with clang 1000.11.45.5 (LLVM 10.0.0) and cmake 3.14.0

This has been tested on Windows 10 with MSVC 19.16.27027.1 ( Visual Studio 15 2017 ) and cmake 3.14