### PR TITLE
Protect SIGQUIT handlers with ifdef to fix windows build

### DIFF
--- a/programs/cli_wallet/main.cpp
+++ b/programs/cli_wallet/main.cpp
@@ -285,14 +285,14 @@ int main( int argc, char** argv )
             fc::set_signal_handler( [](int sig) {}, SIGINT ); // reinstall an empty SIGINT handler
             wallet_cli->cancel();
          }, SIGTERM );
-
+#ifdef SIGQUIT
          fc::set_signal_handler( [wallet_cli,sig_set](int signal) {
             ilog( "Captured SIGQUIT not in daemon mode, exiting" );
             sig_set->cancel();
             fc::set_signal_handler( [](int sig) {}, SIGINT ); // reinstall an empty SIGINT handler
             wallet_cli->cancel();
          }, SIGQUIT );
-
+#endif
          boost::signals2::scoped_connection closed_connection( con->closed.connect( [wallet_cli,sig_set] {
             elog( "Server has disconnected us." );
             sig_set->cancel();
@@ -320,12 +320,12 @@ int main( int argc, char** argv )
             ilog( "Captured SIGTERM in daemon mode, exiting" );
             exit_promise->set_value(signal);
          }, SIGTERM );
-
+#ifdef SIGQUIT
          fc::set_signal_handler( [&exit_promise](int signal) {
             ilog( "Captured SIGQUIT in daemon mode, exiting" );
             exit_promise->set_value(signal);
          }, SIGQUIT );
-
+#endif
          boost::signals2::scoped_connection closed_connection( con->closed.connect( [&exit_promise] {
             elog( "Server has disconnected us." );
             exit_promise->set_value(0);


### PR DESCRIPTION
Apparently SIGQUIT does not exist on windows. This PR disables the signal handler in cli_wallet if the signal isn't available.