### PR TITLE
Travis / sonar fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,17 +29,14 @@ script:
  - ccache -s
  - programs/build_helpers/buildstep Prepare 1 "sed -i '/tests/d' libraries/fc/CMakeLists.txt"
  - programs/build_helpers/buildstep cmake 5 "cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS=--coverage -DCMAKE_CXX_FLAGS=--coverage -DBoost_USE_STATIC_LIBS=OFF -DCMAKE_CXX_OUTPUT_EXTENSION_REPLACE=ON ."
- - programs/build_helpers/buildstep make.cli_wallet 1600 "programs/build_helpers/make_with_sonar bw-output -j 2 cli_wallet"
- - programs/build_helpers/buildstep make.witness_node 300 "programs/build_helpers/make_with_sonar bw-output -j 2 witness_node"
- - programs/build_helpers/buildstep make.serializer 45 "programs/build_helpers/make_with_sonar bw-output -j 2 js_operation_serializer"
- - programs/build_helpers/buildstep make.get_dev_key 10 "programs/build_helpers/make_with_sonar bw-output -j 2 get_dev_key"
- - programs/build_helpers/buildstep make.chain_test 900 "programs/build_helpers/make_with_sonar bw-output -j 2 chain_test"
- - programs/build_helpers/buildstep make.cli_test 200 "programs/build_helpers/make_with_sonar bw-output -j 2 cli_test"
- - programs/build_helpers/buildstep make.perf_test 120 "programs/build_helpers/make_with_sonar bw-output -j 2 performance_test"
+ - programs/build_helpers/buildstep make.cli_wallet 2200 "programs/build_helpers/make_with_sonar bw-output -j 2 cli_wallet witness_node js_operation_serializer get_dev_key network_mapper"
+ - programs/build_helpers/buildstep make.chain_test 1000 "make -j 2 chain_test"
+ - programs/build_helpers/buildstep make.cli_test 200 "make -j 2 cli_test"
+ - programs/build_helpers/buildstep make.perf_test 120 "make -j 2 performance_test"
  - set -o pipefail
  - programs/build_helpers/buildstep run.chain_test 240 "libraries/fc/tests/run-parallel-tests.sh tests/chain_test"
- - programs/build_helpers/buildstep run.cli_test 30 "libraries/fc/tests/run-parallel-tests.sh tests/cli_test"
- - programs/build_helpers/buildstep prepare.sonar 20 'find libraries/[acdenptuw]*/CMakeFiles/*.dir programs/[cdgjsw]*/CMakeFiles/*.dir -type d | while read d; do gcov -o "$d" "${d/CMakeFiles*.dir//}"/*.cpp; done >/dev/null'
- - programs/build_helpers/buildstep run.sonar 400 "which sonar-scanner && sonar-scanner || true"
+ - programs/build_helpers/buildstep run.cli_test 60 "libraries/fc/tests/run-parallel-tests.sh tests/cli_test"
+ - 'programs/build_helpers/buildstep prepare.sonar 20 "find libraries/[acdenptuw]*/CMakeFiles/*.dir programs/[cdgjsw]*/CMakeFiles/*.dir -type d | while read d; do gcov -o \"\$d\" \"\${d/CMakeFiles*.dir//}\"/*.cpp; done >/dev/null; programs/build_helpers/set_sonar_branch sonar-project.properties" || true'
+ - 'programs/build_helpers/buildstep run.sonar 1200 "which sonar-scanner && sonar-scanner" || true'
  - programs/build_helpers/buildstep end 0
  - ccache -s

