### PR TITLE
Use by_collateral when globally settling after hf

### DIFF
--- a/libraries/chain/db_market.cpp
+++ b/libraries/chain/db_market.cpp
@@ -62,34 +62,61 @@ void database::globally_settle_asset( const asset_object& mia, const price& sett
    const asset_dynamic_data_object& mia_dyn = mia.dynamic_asset_data_id(*this);
    auto original_mia_supply = mia_dyn.current_supply;
 
-   const auto& call_price_index = get_index_type<call_order_index>().indices().get<by_price>();
-
    auto maint_time = get_dynamic_global_properties().next_maintenance_time;
    bool before_core_hardfork_342 = ( maint_time <= HARDFORK_CORE_342_TIME ); // better rounding
+   bool before_core_hardfork_1270 = ( maint_time <= HARDFORK_CORE_1270_TIME ); // call price caching issue
 
    // cancel all call orders and accumulate it into collateral_gathered
-   auto call_itr = call_price_index.lower_bound( price::min( bitasset.options.short_backing_asset, mia.id ) );
-   auto call_end = call_price_index.upper_bound( price::max( bitasset.options.short_backing_asset, mia.id ) );
-   asset pays;
-   while( call_itr != call_end )
+   const auto& call_index = get_index_type<call_order_index>().indices();
+   const auto& call_price_index = call_index.get<by_price>();
+   const auto& call_collateral_index = call_index.get<by_collateral>();
+
+   auto call_min = price::min( bitasset.options.short_backing_asset, mia.id );
+   auto call_max = price::max( bitasset.options.short_backing_asset, mia.id );
+
+   auto call_price_itr = call_price_index.begin();
+   auto call_price_end = call_price_itr;
+   auto call_collateral_itr = call_collateral_index.begin();
+   auto call_collateral_end = call_collateral_itr;
+
+   if( before_core_hardfork_1270 )
    {
+      call_price_itr = call_price_index.lower_bound( call_min );
+      call_price_end = call_price_index.upper_bound( call_max );
+   }
+   else
+   {
+      call_collateral_itr = call_collateral_index.lower_bound( call_min );
+      call_collateral_end = call_collateral_index.upper_bound( call_max );
+   }
+
+   asset pays;
+   while( ( before_core_hardfork_1270 && call_price_itr != call_price_end )
+         || (!before_core_hardfork_1270 && call_collateral_itr != call_collateral_end ) )
+   {
+      const call_order_object& order = ( before_core_hardfork_1270 ? *call_price_itr : *call_collateral_itr );
+      if( before_core_hardfork_1270 )
+         ++call_price_itr;
+      else
+         ++call_collateral_itr;
+
       if( before_core_hardfork_342 )
       {
-         pays = call_itr->get_debt() * settlement_price; // round down, in favor of call order
+         pays = order.get_debt() * settlement_price; // round down, in favor of call order
 
          // Be here, the call order can be paying nothing
          if( pays.amount == 0 && !bitasset.is_prediction_market ) // TODO remove this warning after hard fork core-342
-            wlog( "Something for nothing issue (#184, variant E) occurred at block #${block}", ("block",head_block_num()) );
+            wlog( "Something for nothing issue (#184, variant E) occurred at block #${block}",
+                  ("block",head_block_num()) );
       }
       else
-         pays = call_itr->get_debt().multiply_and_round_up( settlement_price ); // round up, in favor of global settlement fund
+         pays = order.get_debt().multiply_and_round_up( settlement_price ); // round up in favor of global-settle fund
 
-      if( pays > call_itr->get_collateral() )
-         pays = call_itr->get_collateral();
+      if( pays > order.get_collateral() )
+         pays = order.get_collateral();
 
       collateral_gathered += pays;
-      const auto&  order = *call_itr;
-      ++call_itr;
+
       FC_ASSERT( fill_call_order( order, pays, order.get_debt(), settlement_price, true ) ); // call order is maker
    }
 

--- a/libraries/chain/db_market.cpp
+++ b/libraries/chain/db_market.cpp
@@ -56,17 +56,15 @@ void database::globally_settle_asset( const asset_object& mia, const price& sett
    auto maint_time = get_dynamic_global_properties().next_maintenance_time;
    bool before_core_hardfork_1270 = ( maint_time <= HARDFORK_CORE_1270_TIME ); // call price caching issue
 
-   const auto& call_index = get_index_type<call_order_index>().indices();
-   const auto& call_price_index = call_index.get<by_price>();
-   const auto& call_collateral_index = call_index.get<by_collateral>();
-
    if( before_core_hardfork_1270 )
    {
-      globally_settle_asset_impl( mia, settlement_price, call_price_index );
+      globally_settle_asset_impl( mia, settlement_price,
+                                  get_index_type<call_order_index>().indices().get<by_price>() );
    }
    else
    {
-      globally_settle_asset_impl( mia, settlement_price, call_collateral_index );
+      globally_settle_asset_impl( mia, settlement_price,
+                                  get_index_type<call_order_index>().indices().get<by_collateral>() );
    }
 }
 

--- a/libraries/chain/db_market.cpp
+++ b/libraries/chain/db_market.cpp
@@ -69,7 +69,9 @@ void database::globally_settle_asset( const asset_object& mia, const price& sett
 }
 
 template<typename IndexType>
-void database::globally_settle_asset_impl( const asset_object& mia, const price& settlement_price, const IndexType& call_index )
+void database::globally_settle_asset_impl( const asset_object& mia,
+                                           const price& settlement_price,
+                                           const IndexType& call_index )
 { try {
    const asset_bitasset_data_object& bitasset = mia.bitasset_data(*this);
    FC_ASSERT( !bitasset.has_settlement(), "black swan already occurred, it should not happen again" );

--- a/libraries/chain/db_market.cpp
+++ b/libraries/chain/db_market.cpp
@@ -54,9 +54,9 @@ namespace graphene { namespace chain { namespace detail {
 void database::globally_settle_asset( const asset_object& mia, const price& settlement_price )
 {
    auto maint_time = get_dynamic_global_properties().next_maintenance_time;
-   bool before_core_hardfork_1270 = ( maint_time <= HARDFORK_CORE_1270_TIME ); // call price caching issue
+   bool before_core_hardfork_1669 = ( maint_time <= HARDFORK_CORE_1669_TIME ); // whether to use call_price
 
-   if( before_core_hardfork_1270 )
+   if( before_core_hardfork_1669 )
    {
       globally_settle_asset_impl( mia, settlement_price,
                                   get_index_type<call_order_index>().indices().get<by_price>() );

--- a/libraries/chain/hardfork.d/CORE_1669.hf
+++ b/libraries/chain/hardfork.d/CORE_1669.hf
@@ -1,0 +1,4 @@
+// bitshares-core issue #1669 Stop using call_price when globally settling
+#ifndef HARDFORK_CORE_1669_TIME
+#define HARDFORK_CORE_1669_TIME (fc::time_point_sec( 1600000000 )) // a temporary date in the future
+#endif

--- a/libraries/chain/include/graphene/chain/database.hpp
+++ b/libraries/chain/include/graphene/chain/database.hpp
@@ -353,6 +353,11 @@ namespace graphene { namespace chain {
          void cancel_bid(const collateral_bid_object& bid, bool create_virtual_op = true);
          void execute_bid( const collateral_bid_object& bid, share_type debt_covered, share_type collateral_from_fund, const price_feed& current_feed );
 
+      private:
+         template<typename IndexType>
+         void globally_settle_asset_impl( const asset_object& bitasset, const price& settle_price, const IndexType& call_index );
+
+      public:
          /**
           * @brief Process a new limit order through the markets
           * @param order The new order to process

--- a/libraries/chain/include/graphene/chain/database.hpp
+++ b/libraries/chain/include/graphene/chain/database.hpp
@@ -355,7 +355,9 @@ namespace graphene { namespace chain {
 
       private:
          template<typename IndexType>
-         void globally_settle_asset_impl( const asset_object& bitasset, const price& settle_price, const IndexType& call_index );
+         void globally_settle_asset_impl( const asset_object& bitasset,
+                                          const price& settle_price,
+                                          const IndexType& call_index );
 
       public:
          /**


### PR DESCRIPTION
We'd like to remove `by_price` index at some time in the future to
improve performance, thus we should avoid using the index after the
hardfork.
https://github.com/bitshares/bitshares-core/issues/1669