### PR TITLE
Fix #1690 cli_wallet crashes on quit

### DIFF
--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -246,7 +246,7 @@ std::vector<fc::ip::endpoint> application_impl::resolve_string_to_ip_endpoints(c
 
 void application_impl::new_connection( const fc::http::websocket_connection_ptr& c )
 {
-   auto wsc = std::make_shared<fc::rpc::websocket_api_connection>(*c, GRAPHENE_NET_MAX_NESTED_OBJECTS);
+   auto wsc = std::make_shared<fc::rpc::websocket_api_connection>(c, GRAPHENE_NET_MAX_NESTED_OBJECTS);
    auto login = std::make_shared<graphene::app::login_api>( std::ref(*_self) );
    login->enable_api("database_api");
 

--- a/libraries/plugins/delayed_node/delayed_node_plugin.cpp
+++ b/libraries/plugins/delayed_node/delayed_node_plugin.cpp
@@ -63,7 +63,9 @@ void delayed_node_plugin::plugin_set_program_options(bpo::options_description& c
 
 void delayed_node_plugin::connect()
 {
-   my->client_connection = std::make_shared<fc::rpc::websocket_api_connection>(*my->client.connect(my->remote_endpoint), GRAPHENE_NET_MAX_NESTED_OBJECTS);
+   my->client_connection = std::make_shared<fc::rpc::websocket_api_connection>(
+                              my->client.connect(my->remote_endpoint),
+                              GRAPHENE_NET_MAX_NESTED_OBJECTS );
    my->database_api = my->client_connection->get_remote_api<graphene::app::database_api>(0);
    my->client_connection_closed = my->client_connection->closed.connect([this] {
       connection_failed();

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -83,7 +83,7 @@
 
 // explicit instantiation for later use
 namespace fc {
-	template class api<graphene::wallet::wallet_api, identity_member>;
+	template class api<graphene::wallet::wallet_api, identity_member_with_optionals>;
 }
 
 #define BRAIN_KEY_WORD_COUNT 16

--- a/programs/cli_wallet/main.cpp
+++ b/programs/cli_wallet/main.cpp
@@ -193,7 +193,7 @@ int main( int argc, char** argv )
       fc::http::websocket_client client;
       idump((wdata.ws_server));
       auto con  = client.connect( wdata.ws_server );
-      auto apic = std::make_shared<fc::rpc::websocket_api_connection>(*con, GRAPHENE_MAX_NESTED_OBJECTS);
+      auto apic = std::make_shared<fc::rpc::websocket_api_connection>(con, GRAPHENE_MAX_NESTED_OBJECTS);
 
       auto remote_api = apic->get_remote_api< login_api >(1);
       edump((wdata.ws_user)(wdata.ws_password) );
@@ -230,7 +230,7 @@ int main( int argc, char** argv )
       if( options.count("rpc-endpoint") )
       {
          _websocket_server->on_connection([&wapi]( const fc::http::websocket_connection_ptr& c ){
-            auto wsc = std::make_shared<fc::rpc::websocket_api_connection>(*c, GRAPHENE_MAX_NESTED_OBJECTS);
+            auto wsc = std::make_shared<fc::rpc::websocket_api_connection>(c, GRAPHENE_MAX_NESTED_OBJECTS);
             wsc->register_api(wapi);
             c->set_session_data( wsc );
          });
@@ -247,7 +247,7 @@ int main( int argc, char** argv )
       if( options.count("rpc-tls-endpoint") )
       {
          _websocket_tls_server->on_connection([&wapi]( const fc::http::websocket_connection_ptr& c ){
-            auto wsc = std::make_shared<fc::rpc::websocket_api_connection>(*c, GRAPHENE_MAX_NESTED_OBJECTS);
+            auto wsc = std::make_shared<fc::rpc::websocket_api_connection>(c, GRAPHENE_MAX_NESTED_OBJECTS);
             wsc->register_api(wapi);
             c->set_session_data( wsc );
          });

--- a/programs/cli_wallet/main.cpp
+++ b/programs/cli_wallet/main.cpp
@@ -277,7 +277,6 @@ int main( int argc, char** argv )
          auto sig_set = fc::set_signal_handler( [wallet_cli](int signal) {
             ilog( "Captured SIGINT not in daemon mode, exiting" );
             fc::set_signal_handler( [](int sig) {}, SIGINT ); // reinstall an empty SIGINT handler
-            fc::usleep( fc::milliseconds(100) ); // sleep a while to cleanup things
             wallet_cli->cancel();
          }, SIGINT );
 

--- a/programs/cli_wallet/main.cpp
+++ b/programs/cli_wallet/main.cpp
@@ -205,27 +205,6 @@ int main( int argc, char** argv )
 
       fc::api<wallet_api> wapi(wapiptr);
 
-      auto wallet_cli = std::make_shared<fc::rpc::cli>( GRAPHENE_MAX_NESTED_OBJECTS );
-      for( auto& name_formatter : wapiptr->get_result_formatters() )
-         wallet_cli->format_result( name_formatter.first, name_formatter.second );
-
-      boost::signals2::scoped_connection closed_connection(con->closed.connect([wallet_cli]{
-         cerr << "Server has disconnected us.\n";
-         wallet_cli->stop();
-      }));
-      (void)(closed_connection);
-
-      if( wapiptr->is_new() )
-      {
-         std::cout << "Please use the set_password method to initialize a new wallet before continuing\n";
-         wallet_cli->set_prompt( "new >>> " );
-      } else
-         wallet_cli->set_prompt( "locked >>> " );
-
-      boost::signals2::scoped_connection locked_connection(wapiptr->lock_changed.connect([&](bool locked) {
-         wallet_cli->set_prompt(  locked ? "locked >>> " : "unlocked >>> " );
-      }));
-
       auto _websocket_server = std::make_shared<fc::http::websocket_server>();
       if( options.count("rpc-endpoint") )
       {
@@ -251,7 +230,8 @@ int main( int argc, char** argv )
             wsc->register_api(wapi);
             c->set_session_data( wsc );
          });
-         ilog( "Listening for incoming TLS RPC requests on ${p}", ("p", options.at("rpc-tls-endpoint").as<string>() ));
+         ilog( "Listening for incoming TLS RPC requests on ${p}",
+               ("p", options.at("rpc-tls-endpoint").as<string>()) );
          _websocket_tls_server->listen( fc::ip::endpoint::from_string(options.at("rpc-tls-endpoint").as<string>()) );
          _websocket_tls_server->start_accept();
       }
@@ -259,7 +239,8 @@ int main( int argc, char** argv )
       auto _http_server = std::make_shared<fc::http::server>();
       if( options.count("rpc-http-endpoint" ) )
       {
-         ilog( "Listening for incoming HTTP RPC requests on ${p}", ("p", options.at("rpc-http-endpoint").as<string>() ) );
+         ilog( "Listening for incoming HTTP RPC requests on ${p}",
+               ("p", options.at("rpc-http-endpoint").as<string>()) );
          _http_server->listen( fc::ip::endpoint::from_string( options.at( "rpc-http-endpoint" ).as<string>() ) );
          //
          // due to implementation, on_request() must come AFTER listen()
@@ -276,43 +257,81 @@ int main( int argc, char** argv )
 
       if( !options.count( "daemon" ) )
       {
+         auto wallet_cli = std::make_shared<fc::rpc::cli>( GRAPHENE_MAX_NESTED_OBJECTS );
+         for( auto& name_formatter : wapiptr->get_result_formatters() )
+            wallet_cli->format_result( name_formatter.first, name_formatter.second );
+
+         if( wapiptr->is_new() )
+         {
+            std::cout << "Please use the set_password method to initialize a new wallet before continuing\n";
+            wallet_cli->set_prompt( "new >>> " );
+         }
+         else
+            wallet_cli->set_prompt( "locked >>> " );
+
+         boost::signals2::scoped_connection locked_connection( wapiptr->lock_changed.connect(
+            [wallet_cli](bool locked) {
+               wallet_cli->set_prompt( locked ? "locked >>> " : "unlocked >>> " );
+            }));
+
+         auto sig_set = fc::set_signal_handler( [wallet_cli](int signal) {
+            ilog( "Captured SIGINT not in daemon mode, exiting" );
+            fc::set_signal_handler( [](int sig) {}, SIGINT ); // reinstall an empty SIGINT handler
+            fc::usleep( fc::milliseconds(100) ); // sleep a while to cleanup things
+            wallet_cli->cancel();
+         }, SIGINT );
+
+         fc::set_signal_handler( [wallet_cli,sig_set](int signal) {
+            ilog( "Captured SIGTERM not in daemon mode, exiting" );
+            sig_set->cancel();
+            fc::set_signal_handler( [](int sig) {}, SIGINT ); // reinstall an empty SIGINT handler
+            wallet_cli->cancel();
+         }, SIGTERM );
+
+         boost::signals2::scoped_connection closed_connection( con->closed.connect( [wallet_cli,sig_set] {
+            elog( "Server has disconnected us." );
+            sig_set->cancel();
+            fc::set_signal_handler( [](int sig) {}, SIGINT ); // reinstall an empty SIGINT handler
+            wallet_cli->cancel();
+         }));
+
          wallet_cli->register_api( wapi );
          wallet_cli->start();
-
-         fc::set_signal_handler([](int signal) {
-            ilog( "Captured SIGINT not in daemon mode" );
-            fclose(stdin);
-         }, SIGINT);
-
-         fc::set_signal_handler([](int signal) {
-            ilog( "Captured SIGTERM not in daemon mode" );
-            fclose(stdin);
-         }, SIGTERM);
-
          wallet_cli->wait();
+
+         locked_connection.disconnect();
+         closed_connection.disconnect();
       }
       else
       {
-        fc::promise<int>::ptr exit_promise = new fc::promise<int>("UNIX Signal Handler");
-        fc::set_signal_handler([&exit_promise](int signal) {
-           exit_promise->set_value(signal);
-        }, SIGINT);
+         fc::promise<int>::ptr exit_promise = new fc::promise<int>("UNIX Signal Handler");
 
-        fc::set_signal_handler([&exit_promise](int signal) {
-           exit_promise->set_value(signal);
-        }, SIGTERM);
+         fc::set_signal_handler( [&exit_promise](int signal) {
+            ilog( "Captured SIGINT in daemon mode, exiting" );
+            exit_promise->set_value(signal);
+         }, SIGINT );
 
-        ilog( "Entering Daemon Mode, ^C to exit" );
-        exit_promise->wait();
+         fc::set_signal_handler( [&exit_promise](int signal) {
+            ilog( "Captured SIGTERM in daemon mode, exiting" );
+            exit_promise->set_value(signal);
+         }, SIGTERM );
+
+         boost::signals2::scoped_connection closed_connection( con->closed.connect( [&exit_promise] {
+            elog( "Server has disconnected us." );
+            exit_promise->set_value(0);
+         }));
+
+         ilog( "Entering Daemon Mode, ^C to exit" );
+         exit_promise->wait();
+
+         closed_connection.disconnect();
       }
 
       wapi->save_wallet_file(wallet_file.generic_string());
-      locked_connection.disconnect();
-      closed_connection.disconnect();
    }
    catch ( const fc::exception& e )
    {
-      std::cout << e.to_detail_string() << "\n";
+      std::cerr << e.to_detail_string() << "\n";
       return -1;
    }
    return 0;

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -217,7 +217,8 @@ public:
       wallet_data.ws_password = "";
       websocket_connection  = websocket_client.connect( wallet_data.ws_server );
 
-      api_connection = std::make_shared<fc::rpc::websocket_api_connection>(*websocket_connection, GRAPHENE_MAX_NESTED_OBJECTS);
+      api_connection = std::make_shared<fc::rpc::websocket_api_connection>( websocket_connection,
+                                                                            GRAPHENE_MAX_NESTED_OBJECTS );
 
       remote_login_api = api_connection->get_remote_api< graphene::app::login_api >(1);
       BOOST_CHECK(remote_login_api->login( wallet_data.ws_user, wallet_data.ws_password ) );


### PR DESCRIPTION
For https://github.com/bitshares/bitshares-core/issues/1690.

Bumped FC
* support optional parameters for API https://github.com/bitshares/bitshares-fc/pull/126
* requires C++14 https://github.com/bitshares/bitshares-fc/pull/131
* CLI fixes and improvements https://github.com/bitshares/bitshares-fc/pull/119
  * pressing TAB key will complete a command as long as possible
  * Increased CLI command history buffer size to 256 (from 15)
  * CLI no longer stores continuous duplicate commands to history, so no longer need to press UP key several times to find a different command
  * pressing Ctrl+C will quit CLI cleanly at most time
  * sending SIGINT or SIGTERM to CLI will terminate it cleanly at most time
  * when CLI got disconnected by the API node, it will quit cleanly at most time
* fix a minor memory leak issue https://github.com/bitshares/bitshares-fc/pull/130
* code cleanup https://github.com/bitshares/bitshares-fc/pull/118

By the way,
* do you know we can press Ctrl+R to search in command history? Although it's a bit buggy.
* Do we want a feature that saves command history to a file e.g. on quit or on the fly and load it on next startup? (we don't have this feature yet)