### PR TITLE
install debug_witness headers

### DIFF
--- a/libraries/plugins/debug_witness/CMakeLists.txt
+++ b/libraries/plugins/debug_witness/CMakeLists.txt
@@ -16,3 +16,4 @@ install( TARGETS
    LIBRARY DESTINATION lib
    ARCHIVE DESTINATION lib
 )
+INSTALL( FILES ${HEADERS} DESTINATION "include/graphene/debug_witness" )


### PR DESCRIPTION
Adds debug_witness headers to installation.

These headers were not installed, but are used by other header files that are installed.