### PR TITLE
update doxy tag

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Bitshares-Core"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "2.0.180823"
+PROJECT_NUMBER         = "3.1.0"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a


### PR DESCRIPTION
Step 11 of https://github.com/bitshares/bitshares-core/wiki/Git-Flow#how-to-create-a-release states to manually update tag locally to generate new docs however this change is never ported back to any branch.

I think the doxy tag can be updated now IMO in `develop` as we now know:
- Next release will be named `3.1.0`.
- Next release will be a feature release, in a hardfork one this update should be probably be made in hardfork branch.
- Current develop branch is not 3.0.0 anymore, but actually it is evolving into `3.1.0`.

If agreement, i will update the wiki too.