--- a/programs/build_helpers/set_sonar_branch
+++ b/programs/build_helpers/set_sonar_branch
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+# Relevant variables set by travis:
+# TRAVIS_BRANCH:
+# * for push builds, or builds not triggered by a pull request, this is the
+#   name of the branch.
+# * for builds triggered by a pull request this is the name of the branch
+#   targeted by the pull request.
+# * for builds triggered by a tag, this is the same as the name of the tag
+#   (see TRAVIS_TAG).
+# TRAVIS_PULL_REQUEST: The pull request number if the current job is a pull
+#   request, “false” if it’s not a pull request.
+# TRAVIS_TAG: If the current build is for a git tag, this variable is set to
+#   the tag’s name.
+
+if [ "$#" != 1 ]; then
+    echo "Usage: $0 <sonar-properties-file>" 1>&2
+    exit 1
+fi
+
+clear_branch () {
+    sed -i '/sonar\.branch/d' "$1"
+}
+
+TARGET=
+FETCH=
+
+if [ -n "$TRAVIS_PULL_REQUEST" -a "$TRAVIS_PULL_REQUEST" != false ]; then
+    # PRs work per default
+    echo "Detected PR '$TRAVIS_PULL_REQUEST'"
+    clear_branch "$1"
+    FETCH="$TRAVIS_BRANCH"
+elif [ -n "$TRAVIS_TAG" ]; then
+    # Tag build is either master or testnet
+    echo "Detected tag '$TRAVIS_TAG'"
+    clear_branch "$1"
+    case "$TRAVIS_TAG" in
+	*test*) TARGET=testnet; FETCH=testnet; ;;
+	*)	FETCH=master; ;;
+    esac
+else
+    case "$TRAVIS_BRANCH" in
+	master|develop|testnet|next_hardfork)
+	    # Long-lived branches stand for themselves
+	    echo "Detected long-lived branch '$TRAVIS_BRANCH'"
+	    clear_branch "$1"
+	    FETCH="$TRAVIS_BRANCH"
+	    ;;
+	*test*release*)
+	    # Testnet release branch will be merged into testnet
+	    echo "Detected testnet release branch '$TRAVIS_BRANCH'"
+	    clear_branch "$1"
+	    TARGET=testnet
+	    FETCH=testnet
+	    ;;
+	*release*)
+	    # Release branch will be merged into default (master)
+	    echo "Detected release branch '$TRAVIS_BRANCH'"
+	    clear_branch "$1"
+	    FETCH=master
+	    ;;
+	*)
+	    # All other branches should have sonar.branch.target in their
+	    # sonar.properties, leave it unchanged
+	    echo "Detected normal branch '$TRAVIS_BRANCH'"
+	    FETCH="$( grep 'sonar\.branch\.target' "$1" | sed 's=^.*[:=] *==' )"
+    esac
+fi
+
+echo "Branch target '$TARGET', fetch target '$FETCH'"
+
+if [ -n "$TARGET" ]; then
+    echo "sonar.branch.target=$TARGET" >>"$1"
+fi
+#if [ -n "$FETCH" ]; then
+    # Unfortunately this leads to sonar failing. Apparently it needs a full
+    # clone, not a shallow one. Since our repo is somewhat large and this is
+    # only required for blame annotations, disabled for now.
+    #git fetch --depth=50 origin "$FETCH:$FETCH"
+#fi
+
+exit 0

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,3 +12,6 @@ sonar.sources=libraries,programs
 sonar.cfamily.build-wrapper-output=bw-output
 sonar.cfamily.gcov.reportsPath=.
 sonar.cfamily.threads=2
+
+# should be changed in hardfork branch and removed in release branches
+sonar.branch.target=develop


### PR DESCRIPTION
Sonar scans haven't been working properly for a while. It turned out that changes in our travis build script were responsible - apparently the sonar build wrapper doesn't work incrementally, so we must build all to-be-scanned targets in one go instead of sequentially.

Also made some other improvements to the travis script, most noteworthy is that the sonar stuff will no longer fail the build. This should lead to fewer red flags, but we may have to trigger rebuilds sometime to actually see the sonar results.

Also fixes sonar target branch detection (more precisely, makes the target branch explicit for develop/hardfork, which will require an additional change when merging to hardfork).