### PR TITLE
Support compiling with C++17/C++2a

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,10 @@ IF(NOT "${Boost_VERSION}" MATCHES "1.53(.*)")
    SET(Boost_LIBRARIES ${BOOST_LIBRARIES_TEMP} ${Boost_LIBRARIES})
 ENDIF()
 
+if( NOT CPP_STANDARD )
+  set( CPP_STANDARD "-std=c++11" )
+endif()
+
 if( WIN32 )
 
     message( STATUS "Configuring BitShares on WIN32")
@@ -109,11 +113,11 @@ else( WIN32 ) # Apple AND Linux
     if( APPLE )
         # Apple Specific Options Here
         message( STATUS "Configuring BitShares on OS X" )
-        set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++11 -stdlib=libc++ -Wall" )
+        set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${CPP_STANDARD} -stdlib=libc++ -Wall" )
     else( APPLE )
         # Linux Specific Options Here
         message( STATUS "Configuring BitShares on Linux" )
-        set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++11 -Wall" )
+        set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${CPP_STANDARD} -Wall" )
         if(USE_PROFILER)
             set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pg" )
         endif( USE_PROFILER )

--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -405,7 +405,7 @@ namespace graphene { namespace app {
        if( start == 0 )
           start = stats.total_ops;
        else
-          start = min( stats.total_ops, start );
+          start = std::min( stats.total_ops, start );
 
        if( start >= stop && start > stats.removed_ops && limit > 0 )
        {

--- a/libraries/app/include/graphene/app/api.hpp
+++ b/libraries/app/include/graphene/app/api.hpp
@@ -53,7 +53,9 @@ namespace graphene { namespace app {
    using namespace graphene::market_history;
    using namespace graphene::grouped_orders;
    using namespace fc::ecc;
-   using namespace std;
+   using std::string;
+   using std::vector;
+   using std::map;
 
    class application;
 

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -61,7 +61,9 @@ namespace graphene { namespace app {
 
 using namespace graphene::chain;
 using namespace graphene::market_history;
-using namespace std;
+using std::string;
+using std::vector;
+using std::map;
 
 class database_api_impl;
 

--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -31,7 +31,8 @@
 using namespace graphene::app;
 using namespace graphene::chain;
 using namespace graphene::utilities;
-using namespace std;
+using std::string;
+using std::vector;
 
 namespace fc
 {

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -94,6 +94,16 @@ namespace fc {
 
 namespace graphene { namespace wallet {
 
+using std::ostream;
+using std::stringstream;
+using std::to_string;
+using std::setprecision;
+using std::fixed;
+using std::ios;
+using std::setiosflags;
+using std::setw;
+using std::endl;
+
 namespace detail {
 
 struct operation_result_printer

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -80,6 +80,9 @@ int sockQuit(void)
 
 #include "../common/genesis_file_util.hpp"
 
+using std::exception;
+using std::cerr;
+
 #define INVOKE(test) ((struct test*)this)->test_method();
 
 //////


### PR DESCRIPTION
Bitshares used 'using namespace std' in several places, and this
caused conflicts between fc::variant and the new std::variant.
Fixed by just importing the specific identifiers we use from
namespace std.