### PR TITLE
add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Set the default behavior, in case core.autocrlf is set incorrectly
+# Note: this is mainly to properly canonicalize the input to embed_genesis
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
-# Set the default behavior, in case core.autocrlf is set incorrectly
-# Note: this is mainly to properly canonicalize the input to embed_genesis
-* text eol=lf
+# Set the default behavior of genesis.json, in case core.autocrlf is set incorrectly
+genesis.json eol=lf


### PR DESCRIPTION
This fixes #1754 

By controlling how git handles text files on Windows, we can assure that the correct chain id gets generated.

Note: This change causes that all text files cloned by git are saved with LF, instead of the Windows standard CRLF. I believe there are no problems in permitting all files to retain their standard non-Windows encoding. But should this cause problems in some area, the `.gitattributes` file can be modified to control which line endings are applied to which files.