### PR TITLE
get_object return first item of vector

### DIFF
--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -3565,7 +3565,7 @@ string wallet_api::serialize_transaction( signed_transaction tx )const
 
 variant wallet_api::get_object( object_id_type id ) const
 {
-   return my->_remote_db->get_objects({id});
+   return my->_remote_db->get_objects({id}).front();
 }
 
 string wallet_api::get_wallet_filename() const


### PR DESCRIPTION
The return value of `wallet_api::get_object` is a variant with a vector inside. This is because the wallet_api calls the database function `get_objects` that accept several ids and response with a vector of them.

The wallet function version is modified to only be called with 1 id and will always return 1 result. The result should be the variant with just the object and not the variant with the vector plus the object as the first item.

This pull request fix this issue and make the command more consistent with other variants like `info()` or `about()`.

This pull can break client applications but i think it is an error in the core side that should be fixed.
