### PR TITLE
Reduce precision of numbers in replay output

### DIFF
--- a/libraries/chain/db_management.cpp
+++ b/libraries/chain/db_management.cpp
@@ -123,12 +123,16 @@ void database::reindex( fc::path data_dir )
 
          if( i % 10000 == 0 )
          {
+            std::stringstream bysize;
+            std::stringstream bynum;
+            bysize << std::fixed << std::setprecision(5) << double(std::get<0>(blocks.front())) / total_block_size * 100;
+            bynum << std::fixed << std::setprecision(5) << double(i*100)/last_block_num;
             ilog(
                "   [by size: ${size}%   ${processed} of ${total}]   [by num: ${num}%   ${i} of ${last}]",
-               ("size", double(std::get<0>(blocks.front())) / total_block_size * 100)
+               ("size", bysize.str())
                ("processed", std::get<0>(blocks.front()))
                ("total", total_block_size)
-               ("num", double(i*100)/last_block_num)
+               ("num", bynum.str())
                ("i", i)
                ("last", last_block_num)
             );


### PR DESCRIPTION
Pull for https://github.com/bitshares/bitshares-core/pull/1666#issuecomment-475824748

Precision for the 2 percs of output reduced to 5m, now this looks as:

```
3121049ms th_a       db_management.cpp:141         reindex              ]    [by size: 48.91844%   4956224 of 10131607]   [by num: 47.82401%   30000 of 62730]
3121161ms th_a       db_management.cpp:141         reindex              ]    [by size: 64.02340%   6486599 of 10131607]   [by num: 63.76534%   40000 of 62730]
3121292ms th_a       db_management.cpp:141         reindex              ]    [by size: 79.76347%   8081321 of 10131607]   [by num: 79.70668%   50000 of 62730]

```