### PR TITLE
Fix unused variable warning

### DIFF
--- a/tests/tests/fee_tests.cpp
+++ b/tests/tests/fee_tests.cpp
@@ -274,8 +274,6 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
 
         };
 
-        const asset_object& core_asset = asset_id_type()(db);
-
         // deposit 100 BTS to the fee pool of ALICEUSD asset
         fund_fee_pool( alice_id(db), aliceusd_id(db), _core(100).amount );
 


### PR DESCRIPTION
This code hasn't been touched in a year... why am I only seeing this warning now?... :confused: