### PR TITLE
Fix some warnings

### DIFF
--- a/libraries/net/include/graphene/net/peer_connection.hpp
+++ b/libraries/net/include/graphene/net/peer_connection.hpp
@@ -65,6 +65,7 @@ namespace graphene { namespace net
     class peer_connection_delegate
     {
     public:
+      virtual ~peer_connection_delegate() = default;
       virtual void on_message(peer_connection* originating_peer,
                               const message& received_message) = 0;
       virtual void on_connection_closed(peer_connection* originating_peer) = 0;

--- a/tests/tests/market_tests.cpp
+++ b/tests/tests/market_tests.cpp
@@ -285,7 +285,7 @@ BOOST_AUTO_TEST_CASE(hardfork_core_338_test)
    // settlement price = 1/10, mssp = 1/11
 
    // This sell order above MSSP will not be matched with a call
-   create_sell_order(seller, bitusd.amount(7), core.amount(78))->id;
+   BOOST_CHECK( create_sell_order(seller, bitusd.amount(7), core.amount(78)) != nullptr );
 
    BOOST_CHECK_EQUAL( 2993, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -369,7 +369,7 @@ BOOST_AUTO_TEST_CASE( more_call_order_update_test )
       GRAPHENE_REQUIRE_THROW( borrow( bob, bitusd.amount(10000), core.amount(17500) ), fc::exception );
 
       BOOST_TEST_MESSAGE( "alice borrow using 4x collateral at 1:1 price" );
-      borrow( alice, bitusd.amount(100000), core.amount(400000) )->id;
+      BOOST_CHECK( borrow( alice, bitusd.amount(100000), core.amount(400000) ) != nullptr );
       BOOST_REQUIRE_EQUAL( get_balance( alice, bitusd ), 100000 );
       BOOST_REQUIRE_EQUAL( get_balance( alice, core ), 10000000 - 400000 );
 
@@ -476,7 +476,7 @@ BOOST_AUTO_TEST_CASE( more_call_order_update_test_after_hardfork_583 )
       GRAPHENE_REQUIRE_THROW( borrow( bob, bitusd.amount(10000), core.amount(17500) ), fc::exception );
 
       BOOST_TEST_MESSAGE( "alice borrow using 4x collateral at 1:1 price" );
-      borrow( alice, bitusd.amount(100000), core.amount(400000) )->id;
+      BOOST_CHECK( borrow( alice, bitusd.amount(100000), core.amount(400000) ) != nullptr );
       BOOST_REQUIRE_EQUAL( get_balance( alice, bitusd ), 100000 );
       BOOST_REQUIRE_EQUAL( get_balance( alice, core ), 10000000 - 400000 );
 


### PR DESCRIPTION
A sister PReq to bitshares/bitshares-fc#116, fix some warnings in the BitShares repo as well:

 - Add a virtual destructor to `peer_connection_delegate` to squelch warnings from inheritors that the class has virtual methods, but no virtual destructor
 - A few test sites reference `->id` without using it as a shorthand to crash if a newly created object is null, but this causes unused reference warnings, so make the checks explicit instead.