### PR TITLE
Fix Windows build errors

### DIFF
--- a/libraries/chain/db_market.cpp
+++ b/libraries/chain/db_market.cpp
@@ -1262,7 +1262,7 @@ asset database::pay_market_fees(const account_object& seller, const asset_object
 
                if ( referrer_rewards_value > 0 && is_authorized_asset(*this, seller.referrer(*this), recv_asset))
                {
-                  FC_ASSERT ( referrer_rewards_value <= reward.amount, "Referrer reward shouldn't be greater than total reward" );
+                  FC_ASSERT ( referrer_rewards_value <= reward.amount.value, "Referrer reward shouldn't be greater than total reward" );
                   const asset referrer_reward = recv_asset.amount(referrer_rewards_value);
                   registrar_reward -= referrer_reward;
                   deposit_market_fee_vesting_balance(seller.referrer, referrer_reward);

--- a/tests/tests/htlc_tests.cpp
+++ b/tests/tests/htlc_tests.cpp
@@ -58,7 +58,7 @@ BOOST_FIXTURE_TEST_SUITE( htlc_tests, database_fixture )
 
 void generate_random_preimage(uint16_t key_size, std::vector<char>& vec)
 {
-	std::independent_bits_engine<std::default_random_engine, CHAR_BIT, unsigned char> rbe;
+	std::independent_bits_engine<std::default_random_engine, CHAR_BIT, unsigned int> rbe;
 	std::generate(begin(vec), end(vec), std::ref(rbe));
 	return;
 }


### PR DESCRIPTION
Fixes #1593 

With these changes (and the ones already merged to bitshares-fc:master), bitshares-core now builds on Windows 10. 