### PR TITLE
Update Dockerfile, default_config.ini and bitsharesentry.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.10.1
+FROM ubuntu:bionic
 MAINTAINER The bitshares decentralized organisation
 
 ENV LANG=en_US.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM phusion/baseimage:0.11
 MAINTAINER The bitshares decentralized organisation
 
 ENV LANG=en_US.UTF-8

--- a/docker/bitsharesentry.sh
+++ b/docker/bitsharesentry.sh
@@ -18,6 +18,7 @@ VERSION=`cat /etc/bitshares/version`
 #   * $BITSHARESD_PARTIAL_OPERATIONS
 #   * $BITSHARESD_MAX_OPS_PER_ACCOUNT
 #   * $BITSHARESD_ES_NODE_URL
+#   * $BITSHARESD_ES_START_AFTER_BLOCK
 #   * $BITSHARESD_TRUSTED_NODE
 #
 
@@ -68,6 +69,10 @@ fi
 
 if [[ ! -z "$BITSHARESD_ES_NODE_URL" ]]; then
     ARGS+=" --elasticsearch-node-url=${BITSHARESD_ES_NODE_URL}"
+fi
+
+if [[ ! -z "$BITSHARESD_ES_START_AFTER_BLOCK" ]]; then
+    ARGS+=" --elasticsearch-start-es-after-block=${BITSHARESD_ES_START_AFTER_BLOCK}"
 fi
 
 if [[ ! -z "$BITSHARESD_TRUSTED_NODE" ]]; then

--- a/docker/default_config.ini
+++ b/docker/default_config.ini
@@ -35,7 +35,7 @@ rpc-endpoint = 0.0.0.0:8090
 enable-stale-production = false
 
 # Percent of witnesses (0-99) that must be participating in order to produce blocks
-required-participation = false
+required-participation = 0
 
 # ID of witness controlled by this node (e.g. "1.6.5", quotes are required, may specify multiple times)
 # witness-id = 

--- a/docker/default_config.ini
+++ b/docker/default_config.ini
@@ -35,7 +35,7 @@ rpc-endpoint = 0.0.0.0:8090
 enable-stale-production = false
 
 # Percent of witnesses (0-99) that must be participating in order to produce blocks
-required-participation = 0
+required-participation = 33
 
 # ID of witness controlled by this node (e.g. "1.6.5", quotes are required, may specify multiple times)
 # witness-id = 

--- a/docker/default_config.ini
+++ b/docker/default_config.ini
@@ -35,7 +35,7 @@ rpc-endpoint = 0.0.0.0:8090
 enable-stale-production = false
 
 # Percent of witnesses (0-99) that must be participating in order to produce blocks
-required-participation = 33
+# required-participation = 33
 
 # ID of witness controlled by this node (e.g. "1.6.5", quotes are required, may specify multiple times)
 # witness-id = 


### PR DESCRIPTION
Update Dockerfile to use ubuntu:bionic instead of phusion baseimage, had libcurl issues (have the issue on telegram)

Updated bitsharesentry.sh to add support to the BITSHARESD_ES_START_AFTER_BLOCK env var, to tell the witness_node to only start throwing data onto ES after the specified block

Updated default_config as per test-3.2.0 release


