### PR TITLE
fix duplicate results in get_key_references

### DIFF
--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -257,7 +257,7 @@ class database_api
       // Keys //
       //////////
 
-      vector<vector<account_id_type>> get_key_references( vector<public_key_type> key )const;
+      vector<flat_set<account_id_type>> get_key_references( vector<public_key_type> key )const;
 
      /**
       * Determine whether a textual representation of a public key

--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -1634,7 +1634,7 @@ class wallet_api
        * @param keys public keys to search for related accounts
        * @return the set of related accounts
        */
-      vector<vector<account_id_type>> get_key_references(const vector<public_key_type> &keys) const;
+      vector<flat_set<account_id_type>> get_key_references(const vector<public_key_type> &keys) const;
 
       /** Returns an uninitialized object representing a given blockchain operation.
        *

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2216,7 +2216,7 @@ public:
       return tx.get_signature_keys(_chain_id);
    }
 
-   vector<vector<account_id_type>> get_key_references(const vector<public_key_type> &keys) const
+   vector<flat_set<account_id_type>> get_key_references(const vector<public_key_type> &keys) const
    {
        return _remote_db->get_key_references(keys);
    }
@@ -4080,7 +4080,7 @@ flat_set<public_key_type> wallet_api::get_transaction_signers(const signed_trans
    return my->get_transaction_signers(tx);
 } FC_CAPTURE_AND_RETHROW( (tx) ) }
 
-vector<vector<account_id_type>> wallet_api::get_key_references(const vector<public_key_type> &keys) const
+vector<flat_set<account_id_type>> wallet_api::get_key_references(const vector<public_key_type> &keys) const
 { try {
    return my->get_key_references(keys);
 } FC_CAPTURE_AND_RETHROW( (keys) ) }

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -473,7 +473,7 @@ BOOST_FIXTURE_TEST_CASE( cli_get_signed_transaction_signers, cli_fixture )
 
       const auto &test_acc = con.wallet_api_ptr->get_account("test");
       flat_set<public_key_type> expected_signers = {test_bki.pub_key};
-      vector<vector<account_id_type> > expected_key_refs{{test_acc.id, test_acc.id}};
+      vector<flat_set<account_id_type> > expected_key_refs{{test_acc.id, test_acc.id}};
 
       auto signers = con.wallet_api_ptr->get_transaction_signers(signed_trx);
       BOOST_CHECK(signers == expected_signers);
@@ -526,7 +526,10 @@ BOOST_FIXTURE_TEST_CASE( cli_get_available_transaction_signers, cli_fixture )
 
       // blockchain has no references to unknown accounts (privkey_1, privkey_2)
       // only test account available
-      vector<vector<account_id_type> > expected_key_refs{{}, {}, {test_acc.id, test_acc.id}};
+      vector<flat_set<account_id_type> > expected_key_refs;
+      expected_key_refs.push_back(flat_set<account_id_type>());
+      expected_key_refs.push_back(flat_set<account_id_type>());
+      expected_key_refs.push_back({test_acc.id});
 
       auto key_refs = con.wallet_api_ptr->get_key_references({expected_signers.begin(), expected_signers.end()});
       std::sort(key_refs.begin(), key_refs.end());

--- a/tests/tests/database_api_tests.cpp
+++ b/tests/tests/database_api_tests.cpp
@@ -1105,7 +1105,7 @@ BOOST_AUTO_TEST_CASE( api_limit_get_key_references ){
       numbered_private_keys.push_back( privkey );
       numbered_key_id.push_back( pubkey );
    }
-   vector< vector<account_id_type> > final_result=db_api.get_key_references(numbered_key_id);
+   vector< flat_set<account_id_type> > final_result=db_api.get_key_references(numbered_key_id);
    BOOST_REQUIRE_EQUAL( final_result.size(), 2u );
    numbered_private_keys.reserve( num_keys );
    for( int i=num_keys1; i<num_keys; i++ )


### PR DESCRIPTION
Pull for https://github.com/bitshares/bitshares-core/issues/1209

The issue is also part of https://github.com/bitshares/bitshares-core/issues/1753

I think we should work in the dupes here while leaving #1753 for pagination.

This pull request implements `flat_set` as described by @abitmore here https://github.com/bitshares/bitshares-core/issues/1753#issue-442917417 to solve the issue.