### PR TITLE
1196 serialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ LIST(APPEND BOOST_COMPONENTS thread
                              chrono
                              unit_test_framework
                              context)
+# boost::endian is also required, but FindBoost can't handle header-only libs
 SET( Boost_USE_STATIC_LIBS ON CACHE STRING "ON or OFF" )
 
 IF( WIN32 )

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ We recommend building on Ubuntu 16.04 LTS (64-bit)
     git submodule sync --recursive
     git submodule update --init --recursive
 
-**NOTE:** Versions of [Boost](http://www.boost.org/) 1.57 through 1.69 are supported. Newer versions may work, but
+**NOTE:** Versions of [Boost](http://www.boost.org/) 1.58 through 1.69 are supported. Newer versions may work, but
 have not been tested. If your system came pre-installed with a version of Boost that you do not wish to use, you may
 manually build your preferred version and use it with BitShares by specifying it on the CMake command line.
 

--- a/libraries/chain/block_database.cpp
+++ b/libraries/chain/block_database.cpp
@@ -24,14 +24,19 @@
 #include <graphene/chain/block_database.hpp>
 #include <graphene/protocol/fee_schedule.hpp>
 #include <fc/io/raw.hpp>
+#include <boost/endian/buffers.hpp>
 
 namespace graphene { namespace chain {
 
 struct index_entry
 {
-   uint64_t      block_pos = 0;
-   uint32_t      block_size = 0;
-   block_id_type block_id;
+   index_entry() {
+      block_pos = 0;
+      block_size = 0;
+   };
+   boost::endian::little_uint64_buf_t block_pos;
+   boost::endian::little_uint32_buf_t block_size;
+   block_id_type                      block_id;
 };
  }}
 FC_REFLECT( graphene::chain::index_entry, (block_pos)(block_size)(block_id) );
@@ -125,7 +130,7 @@ bool block_database::contains( const block_id_type& id )const
    _block_num_to_pos.seekg( index_pos );
    _block_num_to_pos.read( (char*)&e, sizeof(e) );
 
-   return e.block_id == id && e.block_size > 0;
+   return e.block_id == id && e.block_size.value() > 0;
 }
 
 block_id_type block_database::fetch_block_id( uint32_t block_num )const
@@ -159,10 +164,10 @@ optional<signed_block> block_database::fetch_optional( const block_id_type& id )
 
       if( e.block_id != id ) return optional<signed_block>();
 
-      vector<char> data( e.block_size );
-      _blocks.seekg( e.block_pos );
-      if (e.block_size)
-         _blocks.read( data.data(), e.block_size );
+      vector<char> data( e.block_size.value() );
+      _blocks.seekg( e.block_pos.value() );
+      if (e.block_size.value())
+         _blocks.read( data.data(), e.block_size.value() );
       auto result = fc::raw::unpack<signed_block>(data);
       FC_ASSERT( result.id() == e.block_id );
       return result;
@@ -189,9 +194,9 @@ optional<signed_block> block_database::fetch_by_number( uint32_t block_num )cons
       _block_num_to_pos.seekg( index_pos, _block_num_to_pos.beg );
       _block_num_to_pos.read( (char*)&e, sizeof(e) );
 
-      vector<char> data( e.block_size );
-      _blocks.seekg( e.block_pos );
-      _blocks.read( data.data(), e.block_size );
+      vector<char> data( e.block_size.value() );
+      _blocks.seekg( e.block_pos.value() );
+      _blocks.read( data.data(), e.block_size.value() );
       auto result = fc::raw::unpack<signed_block>(data);
       FC_ASSERT( result.id() == e.block_id );
       return result;
@@ -224,14 +229,14 @@ optional<index_entry> block_database::last_index_entry()const {
          pos -= sizeof(index_entry);
          _block_num_to_pos.seekg( pos );
          _block_num_to_pos.read( (char*)&e, sizeof(e) );
-         if( _block_num_to_pos.gcount() == sizeof(e) && e.block_size > 0
-                && int64_t(e.block_pos + e.block_size) <= blocks_size )
+         if( _block_num_to_pos.gcount() == sizeof(e) && e.block_size.value() > 0
+                && int64_t(e.block_pos.value() + e.block_size.value()) <= blocks_size )
             try
             {
-               vector<char> data( e.block_size );
-               _blocks.seekg( e.block_pos );
-               _blocks.read( data.data(), e.block_size );
-               if( _blocks.gcount() == long(e.block_size) )
+               vector<char> data( e.block_size.value() );
+               _blocks.seekg( e.block_pos.value() );
+               _blocks.read( data.data(), e.block_size.value() );
+               if( _blocks.gcount() == long(e.block_size.value()) )
                {
                   const signed_block block = fc::raw::unpack<signed_block>(data);
                   if( block.id() == e.block_id )

--- a/libraries/chain/db_block.cpp
+++ b/libraries/chain/db_block.cpp
@@ -38,6 +38,7 @@
 
 #include <graphene/protocol/fee_schedule.hpp>
 
+#include <fc/io/raw.hpp>
 #include <fc/thread/parallel.hpp>
 
 namespace graphene { namespace chain {
@@ -661,7 +662,7 @@ processed_transaction database::_apply_transaction(const signed_transaction& trx
          const auto& tapos_block_summary = block_summary_id_type( trx.ref_block_num )(*this);
 
          //Verify TaPoS block summary has correct ID prefix, and that this block's time is not past the expiration
-         FC_ASSERT( trx.ref_block_prefix == tapos_block_summary.block_id._hash[1] );
+         FC_ASSERT( trx.ref_block_prefix == tapos_block_summary.block_id._hash[1].value() );
       }
 
       fc::time_point_sec now = head_block_time();

--- a/libraries/chain/include/graphene/chain/global_property_object.hpp
+++ b/libraries/chain/include/graphene/chain/global_property_object.hpp
@@ -22,12 +22,13 @@
  * THE SOFTWARE.
  */
 #pragma once
-#include <fc/uint128.hpp>
 
 #include <graphene/protocol/chain_parameters.hpp>
 #include <graphene/chain/types.hpp>
 #include <graphene/chain/database.hpp>
 #include <graphene/db/object.hpp>
+
+#include <fc/uint128.hpp>
 
 namespace graphene { namespace chain {
 

--- a/libraries/net/include/graphene/net/message.hpp
+++ b/libraries/net/include/graphene/net/message.hpp
@@ -22,6 +22,7 @@
  * THE SOFTWARE.
  */
 #pragma once
+#include <boost/endian/buffers.hpp>
 #include <fc/array.hpp>
 #include <fc/io/varint.hpp>
 #include <fc/network/ip.hpp>
@@ -39,8 +40,8 @@ namespace graphene { namespace net {
    */
   struct message_header
   {
-     uint32_t  size;   // number of bytes in message, capped at MAX_MESSAGE_SIZE
-     uint32_t  msg_type;  // every channel gets a 16 bit message type specifier
+     boost::endian::little_uint32_buf_t size;   // number of bytes in message, capped at MAX_MESSAGE_SIZE
+     boost::endian::little_uint32_buf_t msg_type;  // every channel gets a 16 bit message type specifier
   };
 
   typedef fc::uint160_t message_hash_type;
@@ -85,7 +86,7 @@ namespace graphene { namespace net {
      T as()const 
      {
          try {
-          FC_ASSERT( msg_type == T::type );
+          FC_ASSERT( msg_type.value() == T::type );
           T tmp;
           if( data.size() )
           {
@@ -103,7 +104,7 @@ namespace graphene { namespace net {
               "error unpacking network message as a '${type}'  ${x} !=? ${msg_type}", 
               ("type", fc::get_typename<T>::name() )
               ("x", T::type)
-              ("msg_type", msg_type)
+              ("msg_type", msg_type.value())
               );
      }
   };

--- a/libraries/protocol/block.cpp
+++ b/libraries/protocol/block.cpp
@@ -21,9 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <boost/endian/conversion.hpp>
 #include <graphene/protocol/block.hpp>
 #include <fc/io/raw.hpp>
-#include <fc/bitutil.hpp>
 #include <algorithm>
 
 namespace graphene { namespace protocol {
@@ -34,7 +34,7 @@ namespace graphene { namespace protocol {
 
    uint32_t block_header::num_from_id(const block_id_type& id)
    {
-      return fc::endian_reverse_u32(id._hash[0]);
+      return boost::endian::big_to_native(id._hash[0]);
    }
 
    const block_id_type& signed_block_header::id()const
@@ -42,7 +42,7 @@ namespace graphene { namespace protocol {
       if( !_block_id._hash[0] )
       {
          auto tmp = fc::sha224::hash( *this );
-         tmp._hash[0] = fc::endian_reverse_u32(block_num()); // store the block num in the ID, 160 bits is plenty for the hash
+         tmp._hash[0] = boost::endian::native_to_big(block_num()); // store the block num in the ID, 160 bits is plenty for the hash
          static_assert( sizeof(tmp._hash[0]) == 4, "should be 4 bytes" );
          memcpy(_block_id._hash, tmp._hash, std::min(sizeof(_block_id), sizeof(tmp)));
       }

--- a/libraries/protocol/block.cpp
+++ b/libraries/protocol/block.cpp
@@ -34,15 +34,15 @@ namespace graphene { namespace protocol {
 
    uint32_t block_header::num_from_id(const block_id_type& id)
    {
-      return boost::endian::big_to_native(id._hash[0]);
+      return boost::endian::endian_reverse(id._hash[0].value());
    }
 
    const block_id_type& signed_block_header::id()const
    {
-      if( !_block_id._hash[0] )
+      if( !_block_id._hash[0].value() )
       {
          auto tmp = fc::sha224::hash( *this );
-         tmp._hash[0] = boost::endian::native_to_big(block_num()); // store the block num in the ID, 160 bits is plenty for the hash
+         tmp._hash[0] = boost::endian::endian_reverse(block_num()); // store the block num in the ID, 160 bits is plenty for the hash
          static_assert( sizeof(tmp._hash[0]) == 4, "should be 4 bytes" );
          memcpy(_block_id._hash, tmp._hash, std::min(sizeof(_block_id), sizeof(tmp)));
       }
@@ -72,7 +72,7 @@ namespace graphene { namespace protocol {
       if( transactions.size() == 0 ) 
          return empty_checksum;
 
-      if( !_calculated_merkle_root._hash[0] )
+      if( !_calculated_merkle_root._hash[0].value() )
       {
          vector<digest_type> ids;
          ids.resize( transactions.size() );

--- a/libraries/protocol/include/graphene/protocol/address.hpp
+++ b/libraries/protocol/include/graphene/protocol/address.hpp
@@ -62,12 +62,6 @@ namespace graphene { namespace protocol {
 
        explicit operator std::string()const; ///< converts to base58 + checksum
 
-       friend size_t hash_value( const address& v ) { 
-          const void* tmp = static_cast<const void*>(v.addr._hash+2);
-
-          const size_t* tmp2 = reinterpret_cast<const size_t*>(tmp);
-          return *tmp2;
-       }
        fc::ripemd160 addr;
    };
    inline bool operator == ( const address& a, const address& b ) { return a.addr == b.addr; }
@@ -80,19 +74,6 @@ namespace fc
 {
    void to_variant( const graphene::protocol::address& var,  fc::variant& vo, uint32_t max_depth = 1 );
    void from_variant( const fc::variant& var,  graphene::protocol::address& vo, uint32_t max_depth = 1 );
-}
-
-namespace std
-{
-   template<>
-   struct hash<graphene::protocol::address>
-   {
-       public:
-         size_t operator()(const graphene::protocol::address &a) const
-         {
-            return (uint64_t(a.addr._hash[0])<<32) | uint64_t( a.addr._hash[0] );
-         }
-   };
 }
 
 #include <fc/reflect/reflect.hpp>

--- a/libraries/protocol/memo.cpp
+++ b/libraries/protocol/memo.cpp
@@ -22,6 +22,7 @@
  * THE SOFTWARE.
  */
 #include <graphene/protocol/memo.hpp>
+#include <boost/endian/conversion.hpp>
 #include <fc/crypto/aes.hpp>
 
 namespace graphene { namespace protocol {
@@ -35,7 +36,7 @@ void memo_data::set_message(const fc::ecc::private_key& priv, const fc::ecc::pub
       to = pub;
       if( custom_nonce == 0 )
       {
-         uint64_t entropy = fc::sha224::hash(fc::ecc::private_key::generate())._hash[0];
+         uint64_t entropy = fc::sha224::hash(fc::ecc::private_key::generate())._hash[0].value();
          entropy <<= 32;
          entropy                                                     &= 0xff00000000000000;
          nonce = (fc::time_point::now().time_since_epoch().count()   &  0x00ffffffffffffff) | entropy;
@@ -43,7 +44,7 @@ void memo_data::set_message(const fc::ecc::private_key& priv, const fc::ecc::pub
          nonce = custom_nonce;
       auto secret = priv.get_shared_secret(pub);
       auto nonce_plus_secret = fc::sha512::hash(fc::to_string(nonce) + secret.str());
-      string text = memo_message(digest_type::hash(msg)._hash[0], msg).serialize();
+      string text = memo_message(digest_type::hash(msg)._hash[0].value(), msg).serialize();
       message = fc::aes_encrypt( nonce_plus_secret, vector<char>(text.begin(), text.end()) );
    }
    else
@@ -62,7 +63,7 @@ string memo_data::get_message(const fc::ecc::private_key& priv,
       auto nonce_plus_secret = fc::sha512::hash(fc::to_string(nonce) + secret.str());
       auto plain_text = fc::aes_decrypt( nonce_plus_secret, message );
       auto result = memo_message::deserialize(string(plain_text.begin(), plain_text.end()));
-      FC_ASSERT( result.checksum == uint32_t(digest_type::hash(result.text)._hash[0]) );
+      FC_ASSERT( result.checksum == (uint32_t)digest_type::hash(result.text)._hash[0].value() );
       return result.text;
    }
    else
@@ -74,7 +75,7 @@ string memo_data::get_message(const fc::ecc::private_key& priv,
 string memo_message::serialize() const
 {
    auto serial_checksum = string(sizeof(checksum), ' ');
-   (uint32_t&)(*serial_checksum.data()) = checksum;
+   (uint32_t&)(*serial_checksum.data()) = boost::endian::native_to_little(checksum);
    return serial_checksum + text;
 }
 
@@ -82,7 +83,7 @@ memo_message memo_message::deserialize(const string& serial)
 {
    memo_message result;
    FC_ASSERT( serial.size() >= sizeof(result.checksum) );
-   result.checksum = ((uint32_t&)(*serial.data()));
+   result.checksum = boost::endian::little_to_native((uint32_t&)(*serial.data()));
    result.text = serial.substr(sizeof(result.checksum));
    return result;
 }

--- a/libraries/protocol/transaction.cpp
+++ b/libraries/protocol/transaction.cpp
@@ -25,7 +25,6 @@
 #include <graphene/protocol/fee_schedule.hpp>
 #include <graphene/protocol/block.hpp>
 #include <graphene/protocol/exceptions.hpp>
-#include <boost/endian/conversion.hpp>
 #include <fc/io/raw.hpp>
 #include <algorithm>
 
@@ -94,8 +93,8 @@ void transaction::set_expiration( fc::time_point_sec expiration_time )
 
 void transaction::set_reference_block( const block_id_type& reference_block )
 {
-   ref_block_num = boost::endian::big_to_native(reference_block._hash[0]);
-   ref_block_prefix = reference_block._hash[1];
+   ref_block_num = boost::endian::endian_reverse(reference_block._hash[0].value());
+   ref_block_prefix = reference_block._hash[1].value();
 }
 
 void transaction::get_required_authorities( flat_set<account_id_type>& active,
@@ -400,7 +399,7 @@ set<public_key_type> signed_transaction::minimize_required_signatures(
 
 const transaction_id_type& precomputable_transaction::id()const
 {
-   if( !_tx_id_buffer._hash[0] )
+   if( !_tx_id_buffer._hash[0].value() )
       transaction::id();
    return _tx_id_buffer;
 }

--- a/libraries/protocol/transaction.cpp
+++ b/libraries/protocol/transaction.cpp
@@ -25,8 +25,8 @@
 #include <graphene/protocol/fee_schedule.hpp>
 #include <graphene/protocol/block.hpp>
 #include <graphene/protocol/exceptions.hpp>
+#include <boost/endian/conversion.hpp>
 #include <fc/io/raw.hpp>
-#include <fc/bitutil.hpp>
 #include <algorithm>
 
 namespace graphene { namespace protocol {
@@ -94,7 +94,7 @@ void transaction::set_expiration( fc::time_point_sec expiration_time )
 
 void transaction::set_reference_block( const block_id_type& reference_block )
 {
-   ref_block_num = fc::endian_reverse_u32(reference_block._hash[0]);
+   ref_block_num = boost::endian::big_to_native(reference_block._hash[0]);
    ref_block_prefix = reference_block._hash[1];
 }
 

--- a/libraries/protocol/types.cpp
+++ b/libraries/protocol/types.cpp
@@ -51,7 +51,7 @@ namespace graphene { namespace protocol {
        auto bin = fc::from_base58( base58str.substr( prefix_len ) );
        auto bin_key = fc::raw::unpack<binary_key>(bin);
        key_data = bin_key.data;
-       FC_ASSERT( fc::ripemd160::hash( key_data.data, key_data.size() )._hash[0] == bin_key.check );
+       FC_ASSERT( fc::ripemd160::hash( key_data.data, key_data.size() )._hash[0].value() == bin_key.check );
     };
 
     public_key_type::operator fc::ecc::public_key_data() const
@@ -68,7 +68,7 @@ namespace graphene { namespace protocol {
     {
        binary_key k;
        k.data = key_data;
-       k.check = fc::ripemd160::hash( k.data.data, k.data.size() )._hash[0];
+       k.check = fc::ripemd160::hash( k.data.data, k.data.size() )._hash[0].value();
        auto data = fc::raw::pack( k );
        return GRAPHENE_ADDRESS_PREFIX + fc::to_base58( data.data(), data.size() );
     }

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -170,7 +170,7 @@ optional<T> maybe_id( const string& name_or_id )
 
 string address_to_shorthash( const address& addr )
 {
-   uint32_t x = addr.addr._hash[0];
+   uint32_t x = addr.addr._hash[0].value();
    static const char hd[] = "0123456789abcdef";
    string result;
 
@@ -4800,7 +4800,7 @@ blind_confirmation wallet_api::blind_transfer_help( string from_key_or_label,
       conf_output.decrypted_memo.amount = change;
       conf_output.decrypted_memo.blinding_factor = change_blind_factor;
       conf_output.decrypted_memo.commitment = change_out.commitment;
-      conf_output.decrypted_memo.check   = from_secret._hash[0];
+      conf_output.decrypted_memo.check   = from_secret._hash[0].value();
       conf_output.confirmation.one_time_key = one_time_key.get_public_key();
       conf_output.confirmation.to = from_key;
       conf_output.confirmation.encrypted_memo = fc::aes_encrypt( from_secret, fc::raw::pack( conf_output.decrypted_memo ) );
@@ -4818,7 +4818,7 @@ blind_confirmation wallet_api::blind_transfer_help( string from_key_or_label,
    conf_output.decrypted_memo.amount = amount;
    conf_output.decrypted_memo.blinding_factor = blind_factor;
    conf_output.decrypted_memo.commitment = to_out.commitment;
-   conf_output.decrypted_memo.check   = secret._hash[0];
+   conf_output.decrypted_memo.check   = secret._hash[0].value();
    conf_output.confirmation.one_time_key = one_time_key.get_public_key();
    conf_output.confirmation.to = to_key;
    conf_output.confirmation.encrypted_memo = fc::aes_encrypt( secret, fc::raw::pack( conf_output.decrypted_memo ) );
@@ -4906,7 +4906,7 @@ blind_confirmation wallet_api::transfer_to_blind( string from_account_id_or_name
       conf_output.decrypted_memo.amount = amount;
       conf_output.decrypted_memo.blinding_factor = blind_factor;
       conf_output.decrypted_memo.commitment = out.commitment;
-      conf_output.decrypted_memo.check   = secret._hash[0];
+      conf_output.decrypted_memo.check   = secret._hash[0].value();
       conf_output.confirmation.one_time_key = one_time_key.get_public_key();
       conf_output.confirmation.to = to_key;
       conf_output.confirmation.encrypted_memo = fc::aes_encrypt( secret, fc::raw::pack( conf_output.decrypted_memo ) );

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -55,7 +55,6 @@
 #include <fc/network/http/websocket.hpp>
 #include <fc/rpc/cli.hpp>
 #include <fc/rpc/websocket_api.hpp>
-#include <fc/crypto/aes.hpp>
 #include <fc/crypto/hex.hpp>
 #include <fc/thread/mutex.hpp>
 #include <fc/thread/scoped_lock.hpp>
@@ -74,6 +73,8 @@
 #include <graphene/wallet/api_documentation.hpp>
 #include <graphene/wallet/reflect_util.hpp>
 #include <graphene/debug_witness/debug_api.hpp>
+
+#include <fc/crypto/aes.hpp>
 
 #ifndef WIN32
 # include <sys/types.h>

--- a/programs/network_mapper/network_mapper.cpp
+++ b/programs/network_mapper/network_mapper.cpp
@@ -74,8 +74,9 @@ public:
   {
     graphene::net::message_hash_type message_hash = received_message.id();
     dlog( "handling message ${type} ${hash} size ${size} from peer ${endpoint}",
-          ( "type", graphene::net::core_message_type_enum(received_message.msg_type ) )("hash", message_hash )("size", received_message.size )("endpoint", originating_peer->get_remote_endpoint() ) );
-    switch ( received_message.msg_type )
+          ( "type", graphene::net::core_message_type_enum(received_message.msg_type.value() ) )("hash", message_hash )
+          ("size", received_message.size )("endpoint", originating_peer->get_remote_endpoint() ) );
+    switch ( received_message.msg_type.value() )
     {
     case graphene::net::core_message_type_enum::hello_message_type:
       on_hello_message( originating_peer, received_message.as<graphene::net::hello_message>() );

--- a/tests/generate_empty_blocks/main.cpp
+++ b/tests/generate_empty_blocks/main.cpp
@@ -131,14 +131,14 @@ int main( int argc, char** argv )
          signed_block b = db.generate_block(db.get_slot_time(slot), db.get_scheduled_witness(slot), nathan_priv_key, database::skip_nothing);
          FC_ASSERT( db.head_block_id() == b.id() );
          fc::sha256 h = b.digest();
-         uint64_t rand = h._hash[0];
+         uint64_t rand = h._hash[0].value();
          slot = 1;
          while(true)
          {
             if( (rand % 100) < miss_rate )
             {
                slot++;
-               rand = (rand/100) ^ h._hash[slot&3];
+               rand = (rand/100) ^ h._hash[slot&3].value();
                missed++;
             }
             else

--- a/tests/tests/app_util_tests.cpp
+++ b/tests/tests/app_util_tests.cpp
@@ -24,9 +24,9 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <graphene/app/util.hpp>
-
 #include "../common/database_fixture.hpp"
+
+#include <graphene/app/util.hpp>
 
 using namespace graphene::chain;
 using namespace graphene::chain::test;

--- a/tests/tests/fee_tests.cpp
+++ b/tests/tests/fee_tests.cpp
@@ -22,8 +22,6 @@
  * THE SOFTWARE.
  */
 
-#include <fc/uint128.hpp>
-
 #include <graphene/chain/hardfork.hpp>
 
 #include <graphene/chain/fba_accumulator_id.hpp>
@@ -37,6 +35,8 @@
 #include <boost/test/unit_test.hpp>
 
 #include "../common/database_fixture.hpp"
+
+#include <fc/uint128.hpp>
 
 using namespace graphene::chain;
 using namespace graphene::chain::test;


### PR DESCRIPTION
Fixes #1196 
Requires https://github.com/bitshares/bitshares-fc/pull/122

Tested on an emulated big-endian PPC64 system - compiles, syncs, replays, tests ok, snapshot comparison at block 2,000,000 without plugins produced identical results. (Emulation is dead slow, didn't test a full replay.)

**Note:** this bumps the minimum required boost version to 1.58.