### PR TITLE
add genesis data to es_objects

### DIFF
--- a/libraries/plugins/es_objects/es_objects.cpp
+++ b/libraries/plugins/es_objects/es_objects.cpp
@@ -322,13 +322,13 @@ void es_objects_plugin::plugin_initialize(const boost::program_options::variable
       }
    });
 
-   database().new_objects.connect([&]( const vector<object_id_type>& ids, const flat_set<account_id_type>& impacted_accounts ) {
+   database().new_objects.connect([this]( const vector<object_id_type>& ids, const flat_set<account_id_type>& impacted_accounts ) {
       if(!my->index_database(ids, "create"))
       {
          FC_THROW_EXCEPTION(graphene::chain::plugin_exception, "Error creating object from ES database, we are going to keep trying.");
       }
    });
-   database().changed_objects.connect([&]( const vector<object_id_type>& ids, const flat_set<account_id_type>& impacted_accounts ) {
+   database().changed_objects.connect([this]( const vector<object_id_type>& ids, const flat_set<account_id_type>& impacted_accounts ) {
       if(!my->index_database(ids, "update"))
       {
          FC_THROW_EXCEPTION(graphene::chain::plugin_exception, "Error updating object from ES database, we are going to keep trying.");

--- a/libraries/plugins/es_objects/es_objects.cpp
+++ b/libraries/plugins/es_objects/es_objects.cpp
@@ -68,7 +68,6 @@ class es_objects_plugin_impl
       vector<std::string> prepare;
 
       bool _es_objects_keep_only_current = true;
-      bool _es_objects_load_genesis = true;
 
       uint32_t block_number;
       fc::time_point_sec block_time;

--- a/libraries/plugins/es_objects/es_objects.cpp
+++ b/libraries/plugins/es_objects/es_objects.cpp
@@ -80,52 +80,49 @@ class es_objects_plugin_impl
 
 bool es_objects_plugin_impl::genesis()
 {
-   if(_es_objects_load_genesis) {
 
-      ilog("elasticsearch OBJECTS: inserting data from genesis");
+   ilog("elasticsearch OBJECTS: inserting data from genesis");
 
-      graphene::chain::database &db = _self.database();
+   graphene::chain::database &db = _self.database();
 
-      block_number = db.head_block_num();
-      block_time = db.head_block_time();
+   block_number = db.head_block_num();
+   block_time = db.head_block_time();
 
-      if (_es_objects_accounts) {
-         auto &index_accounts = db.get_index(1, 2);
-         index_accounts.inspect_all_objects([this, &db](const graphene::db::object &o) {
-            auto obj = db.find_object(o.id);
-            auto a = static_cast<const account_object *>(obj);
-            prepareTemplate<account_object>(*a, "account");
-         });
-      }
-      if (_es_objects_assets) {
-         auto &index_assets = db.get_index(1, 3);
-         index_assets.inspect_all_objects([this, &db](const graphene::db::object &o) {
-            auto obj = db.find_object(o.id);
-            auto a = static_cast<const asset_object *>(obj);
-            prepareTemplate<asset_object>(*a, "asset");
-         });
-      }
-      if (_es_objects_balances) {
-         auto &index_balances = db.get_index(2, 5);
-         index_balances.inspect_all_objects([this, &db](const graphene::db::object &o) {
-            auto obj = db.find_object(o.id);
-            auto b = static_cast<const account_balance_object *>(obj);
-            prepareTemplate<account_balance_object>(*b, "balance");
-         });
-      }
-
-      graphene::utilities::ES es;
-      es.curl = curl;
-      es.bulk_lines = bulk;
-      es.elasticsearch_url = _es_objects_elasticsearch_url;
-      es.auth = _es_objects_auth;
-      if (!graphene::utilities::SendBulk(std::move(es)))
-         FC_THROW_EXCEPTION(graphene::chain::plugin_exception, "Error inserting genesis data.");
-      else {
-         bulk.clear();
-         return true;
-      }
+   if (_es_objects_accounts) {
+      auto &index_accounts = db.get_index(1, 2);
+      index_accounts.inspect_all_objects([this, &db](const graphene::db::object &o) {
+         auto obj = db.find_object(o.id);
+         auto a = static_cast<const account_object *>(obj);
+         prepareTemplate<account_object>(*a, "account");
+      });
    }
+   if (_es_objects_assets) {
+      auto &index_assets = db.get_index(1, 3);
+      index_assets.inspect_all_objects([this, &db](const graphene::db::object &o) {
+         auto obj = db.find_object(o.id);
+         auto a = static_cast<const asset_object *>(obj);
+         prepareTemplate<asset_object>(*a, "asset");
+      });
+   }
+   if (_es_objects_balances) {
+      auto &index_balances = db.get_index(2, 5);
+      index_balances.inspect_all_objects([this, &db](const graphene::db::object &o) {
+         auto obj = db.find_object(o.id);
+         auto b = static_cast<const account_balance_object *>(obj);
+         prepareTemplate<account_balance_object>(*b, "balance");
+      });
+   }
+
+   graphene::utilities::ES es;
+   es.curl = curl;
+   es.bulk_lines = bulk;
+   es.elasticsearch_url = _es_objects_elasticsearch_url;
+   es.auth = _es_objects_auth;
+   if (!graphene::utilities::SendBulk(std::move(es)))
+      FC_THROW_EXCEPTION(graphene::chain::plugin_exception, "Error inserting genesis data.");
+   else
+      bulk.clear();
+
    return true;
 }
 
@@ -313,8 +310,6 @@ void es_objects_plugin::plugin_set_program_options(
          ("es-objects-index-prefix", boost::program_options::value<std::string>(), "Add a prefix to the index(objects-)")
          ("es-objects-keep-only-current", boost::program_options::value<bool>(), "Keep only current state of the objects(true)")
          ("es-objects-start-es-after-block", boost::program_options::value<uint32_t>(), "Start doing ES job after block(0)")
-         ("es-objects-load-genesis", boost::program_options::value<bool>(), "Index whatever is in the database on startup."
-                                                                            "Used to load genesis data into ES(true)")
          ;
    cfg.add(cli);
 }
@@ -386,9 +381,6 @@ void es_objects_plugin::plugin_initialize(const boost::program_options::variable
    }
    if (options.count("es-objects-start-es-after-block")) {
       my->_es_objects_start_es_after_block = options["es-objects-start-es-after-block"].as<uint32_t>();
-   }
-   if (options.count("es-objects-load-genesis")) {
-      my->_es_objects_load_genesis = options["es-objects-load-genesis"].as<bool>();
    }
 }
 

--- a/libraries/plugins/es_objects/es_objects.cpp
+++ b/libraries/plugins/es_objects/es_objects.cpp
@@ -315,7 +315,7 @@ void es_objects_plugin::plugin_set_program_options(
 
 void es_objects_plugin::plugin_initialize(const boost::program_options::variables_map& options)
 {
-   database().applied_block.connect([&](const signed_block &b) {
+   database().applied_block.connect([this](const signed_block &b) {
       if(b.block_num() == 1) {
          if (!my->genesis())
             FC_THROW_EXCEPTION(graphene::chain::plugin_exception, "Error populating genesis data.");

--- a/libraries/plugins/es_objects/es_objects.cpp
+++ b/libraries/plugins/es_objects/es_objects.cpp
@@ -84,12 +84,8 @@ void es_objects_plugin_impl::genesis()
 
    graphene::chain::database &db = _self.database();
 
-   block_number = 1;
-   auto block1 = db.fetch_block_by_number(1);
-   if(block1.valid())
-      block_time = block1->timestamp;
-   else
-      block_time = db.head_block_time();
+   block_number = db.head_block_num();
+   block_time = db.head_block_time();
 
    if(_es_objects_accounts) {
       auto& index_accounts = db.get_index( 1, 2 );
@@ -316,7 +312,8 @@ void es_objects_plugin::plugin_set_program_options(
          ("es-objects-index-prefix", boost::program_options::value<std::string>(), "Add a prefix to the index(objects-)")
          ("es-objects-keep-only-current", boost::program_options::value<bool>(), "Keep only current state of the objects(true)")
          ("es-objects-start-es-after-block", boost::program_options::value<uint32_t>(), "Start doing ES job after block(0)")
-         ("es-objects-load-genesis", boost::program_options::value<bool>(), "Load genesis data to ES(true)")
+         ("es-objects-load-genesis", boost::program_options::value<bool>(), "Index whatever is in the database on startup."
+                                                                            "Used to load genesis data into ES(true)")
          ;
    cfg.add(cli);
 }


### PR DESCRIPTION
For issue https://github.com/bitshares/bitshares-core/issues/1652

Provides option `es-objects-load-genesis` enabled by default to save accounts, assets and balances from the genesis file to ES.

![1652](https://user-images.githubusercontent.com/21685097/56038102-7aecbc00-5d07-11e9-8805-696523e2f8dd.png)
