### PR TITLE
Clean up hardfork code

### DIFF
--- a/libraries/chain/account_evaluator.cpp
+++ b/libraries/chain/account_evaluator.cpp
@@ -125,13 +125,6 @@ void_result account_create_evaluator::do_evaluate( const account_create_operatio
       FC_ASSERT( !op.extensions.value.owner_special_authority.valid() );
       FC_ASSERT( !op.extensions.value.active_special_authority.valid() );
    }
-   if( d.head_block_time() < HARDFORK_599_TIME )
-   {
-      FC_ASSERT( !op.extensions.value.null_ext.valid() );
-      FC_ASSERT( !op.extensions.value.owner_special_authority.valid() );
-      FC_ASSERT( !op.extensions.value.active_special_authority.valid() );
-      FC_ASSERT( !op.extensions.value.buyback_options.valid() );
-   }
 
    FC_ASSERT( fee_paying_account->is_lifetime_member(), "Only Lifetime members may register an account." );
    FC_ASSERT( op.referrer(d).is_member(d.head_block_time()), "The referrer must be either a lifetime or annual subscriber." );
@@ -277,12 +270,6 @@ void_result account_update_evaluator::do_evaluate( const account_update_operatio
    database& d = db();
    if( d.head_block_time() < HARDFORK_516_TIME )
    {
-      FC_ASSERT( !o.extensions.value.owner_special_authority.valid() );
-      FC_ASSERT( !o.extensions.value.active_special_authority.valid() );
-   }
-   if( d.head_block_time() < HARDFORK_599_TIME )
-   {
-      FC_ASSERT( !o.extensions.value.null_ext.valid() );
       FC_ASSERT( !o.extensions.value.owner_special_authority.valid() );
       FC_ASSERT( !o.extensions.value.active_special_authority.valid() );
    }

--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -1028,8 +1028,6 @@ void_result asset_claim_fees_evaluator::do_apply( const asset_claim_fees_operati
 
 void_result asset_claim_pool_evaluator::do_evaluate( const asset_claim_pool_operation& o )
 { try {
-    FC_ASSERT( db().head_block_time() >= HARDFORK_CORE_188_TIME,
-         "This operation is only available after Hardfork #188!" );
     FC_ASSERT( o.asset_id(db()).issuer == o.issuer, "Asset fee pool may only be claimed by the issuer" );
 
     return void_result();

--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -1003,7 +1003,6 @@ void_result asset_publish_feeds_evaluator::do_apply(const asset_publish_feed_ope
 
 void_result asset_claim_fees_evaluator::do_evaluate( const asset_claim_fees_operation& o )
 { try {
-   FC_ASSERT( db().head_block_time() > HARDFORK_413_TIME );
    FC_ASSERT( o.amount_to_claim.asset_id(db()).issuer == o.issuer, "Asset fees may only be claimed by the issuer" );
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (o) ) }

--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -67,11 +67,6 @@ void_result asset_create_evaluator::do_evaluate( const asset_create_operation& o
          FC_ASSERT( asset_symbol_itr->issuer == op.issuer, "Asset ${s} may only be created by issuer of ${p}, ${i}",
                     ("s",op.symbol)("p",prefix)("i", op.issuer(d).name) );
       }
-
-      if(d.head_block_time() <= HARDFORK_CORE_620_TIME ) { // TODO: remove this check after hf_620
-         static const std::locale& loc = std::locale::classic();
-         FC_ASSERT(isalpha(op.symbol.back(), loc), "Asset ${s} must end with alpha character before hardfork 620", ("s",op.symbol));
-      }
    }
    else
    {

--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -370,12 +370,6 @@ void_result asset_update_issuer_evaluator::do_evaluate(const asset_update_issuer
               "Incorrect issuer for asset! (${o.issuer} != ${a.issuer})",
               ("o.issuer", o.issuer)("a.issuer", a.issuer) );
 
-   if( d.head_block_time() < HARDFORK_CORE_199_TIME )
-   {
-      // TODO: remove after HARDFORK_CORE_199_TIME has passed
-      FC_ASSERT(false, "Not allowed until hardfork 199");
-   }
-
    return void_result();
 } FC_CAPTURE_AND_RETHROW((o)) }
 

--- a/libraries/chain/buyback.cpp
+++ b/libraries/chain/buyback.cpp
@@ -31,7 +31,6 @@ namespace graphene { namespace chain {
 
 void evaluate_buyback_account_options( const database& db, const buyback_account_options& bbo )
 {
-   FC_ASSERT( db.head_block_time() >= HARDFORK_538_TIME );
    const asset_object& a = bbo.asset_to_buy(db);
    GRAPHENE_ASSERT( a.issuer == bbo.asset_to_buy_issuer,
       account_create_buyback_incorrect_issuer, "Incorrect asset issuer specified in buyback_account_options", ("asset", a)("bbo", bbo) );

--- a/libraries/chain/db_market.cpp
+++ b/libraries/chain/db_market.cpp
@@ -641,25 +641,16 @@ int database::match( const limit_order_object& bid, const call_order_object& ask
    // TODO remove when we're sure it's always false
    bool before_core_hardfork_342 = ( maint_time <= HARDFORK_CORE_342_TIME ); // better rounding
    // TODO remove when we're sure it's always false
-   bool before_core_hardfork_834 = ( maint_time <= HARDFORK_CORE_834_TIME ); // target collateral ratio option
    if( before_core_hardfork_184 )
       ilog( "match(limit,call) is called before hardfork core-184 at block #${block}", ("block",head_block_num()) );
    if( before_core_hardfork_342 )
       ilog( "match(limit,call) is called before hardfork core-342 at block #${block}", ("block",head_block_num()) );
-   if( before_core_hardfork_834 )
-      ilog( "match(limit,call) is called before hardfork core-834 at block #${block}", ("block",head_block_num()) );
 
    bool cull_taker = false;
 
    asset usd_for_sale = bid.amount_for_sale();
-   // TODO if we're sure `before_core_hardfork_834` is always false, remove the check
-   asset usd_to_buy   = ( before_core_hardfork_834 ?
-                          ask.get_debt() :
-                          asset( ask.get_max_debt_to_cover( match_price,
-                                                            feed_price,
-                                                            maintenance_collateral_ratio,
-                                                            maintenance_collateralization ),
-                                 ask.debt_type() ) );
+   asset usd_to_buy   = asset( ask.get_max_debt_to_cover( match_price, feed_price, 
+         maintenance_collateral_ratio,  maintenance_collateralization ), ask.debt_type() );
 
    asset call_pays, call_receives, order_pays, order_receives;
    if( usd_to_buy > usd_for_sale )

--- a/libraries/chain/evaluator.cpp
+++ b/libraries/chain/evaluator.cpp
@@ -61,11 +61,11 @@ database& generic_evaluator::db()const { return trx_state->db(); }
       fee_asset = &fee.asset_id(d);
       fee_asset_dyn_data = &fee_asset->dynamic_asset_data_id(d);
 
-      if( d.head_block_time() > HARDFORK_419_TIME )
-      {
-         FC_ASSERT( is_authorized_asset( d, *fee_paying_account, *fee_asset ), "Account ${acct} '${name}' attempted to pay fee by using asset ${a} '${sym}', which is unauthorized due to whitelist / blacklist",
-            ("acct", fee_paying_account->id)("name", fee_paying_account->name)("a", fee_asset->id)("sym", fee_asset->symbol) );
-      }
+      FC_ASSERT( is_authorized_asset( d, *fee_paying_account, *fee_asset ), 
+            "Account ${acct} '${name}' attempted to pay fee by using asset ${a} '${sym}', "
+            "which is unauthorized due to whitelist / blacklist",
+            ( "acct", fee_paying_account->id)("name", fee_paying_account->name)("a", fee_asset->id)
+            ("sym", fee_asset->symbol) );
 
       if( fee_from_account.asset_id == asset_id_type() )
          core_fee_paid = fee_from_account.amount;

--- a/libraries/chain/hardfork.d/23.hf
+++ b/libraries/chain/hardfork.d/23.hf
@@ -1,4 +1,0 @@
-// Issue #23: Withdrawal claims made before the first withdrawal period are incorrectly allowed
-#ifndef HARDFORK_23_TIME
-#define HARDFORK_23_TIME (fc::time_point_sec( 1512747600 ))
-#endif

--- a/libraries/chain/hardfork.d/357.hf
+++ b/libraries/chain/hardfork.d/357.hf
@@ -1,4 +1,0 @@
-// #357 Disallow publishing certain malformed price feeds
-#ifndef HARDFORK_357_TIME
-#define HARDFORK_357_TIME (fc::time_point_sec( 1444416300 ))
-#endif

--- a/libraries/chain/hardfork.d/359.hf
+++ b/libraries/chain/hardfork.d/359.hf
@@ -1,4 +1,0 @@
-// #359 Allow digits in asset name
-#ifndef HARDFORK_359_TIME
-#define HARDFORK_359_TIME (fc::time_point_sec( 1444416300 ))
-#endif

--- a/libraries/chain/hardfork.d/409.hf
+++ b/libraries/chain/hardfork.d/409.hf
@@ -1,4 +1,0 @@
-// #409 Allow creation of sub-assets
-#ifndef HARDFORK_409_TIME
-#define HARDFORK_409_TIME (fc::time_point_sec( 1446652800 ))
-#endif

--- a/libraries/chain/hardfork.d/413.hf
+++ b/libraries/chain/hardfork.d/413.hf
@@ -1,4 +1,0 @@
-// #413 Add operation to claim asset fees
-#ifndef HARDFORK_413_TIME
-#define HARDFORK_413_TIME (fc::time_point_sec( 1446652800 ))
-#endif

--- a/libraries/chain/hardfork.d/415.hf
+++ b/libraries/chain/hardfork.d/415.hf
@@ -1,4 +1,0 @@
-// #415 Default accept policy for asset with no whitelist authorities
-#ifndef HARDFORK_415_TIME
-#define HARDFORK_415_TIME (fc::time_point_sec( 1446652800 ))
-#endif

--- a/libraries/chain/hardfork.d/416.hf
+++ b/libraries/chain/hardfork.d/416.hf
@@ -1,4 +1,0 @@
-// #416 enforce_white_list is inconsistently applied
-#ifndef HARDFORK_416_TIME
-#define HARDFORK_416_TIME (fc::time_point_sec( 1446652800 ))
-#endif

--- a/libraries/chain/hardfork.d/419.hf
+++ b/libraries/chain/hardfork.d/419.hf
@@ -1,4 +1,0 @@
-// #419 Account can pay fees in blacklisted asset
-#ifndef HARDFORK_419_TIME
-#define HARDFORK_419_TIME (fc::time_point_sec( 1446652800 ))
-#endif

--- a/libraries/chain/hardfork.d/538.hf
+++ b/libraries/chain/hardfork.d/538.hf
@@ -1,4 +1,0 @@
-// #538 Buyback accounts
-#ifndef HARDFORK_538_TIME
-#define HARDFORK_538_TIME (fc::time_point_sec( 1456250400 ))
-#endif

--- a/libraries/chain/hardfork.d/599.hf
+++ b/libraries/chain/hardfork.d/599.hf
@@ -1,4 +1,0 @@
-// #599 Unpacking of extension is incorrect
-#ifndef HARDFORK_599_TIME
-#define HARDFORK_599_TIME (fc::time_point_sec( 1459789200 ))
-#endif

--- a/libraries/chain/hardfork.d/CORE_1040.hf
+++ b/libraries/chain/hardfork.d/CORE_1040.hf
@@ -1,4 +1,0 @@
-// bitshares-core issue #1040 Remove temp-account balance check
-#ifndef HARDFORK_CORE_1040_TIME
-#define HARDFORK_CORE_1040_TIME (fc::time_point_sec( 1532008920 )) // Thu, 19 Jul 2018 14:02:00 UTC
-#endif

--- a/libraries/chain/hardfork.d/CORE_188.hf
+++ b/libraries/chain/hardfork.d/CORE_188.hf
@@ -1,4 +1,0 @@
-// #188 Add operation to allow claiming of funds in an asset's fee pool
-#ifndef HARDFORK_CORE_188_TIME
-#define HARDFORK_CORE_188_TIME (fc::time_point_sec( 1532008920 )) // Thu, 19 Jul 2018 14:02:00 UTC
-#endif

--- a/libraries/chain/hardfork.d/CORE_620.hf
+++ b/libraries/chain/hardfork.d/CORE_620.hf
@@ -1,4 +1,0 @@
-// bitshares-core issue #620 Allow numbers at the end of asset symbol
-#ifndef HARDFORK_CORE_620_TIME
-#define HARDFORK_CORE_620_TIME (fc::time_point_sec( 1532008920 )) // Thu, 19 Jul 2018 14:02:00 UTC
-#endif

--- a/libraries/chain/hardfork.d/CORE_942.hf
+++ b/libraries/chain/hardfork.d/CORE_942.hf
@@ -1,5 +1,0 @@
-// bitshares-core issue #942
-//   Incorrectly checking asset authorization for withdraw_from_account in withdraw_permission_claim_evaluator
-#ifndef HARDFORK_CORE_942_TIME
-#define HARDFORK_CORE_942_TIME (fc::time_point_sec( 1532008920 )) // Thu, 19 Jul 2018 14:02:00 UTC
-#endif

--- a/libraries/chain/is_authorized_asset.cpp
+++ b/libraries/chain/is_authorized_asset.cpp
@@ -50,11 +50,8 @@ bool _is_authorized_asset(
          return false;
    }
 
-   if( d.head_block_time() > HARDFORK_415_TIME )
-   {
-      if( asset_obj.options.whitelist_authorities.size() == 0 )
-         return true;
-   }
+   if( asset_obj.options.whitelist_authorities.size() == 0 )
+      return true;
 
    for( const auto id : acct.whitelisting_accounts )
    {

--- a/libraries/chain/market_evaluator.cpp
+++ b/libraries/chain/market_evaluator.cpp
@@ -161,11 +161,6 @@ void_result call_order_update_evaluator::do_evaluate(const call_order_update_ope
 
    auto next_maintenance_time = d.get_dynamic_global_properties().next_maintenance_time;
 
-   // TODO: remove this check and the assertion after hf_834
-   if( next_maintenance_time <= HARDFORK_CORE_834_TIME )
-      FC_ASSERT( !o.extensions.value.target_collateral_ratio.valid(),
-                 "Can not set target_collateral_ratio in call_order_update_operation before hardfork 834." );
-
    _paying_account = &o.funding_account(d);
    _debt_asset     = &o.delta_debt.asset_id(d);
    FC_ASSERT( _debt_asset->is_market_issued(), "Unable to cover ${sym} as it is not a collateralized asset.",

--- a/libraries/chain/market_evaluator.cpp
+++ b/libraries/chain/market_evaluator.cpp
@@ -325,7 +325,7 @@ object_id_type call_order_update_evaluator::do_apply(const call_order_update_ope
          call_obj = d.find(call_order_id);
          // we know no black swan event has occurred
          FC_ASSERT( call_obj, "no margin call was executed and yet the call object was deleted" );
-         if( d.head_block_time() <= HARDFORK_CORE_583_TIME ) // TODO remove after hard fork core-583
+         if( d.head_block_time() <= HARDFORK_CORE_583_TIME )
          {
             // We didn't fill any call orders.  This may be because we
             // aren't in margin call territory, or it may be because there

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -49,13 +49,6 @@ struct proposal_operation_hardfork_visitor
                     "Can not set target_collateral_ratio in call_order_update_operation before hardfork 834." );
       }
    }
-   // hf_620
-   void operator()(const graphene::chain::asset_create_operation &v) const {
-      if (block_time < HARDFORK_CORE_620_TIME) {
-         static const std::locale &loc = std::locale::classic();
-         FC_ASSERT(isalpha(v.symbol.back(), loc), "Asset ${s} must end with alpha character before hardfork 620", ("s", v.symbol));
-      }
-   }
    // hf_199
    void operator()(const graphene::chain::asset_update_issuer_operation &v) const {
       if (block_time < HARDFORK_CORE_199_TIME) {

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -56,13 +56,6 @@ struct proposal_operation_hardfork_visitor
             || (v.delta_debt.asset_id( db ).bitasset_data_id
             && (*(v.delta_debt.asset_id( db ).bitasset_data_id))( db ).is_prediction_market )
             , "Soft fork - preventing proposal with call_order_update!" );
-   
-      // TODO review and cleanup code below after hard fork
-      // hf_834
-      if (next_maintenance_time <= HARDFORK_CORE_834_TIME) {
-         FC_ASSERT( !v.extensions.value.target_collateral_ratio.valid(),
-                    "Can not set target_collateral_ratio in call_order_update_operation before hardfork 834." );
-      }
    }
    // hf_1268
    void operator()(const graphene::chain::asset_create_operation &v) const {

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -76,12 +76,6 @@ struct proposal_operation_hardfork_visitor
    void operator()(const graphene::chain::vesting_balance_create_operation &v) const {
       detail::check_vesting_balance_policy_hf_1268(block_time, v.policy);
    }
-   // hf_199
-   void operator()(const graphene::chain::asset_update_issuer_operation &v) const {
-      if (block_time < HARDFORK_CORE_199_TIME) {
-         FC_ASSERT(false, "Not allowed until hardfork 199");
-      }
-   }
    // hf_588
    // issue #588
    //

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -62,12 +62,6 @@ struct proposal_operation_hardfork_visitor
          FC_ASSERT(false, "Not allowed until hardfork 199");
       }
    }
-   // hf_188
-   void operator()(const graphene::chain::asset_claim_pool_operation &v) const {
-      if (block_time < HARDFORK_CORE_188_TIME) {
-         FC_ASSERT(false, "Not allowed until hardfork 188");
-      }
-   }
    // hf_588
    // issue #588
    //

--- a/libraries/chain/transfer_evaluator.cpp
+++ b/libraries/chain/transfer_evaluator.cpp
@@ -102,12 +102,6 @@ void_result override_transfer_evaluator::do_evaluate( const override_transfer_op
    FC_ASSERT( is_authorized_asset( d, to_account, asset_type ) );
    FC_ASSERT( is_authorized_asset( d, from_account, asset_type ) );
 
-   if( d.head_block_time() <= HARDFORK_419_TIME )
-   {
-      FC_ASSERT( is_authorized_asset( d, from_account, asset_type ) );
-   }
-   // the above becomes no-op after hardfork because this check will then be performed in evaluator
-
    FC_ASSERT( d.get_balance( from_account, asset_type ).amount >= op.amount.amount,
               "", ("total_transfer",op.amount)("balance",d.get_balance(from_account, asset_type).amount) );
 

--- a/libraries/chain/withdraw_permission_evaluator.cpp
+++ b/libraries/chain/withdraw_permission_evaluator.cpp
@@ -84,17 +84,9 @@ void_result withdraw_permission_claim_evaluator::do_evaluate(const withdraw_perm
 
    const account_object& from  = op.withdraw_from_account(d);
    bool from_is_authorized = ( is_authorized_asset( d, from, _asset ) );
-   if( head_block_time > HARDFORK_CORE_942_TIME ) // TODO remove this check after hard fork if things in `else` did not occur
-   {
-      FC_ASSERT( from_is_authorized,
-                 "Account ${acct} '${name}' is unauthorized to withdraw asset ${a} '${sym}' due to whitelist / blacklist",
-                 ("acct", from.id)("name", from.name)("a", _asset.id)("sym", _asset.symbol) );
-   }
-   else
-   {
-      if( !from_is_authorized )
-         wlog( "Unauthorized asset withdrawal (issue #942) occurred at block ${b}", ("b", d.head_block_num()) );
-   }
+   FC_ASSERT( from_is_authorized,
+         "Account ${acct} '${name}' is unauthorized to withdraw asset ${a} '${sym}' due to whitelist / blacklist",
+         ("acct", from.id)("name", from.name)("a", _asset.id)("sym", _asset.symbol) );
 
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (op) ) }

--- a/libraries/chain/withdraw_permission_evaluator.cpp
+++ b/libraries/chain/withdraw_permission_evaluator.cpp
@@ -65,9 +65,7 @@ void_result withdraw_permission_claim_evaluator::do_evaluate(const withdraw_perm
    FC_ASSERT(permit.expiration > head_block_time);
    FC_ASSERT(permit.authorized_account == op.withdraw_to_account);
    FC_ASSERT(permit.withdraw_from_account == op.withdraw_from_account);
-   if (head_block_time >= HARDFORK_23_TIME) {
-      FC_ASSERT(permit.period_start_time <= head_block_time);
-   }
+   FC_ASSERT(permit.period_start_time <= head_block_time);
    FC_ASSERT(op.amount_to_withdraw <= permit.available_this_period( head_block_time ) );
    FC_ASSERT(d.get_balance(op.withdraw_from_account, op.amount_to_withdraw.asset_id) >= op.amount_to_withdraw);
 

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -1331,10 +1331,7 @@ public:
       optional<account_id_type> new_issuer_account_id;
       if (new_issuer)
       {
-        FC_ASSERT( _remote_db->get_dynamic_global_properties().time < HARDFORK_CORE_199_TIME,
-              "The use of 'new_issuer' is no longer supported. Please use `update_asset_issuer' instead!");
-        account_object new_issuer_account = get_account(*new_issuer);
-        new_issuer_account_id = new_issuer_account.id;
+        FC_ASSERT( false, "The use of 'new_issuer' is no longer supported. Please use `update_asset_issuer' instead!");
       }
 
       asset_update_operation update_op;

--- a/tests/tests/fee_tests.cpp
+++ b/tests/tests/fee_tests.cpp
@@ -3435,7 +3435,6 @@ BOOST_AUTO_TEST_CASE( stealth_fba_test )
       generate_blocks( HARDFORK_555_TIME );
       generate_blocks( HARDFORK_563_TIME );
       generate_blocks( HARDFORK_572_TIME );
-      generate_blocks( HARDFORK_599_TIME );
 
       // Philbin (registrar who registers Rex)
 

--- a/tests/tests/fee_tests.cpp
+++ b/tests/tests/fee_tests.cpp
@@ -173,17 +173,6 @@ BOOST_AUTO_TEST_CASE(asset_claim_fees_test)
 
       }
 
-      if( db.head_block_time() <= HARDFORK_413_TIME )
-      {
-         // can't claim before hardfork
-         GRAPHENE_REQUIRE_THROW( claim_fees( izzy_id, _izzy(1) ), fc::exception );
-         generate_blocks( HARDFORK_413_TIME );
-         while( db.head_block_time() <= HARDFORK_413_TIME )
-         {
-            generate_block();
-         }
-      }
-
       {
          const asset_object& izzycoin = izzycoin_id(db);
          const asset_object& jillcoin = jillcoin_id(db);

--- a/tests/tests/fee_tests.cpp
+++ b/tests/tests/fee_tests.cpp
@@ -279,13 +279,6 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
         // deposit 100 BTS to the fee pool of ALICEUSD asset
         fund_fee_pool( alice_id(db), aliceusd_id(db), _core(100).amount );
 
-        // Unable to claim pool before the hardfork
-        GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, aliceusd_id, _core(1), core_asset), fc::exception );
-        GRAPHENE_REQUIRE_THROW( claim_pool_proposal( alice_id, aliceusd_id, _core(1), core_asset), fc::exception );
-
-        // Fast forward to hard fork date
-        generate_blocks( HARDFORK_CORE_188_TIME );
-
         // New reference for core_asset after having produced blocks
         const asset_object& core_asset_hf = asset_id_type()(db);
 

--- a/tests/tests/fee_tests.cpp
+++ b/tests/tests/fee_tests.cpp
@@ -3432,7 +3432,6 @@ BOOST_AUTO_TEST_CASE( stealth_fba_test )
       ACTORS( (alice)(bob)(chloe)(dan)(izzy)(philbin)(tom) );
       upgrade_to_lifetime_member(philbin_id);
 
-      generate_blocks( HARDFORK_538_TIME );
       generate_blocks( HARDFORK_555_TIME );
       generate_blocks( HARDFORK_563_TIME );
       generate_blocks( HARDFORK_572_TIME );

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -599,9 +599,6 @@ BOOST_AUTO_TEST_CASE( call_order_update_validation_test )
 BOOST_AUTO_TEST_CASE( call_order_update_target_cr_hardfork_time_test )
 {
    try {
-      auto mi = db.get_global_properties().parameters.maintenance_interval;
-      generate_blocks(HARDFORK_CORE_834_TIME - mi);
-
       set_expiration( db, trx );
 
       ACTORS((sam)(alice)(bob));
@@ -621,15 +618,6 @@ BOOST_AUTO_TEST_CASE( call_order_update_target_cr_hardfork_time_test )
       publish_feed( bitusd, sam, current_feed );
 
       FC_ASSERT( bitusd.bitasset_data(db).current_feed.settlement_price == current_feed.settlement_price );
-
-      BOOST_TEST_MESSAGE( "alice tries to borrow using 4x collateral at 1:1 price with target_cr set, "
-                          "will fail before hard fork time" );
-      GRAPHENE_REQUIRE_THROW( borrow( alice, bitusd.amount(100000), core.amount(400000), 0 ), fc::assert_exception );
-      GRAPHENE_REQUIRE_THROW( borrow( alice, bitusd.amount(100000), core.amount(400000), 1 ), fc::assert_exception );
-      GRAPHENE_REQUIRE_THROW( borrow( alice, bitusd.amount(100000), core.amount(400000), 1749 ), fc::assert_exception );
-      GRAPHENE_REQUIRE_THROW( borrow( alice, bitusd.amount(100000), core.amount(400000), 1750 ), fc::assert_exception );
-      GRAPHENE_REQUIRE_THROW( borrow( alice, bitusd.amount(100000), core.amount(400000), 1751 ), fc::assert_exception );
-      GRAPHENE_REQUIRE_THROW( borrow( alice, bitusd.amount(100000), core.amount(400000), 65535 ), fc::assert_exception );
 
       auto call_update_proposal = [this]( const account_object& proposer,
                                        const account_object& updater,
@@ -658,13 +646,7 @@ BOOST_AUTO_TEST_CASE( call_order_update_target_cr_hardfork_time_test )
          PUSH_TX( db, tx, ~0 );
       };
 
-      BOOST_TEST_MESSAGE( "bob tries to propose a proposal with target_cr set, "
-                          "will fail before hard fork time" );
-      GRAPHENE_REQUIRE_THROW( call_update_proposal( bob, alice, bitusd.amount(10), core.amount(40), 0 ), fc::assert_exception );
-      GRAPHENE_REQUIRE_THROW( call_update_proposal( bob, alice, bitusd.amount(10), core.amount(40), 1750 ), fc::assert_exception );
-      GRAPHENE_REQUIRE_THROW( call_update_proposal( bob, alice, bitusd.amount(10), core.amount(40), 65535 ), fc::assert_exception );
-
-      generate_blocks( db.get_dynamic_global_properties().next_maintenance_time );
+      generate_blocks(HARDFORK_CORE_834_TIME);
       set_expiration( db, trx );
 
       BOOST_TEST_MESSAGE( "bob tries to propose a proposal with target_cr set, "

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -1349,6 +1349,9 @@ BOOST_AUTO_TEST_CASE( update_uia_issuer )
       const auto& test = create_user_issued_asset("UPDATEISSUER", alice_id(db), 0);
       const asset_id_type test_id = test.id;
 
+      // Fast Forward to Hardfork time
+      generate_blocks( HARDFORK_CORE_199_TIME );
+
       update_issuer_proposal( test_id, alice_id(db), bob_id(db), alice_owner);
 
       BOOST_TEST_MESSAGE( "Can't change issuer if not my asset" );

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -1349,16 +1349,6 @@ BOOST_AUTO_TEST_CASE( update_uia_issuer )
       const auto& test = create_user_issued_asset("UPDATEISSUER", alice_id(db), 0);
       const asset_id_type test_id = test.id;
 
-      BOOST_TEST_MESSAGE( "can't use this operation before the hardfork" );
-      GRAPHENE_REQUIRE_THROW( update_issuer( test_id, alice_id(db), bob_id(db), alice_owner), fc::exception );
-
-      BOOST_TEST_MESSAGE( "can't use this operation before the hardfork (even if wrapped into a proposal)" );
-      GRAPHENE_REQUIRE_THROW( update_issuer_proposal( test_id, alice_id(db), bob_id(db), alice_owner), fc::exception );
-
-      // Fast Forward to Hardfork time
-      generate_blocks( HARDFORK_CORE_199_TIME );
-
-      BOOST_TEST_MESSAGE( "After hardfork time, proposal goes through (but doesn't execute yet)" );
       update_issuer_proposal( test_id, alice_id(db), bob_id(db), alice_owner);
 
       BOOST_TEST_MESSAGE( "Can't change issuer if not my asset" );

--- a/tests/tests/operation_tests2.cpp
+++ b/tests/tests/operation_tests2.cpp
@@ -2019,7 +2019,6 @@ BOOST_AUTO_TEST_CASE( top_n_special )
    ACTORS( (alice)(bob)(chloe)(dan)(izzy)(stan) );
 
    generate_blocks( HARDFORK_516_TIME );
-   generate_blocks( HARDFORK_599_TIME );
 
    try
    {
@@ -2171,7 +2170,6 @@ BOOST_AUTO_TEST_CASE( buyback )
    upgrade_to_lifetime_member(philbin_id);
 
    generate_blocks( HARDFORK_555_TIME );
-   generate_blocks( HARDFORK_599_TIME );
 
    try
    {

--- a/tests/tests/operation_tests2.cpp
+++ b/tests/tests/operation_tests2.cpp
@@ -351,7 +351,6 @@ BOOST_AUTO_TEST_CASE( withdraw_permission_whitelist_asset_test )
                  | database::skip_merkle_check
                  ;
 
-   generate_blocks( HARDFORK_415_TIME, true, skip ); // get over Graphene 415 asset whitelisting bug
    generate_block( skip );
 
    for( int i=0; i<2; i++ )

--- a/tests/tests/operation_tests2.cpp
+++ b/tests/tests/operation_tests2.cpp
@@ -355,12 +355,6 @@ BOOST_AUTO_TEST_CASE( withdraw_permission_whitelist_asset_test )
 
    for( int i=0; i<2; i++ )
    {
-      if( i == 1 )
-      {
-         generate_blocks( HARDFORK_CORE_942_TIME, true, skip );
-         generate_block( skip );
-      }
-
       int blocks = 0;
       set_expiration( db, trx );
 
@@ -424,10 +418,7 @@ BOOST_AUTO_TEST_CASE( withdraw_permission_whitelist_asset_test )
          op.withdraw_to_account = dan_id;
          op.amount_to_withdraw = asset(5, uia_id);
          trx.operations.push_back(op);
-         if( i == 0 ) // before hard fork, should pass
-            PUSH_TX( db, trx, ~0 );
-         else // after hard fork, should throw
-            GRAPHENE_CHECK_THROW( PUSH_TX( db, trx, ~0 ), fc::assert_exception );
+         GRAPHENE_CHECK_THROW( PUSH_TX( db, trx, ~0 ), fc::assert_exception );
          trx.operations.clear();
       }
 

--- a/tests/tests/operation_tests2.cpp
+++ b/tests/tests/operation_tests2.cpp
@@ -2170,7 +2170,6 @@ BOOST_AUTO_TEST_CASE( buyback )
    ACTORS( (alice)(bob)(chloe)(dan)(izzy)(philbin) );
    upgrade_to_lifetime_member(philbin_id);
 
-   generate_blocks( HARDFORK_538_TIME );
    generate_blocks( HARDFORK_555_TIME );
    generate_blocks( HARDFORK_599_TIME );
 

--- a/tests/tests/operation_tests2.cpp
+++ b/tests/tests/operation_tests2.cpp
@@ -102,13 +102,9 @@ withdrawal_period_descriptor current_period(const withdraw_permission_object& pe
  * (a) it checks the creation of withdrawal claims,
  * (b) it is used as a precursor for tests that evaluate withdrawal claims.
  *
- * NOTE: This test verifies proper withdrawal claim behavior
- * as it occurred before (for backward compatibility)
- * Issue #23 was addressed.
- * That issue is concerned with ensuring that the first claim
- * can occur before the first withdrawal period.
+ * NOTE: This test verifies proper withdrawal claim behavior.
  */
-BOOST_AUTO_TEST_CASE( withdraw_permission_create_before_hardfork_23 )
+BOOST_AUTO_TEST_CASE( withdraw_permission_create )
 { try {
    auto nathan_private_key = generate_private_key("nathan");
    auto dan_private_key = generate_private_key("dan");
@@ -126,52 +122,7 @@ BOOST_AUTO_TEST_CASE( withdraw_permission_create_before_hardfork_23 )
       op.withdrawal_limit = asset(5);
       op.withdrawal_period_sec = fc::hours(1).to_seconds();
       op.periods_until_expiration = 5;
-      op.period_start_time = db.head_block_time() + db.get_global_properties().parameters.block_interval*5; // 5 blocks after current blockchain time
-      trx.operations.push_back(op);
-      REQUIRE_OP_VALIDATION_FAILURE(op, withdrawal_limit, asset());
-      REQUIRE_OP_VALIDATION_FAILURE(op, periods_until_expiration, 0);
-      REQUIRE_OP_VALIDATION_FAILURE(op, withdraw_from_account, dan_id);
-      REQUIRE_OP_VALIDATION_FAILURE(op, withdrawal_period_sec, 0);
-      REQUIRE_THROW_WITH_VALUE(op, withdrawal_limit, asset(10, asset_id_type(10)));
-      REQUIRE_THROW_WITH_VALUE(op, authorized_account, account_id_type(1000));
-      REQUIRE_THROW_WITH_VALUE(op, period_start_time, fc::time_point_sec(10000));
-      REQUIRE_THROW_WITH_VALUE(op, withdrawal_period_sec, 1);
-      trx.operations.back() = op;
-   }
-   sign( trx, nathan_private_key );
-   PUSH_TX( db, trx );
-   trx.clear();
-} FC_LOG_AND_RETHROW() }
-
-/**
- * This auxiliary test is used for two purposes:
- * (a) it checks the creation of withdrawal claims,
- * (b) it is used as a precursor for tests that evaluate withdrawal claims.
- *
- * NOTE: This test verifies proper withdrawal claim behavior
- * as it should occur after Issue #23 is addressed.
- * That issue is concerned with ensuring that the first claim
- * can occur before the first withdrawal period.
- */
-BOOST_AUTO_TEST_CASE( withdraw_permission_create_after_hardfork_23 )
-{ try {
-   auto nathan_private_key = generate_private_key("nathan");
-   auto dan_private_key = generate_private_key("dan");
-   account_id_type nathan_id = create_account("nathan", nathan_private_key.get_public_key()).id;
-   account_id_type dan_id = create_account("dan", dan_private_key.get_public_key()).id;
-
-   transfer(account_id_type(), nathan_id, asset(1000));
-   generate_block();
-   set_expiration( db, trx );
-
-   {
-      withdraw_permission_create_operation op;
-      op.authorized_account = dan_id;
-      op.withdraw_from_account = nathan_id;
-      op.withdrawal_limit = asset(5);
-      op.withdrawal_period_sec = fc::hours(1).to_seconds();
-      op.periods_until_expiration = 5;
-      op.period_start_time = HARDFORK_23_TIME + db.get_global_properties().parameters.block_interval*5; // 5 blocks after fork time
+      op.period_start_time = db.head_block_time() + db.get_global_properties().parameters.block_interval*5; // 5 blocks after fork time
       trx.operations.push_back(op);
       REQUIRE_OP_VALIDATION_FAILURE(op, withdrawal_limit, asset());
       REQUIRE_OP_VALIDATION_FAILURE(op, periods_until_expiration, 0);
@@ -194,177 +145,11 @@ BOOST_AUTO_TEST_CASE( withdraw_permission_create_after_hardfork_23 )
  * NOTE: The simulated elapse of blockchain time through the use of
  * generate_blocks() must be carefully used in order to simulate
  * this test.
- * NOTE: This test verifies proper withdrawal claim behavior
- * as it occurred before (for backward compatibility)
- * Issue #23 was addressed.
- * That issue is concerned with ensuring that the first claim
- * can occur before the first withdrawal period.
+ * NOTE: This test verifies proper withdrawal claim behavior.
  */
-BOOST_AUTO_TEST_CASE( withdraw_permission_test_before_hardfork_23 )
+BOOST_AUTO_TEST_CASE( withdraw_permission_test )
 { try {
-      INVOKE(withdraw_permission_create_before_hardfork_23);
-
-      auto nathan_private_key = generate_private_key("nathan");
-      auto dan_private_key = generate_private_key("dan");
-      account_id_type nathan_id = get_account("nathan").id;
-      account_id_type dan_id = get_account("dan").id;
-      withdraw_permission_id_type permit;
-      set_expiration( db, trx );
-
-      fc::time_point_sec first_start_time;
-      {
-          const withdraw_permission_object& permit_object = permit(db);
-          BOOST_CHECK(permit_object.authorized_account == dan_id);
-          BOOST_CHECK(permit_object.withdraw_from_account == nathan_id);
-          BOOST_CHECK(permit_object.period_start_time > db.head_block_time());
-          first_start_time = permit_object.period_start_time;
-          BOOST_CHECK(permit_object.withdrawal_limit == asset(5));
-          BOOST_CHECK(permit_object.withdrawal_period_sec == fc::hours(1).to_seconds());
-          BOOST_CHECK(permit_object.expiration == first_start_time + permit_object.withdrawal_period_sec*5 );
-      }
-
-   generate_blocks(2); // Still before the first period, but BEFORE the real time during which "early" claims are checked
-
-      {
-          withdraw_permission_claim_operation op;
-          op.withdraw_permission = permit;
-          op.withdraw_from_account = nathan_id;
-          op.withdraw_to_account = dan_id;
-          op.amount_to_withdraw = asset(1);
-          set_expiration( db, trx );
-
-          trx.operations.push_back(op);
-          sign( trx, dan_private_key ); // Transaction should be signed to be valid
-
-          // This operation/transaction will be pushed early/before the first
-          // withdrawal period
-          // However, this will not cause an exception prior to HARDFORK_23_TIME
-          // because withdrawaing before that the first period was acceptable
-          // before the fix
-          PUSH_TX( db, trx ); // <-- Claim #1
-
-
-          //Get to the actual withdrawal period
-          bool miss_intermediate_blocks = false; // Required to have generate_blocks() elapse flush to the time of interest
-          generate_blocks(first_start_time, miss_intermediate_blocks);
-          set_expiration( db, trx );
-
-          REQUIRE_THROW_WITH_VALUE(op, withdraw_permission, withdraw_permission_id_type(5));
-          REQUIRE_THROW_WITH_VALUE(op, withdraw_from_account, dan_id);
-          REQUIRE_THROW_WITH_VALUE(op, withdraw_from_account, account_id_type());
-          REQUIRE_THROW_WITH_VALUE(op, withdraw_to_account, nathan_id);
-          REQUIRE_THROW_WITH_VALUE(op, withdraw_to_account, account_id_type());
-          REQUIRE_THROW_WITH_VALUE(op, amount_to_withdraw, asset(10));
-          REQUIRE_THROW_WITH_VALUE(op, amount_to_withdraw, asset(6));
-          set_expiration( db, trx );
-          trx.clear();
-          trx.operations.push_back(op);
-          sign( trx, dan_private_key );
-          PUSH_TX( db, trx ); // <-- Claim #2
-
-          // would be legal on its own, but doesn't work because trx already withdrew
-          REQUIRE_THROW_WITH_VALUE(op, amount_to_withdraw, asset(5));
-
-          // Make sure we can withdraw again this period, as long as we're not exceeding the periodic limit
-          trx.clear();
-          // withdraw 1
-          trx.operations = {op};
-          // make it different from previous trx so it's non-duplicate
-          trx.expiration += fc::seconds(1);
-          sign( trx, dan_private_key );
-          PUSH_TX( db, trx ); // <-- Claim #3
-          trx.clear();
-      }
-
-      // Account for three (3) claims of one (1) unit
-      BOOST_CHECK_EQUAL(get_balance(nathan_id, asset_id_type()), 997);
-      BOOST_CHECK_EQUAL(get_balance(dan_id, asset_id_type()), 3);
-
-      {
-          const withdraw_permission_object& permit_object = permit(db);
-          BOOST_CHECK(permit_object.authorized_account == dan_id);
-          BOOST_CHECK(permit_object.withdraw_from_account == nathan_id);
-          BOOST_CHECK(permit_object.period_start_time == first_start_time);
-          BOOST_CHECK(permit_object.withdrawal_limit == asset(5));
-          BOOST_CHECK(permit_object.withdrawal_period_sec == fc::hours(1).to_seconds());
-          BOOST_CHECK_EQUAL(permit_object.claimed_this_period.value, 3 ); // <-- Account for three (3) claims of one (1) unit
-          BOOST_CHECK(permit_object.expiration == first_start_time + 5*permit_object.withdrawal_period_sec);
-          generate_blocks(first_start_time + permit_object.withdrawal_period_sec);
-          // lazy update:  verify period_start_time isn't updated until new trx occurs
-          BOOST_CHECK(permit_object.period_start_time == first_start_time);
-      }
-
-      {
-          // Leave Nathan with one unit
-          transfer(nathan_id, dan_id, asset(996));
-
-          // Attempt a withdrawal claim for units than available
-          withdraw_permission_claim_operation op;
-          op.withdraw_permission = permit;
-          op.withdraw_from_account = nathan_id;
-          op.withdraw_to_account = dan_id;
-          op.amount_to_withdraw = asset(5);
-          trx.operations.push_back(op);
-          set_expiration( db, trx );
-          sign( trx, dan_private_key );
-          //Throws because nathan doesn't have the money
-          GRAPHENE_CHECK_THROW(PUSH_TX( db, trx ), fc::exception);
-
-          // Attempt a withdrawal claim for which nathan does have sufficient units
-          op.amount_to_withdraw = asset(1);
-          trx.clear();
-          trx.operations = {op};
-          set_expiration( db, trx );
-          sign( trx, dan_private_key );
-          PUSH_TX( db, trx );
-      }
-
-      BOOST_CHECK_EQUAL(get_balance(nathan_id, asset_id_type()), 0);
-      BOOST_CHECK_EQUAL(get_balance(dan_id, asset_id_type()), 1000);
-      trx.clear();
-      transfer(dan_id, nathan_id, asset(1000));
-
-      {
-          const withdraw_permission_object& permit_object = permit(db);
-          BOOST_CHECK(permit_object.authorized_account == dan_id);
-          BOOST_CHECK(permit_object.withdraw_from_account == nathan_id);
-          BOOST_CHECK(permit_object.period_start_time == first_start_time + permit_object.withdrawal_period_sec);
-          BOOST_CHECK(permit_object.expiration == first_start_time + 5*permit_object.withdrawal_period_sec);
-          BOOST_CHECK(permit_object.withdrawal_limit == asset(5));
-          BOOST_CHECK(permit_object.withdrawal_period_sec == fc::hours(1).to_seconds());
-          generate_blocks(permit_object.expiration);
-      }
-      // Ensure the permit object has been garbage collected
-      BOOST_CHECK(db.find_object(permit) == nullptr);
-
-      {
-          withdraw_permission_claim_operation op;
-          op.withdraw_permission = permit;
-          op.withdraw_from_account = nathan_id;
-          op.withdraw_to_account = dan_id;
-          op.amount_to_withdraw = asset(5);
-          trx.operations.push_back(op);
-          set_expiration( db, trx );
-          sign( trx, dan_private_key );
-          //Throws because the permission has expired
-          GRAPHENE_CHECK_THROW(PUSH_TX( db, trx ), fc::exception);
-      }
-  } FC_LOG_AND_RETHROW() }
-
-/**
- * Test the claims of withdrawals both before and during
- * authorized withdrawal periods.
- * NOTE: The simulated elapse of blockchain time through the use of
- * generate_blocks() must be carefully used in order to simulate
- * this test.
- * NOTE: This test verifies proper withdrawal claim behavior
- * as it should occur after Issue #23 is addressed.
- * That issue is concerned with ensuring that the first claim
- * can occur before the first withdrawal period.
- */
-BOOST_AUTO_TEST_CASE( withdraw_permission_test_after_hardfork_23 )
-{ try {
-   INVOKE(withdraw_permission_create_after_hardfork_23);
+   INVOKE(withdraw_permission_create);
 
    auto nathan_private_key = generate_private_key("nathan");
    auto dan_private_key = generate_private_key("dan");
@@ -384,8 +169,6 @@ BOOST_AUTO_TEST_CASE( withdraw_permission_test_after_hardfork_23 )
       BOOST_CHECK(permit_object.withdrawal_period_sec == fc::hours(1).to_seconds());
       BOOST_CHECK(permit_object.expiration == first_start_time + permit_object.withdrawal_period_sec*5 );
    }
-
-   generate_blocks(HARDFORK_23_TIME); // Still before the first period, but DURING the real time during which "early" claims are checked
 
    {
       withdraw_permission_claim_operation op;
@@ -508,7 +291,7 @@ BOOST_AUTO_TEST_CASE( withdraw_permission_test_after_hardfork_23 )
 
 BOOST_AUTO_TEST_CASE( withdraw_permission_nominal_case )
 { try {
-   INVOKE(withdraw_permission_create_before_hardfork_23);
+   INVOKE(withdraw_permission_create);
 
    auto nathan_private_key = generate_private_key("nathan");
    auto dan_private_key = generate_private_key("dan");
@@ -680,9 +463,9 @@ BOOST_AUTO_TEST_CASE( withdraw_permission_whitelist_asset_test )
  */
 BOOST_AUTO_TEST_CASE( withdraw_permission_incremental_case )
 { try {
-    INVOKE(withdraw_permission_create_after_hardfork_23);
-    time_point_sec expected_first_period_start_time = HARDFORK_23_TIME + db.get_global_properties().parameters.block_interval*5; // Hard-coded to synchronize with withdraw_permission_create_after_hardfork_23()
-    uint64_t expected_period_duration_seconds = fc::hours(1).to_seconds(); // Hard-coded to synchronize with withdraw_permission_create_after_hardfork_23()
+    INVOKE(withdraw_permission_create);
+    time_point_sec expected_first_period_start_time = db.head_block_time() + db.get_global_properties().parameters.block_interval*5; // Hard-coded to synchronize with withdraw_permission_create()
+    uint64_t expected_period_duration_seconds = fc::hours(1).to_seconds(); // Hard-coded to synchronize with withdraw_permission_create()
 
     auto nathan_private_key = generate_private_key("nathan");
     auto dan_private_key = generate_private_key("dan");
@@ -884,7 +667,7 @@ BOOST_AUTO_TEST_CASE( withdraw_permission_incremental_case )
 
 BOOST_AUTO_TEST_CASE( withdraw_permission_update )
 { try {
-   INVOKE(withdraw_permission_create_before_hardfork_23);
+   INVOKE(withdraw_permission_create);
 
    auto nathan_private_key = generate_private_key("nathan");
    account_id_type nathan_id = get_account("nathan").id;

--- a/tests/tests/uia_tests.cpp
+++ b/tests/tests/uia_tests.cpp
@@ -265,17 +265,8 @@ BOOST_AUTO_TEST_CASE( transfer_whitelist_uia )
       BOOST_TEST_MESSAGE( "Attempting to transfer from nathan after blacklisting, should fail" );
       op.amount = advanced.amount(50);
       trx.operations.back() = op;
-      //Fail because nathan is blacklisted
-      if( db.head_block_time() <= HARDFORK_419_TIME )
-      {
-         // before the hardfork time, it fails because the whitelist check fails
-         GRAPHENE_REQUIRE_THROW(PUSH_TX( db, trx, ~0 ), transfer_from_account_not_whitelisted );
-      }
-      else
-      {
-         // after the hardfork time, it fails because the fees are not in a whitelisted asset
-         GRAPHENE_REQUIRE_THROW(PUSH_TX( db, trx, ~0 ), fc::exception );
-      }
+      // it fails because the fees are not in a whitelisted asset
+      GRAPHENE_REQUIRE_THROW(PUSH_TX( db, trx, ~0 ), fc::exception );
 
       BOOST_TEST_MESSAGE( "Attempting to burn from nathan after blacklisting, should fail" );
       asset_reserve_operation burn;

--- a/tests/tests/uia_tests.cpp
+++ b/tests/tests/uia_tests.cpp
@@ -512,11 +512,7 @@ BOOST_AUTO_TEST_CASE( asset_name_test )
       create_user_issued_asset( "ALPHA.ONE", alice_id(db), 0 );
       BOOST_CHECK(  has_asset("ALPHA") );    BOOST_CHECK( has_asset("ALPHA.ONE") );
 
-      // Sam tries to create asset ending in a number but fails before hf_620
-      GRAPHENE_REQUIRE_THROW( create_user_issued_asset( "SP500", sam_id(db), 0 ), fc::assert_exception );
-      BOOST_CHECK(  !has_asset("SP500") );
-
-      // create a proposal to create asset ending in a number, this will fail before hf_620
+      // create a proposal to create asset ending in a number
       auto& core = asset_id_type()(db);
       asset_create_operation op_p;
       op_p.issuer = alice_id;
@@ -537,9 +533,8 @@ BOOST_AUTO_TEST_CASE( asset_name_test )
       db.current_fee_schedule().set_fee( tx.operations.back() );
       set_expiration( db, tx );
       sign( tx, alice_private_key );
-      GRAPHENE_REQUIRE_THROW(PUSH_TX( db, tx ), fc::assert_exception);
+      PUSH_TX( db, tx );
 
-      generate_blocks( HARDFORK_CORE_620_TIME + 1);
       generate_block();
 
       // Sam can create asset ending in number after hf_620

--- a/tests/tests/uia_tests.cpp
+++ b/tests/tests/uia_tests.cpp
@@ -154,14 +154,6 @@ BOOST_AUTO_TEST_CASE( issue_whitelist_uia )
       op.issue_to_account = nathan_id;
       trx.operations.emplace_back(op);
       set_expiration( db, trx );
-      //Fail because nathan is not whitelisted, but only before hardfork time
-      if( db.head_block_time() <= HARDFORK_415_TIME )
-      {
-         GRAPHENE_REQUIRE_THROW(PUSH_TX( db, trx, ~0 ), fc::exception);
-         generate_blocks( HARDFORK_415_TIME );
-         generate_block();
-         set_expiration( db, trx );
-      }
       PUSH_TX( db, trx, ~0 );
 
       BOOST_CHECK(is_authorized_asset( db, nathan_id(db), uia_id(db) ));


### PR DESCRIPTION
Fixes #1553 

There are some hardfork dates that have long passed, and the alternate logic never was used. This PR removes those unnecessary sections.

All hardfork code prior to v3.0.0 was reviewed. The code that remains is believed to be necessary, and was untouched.

Snapshots were done on testnet and mainnet to assure that the results are the same.