### PR TITLE
add htlc parameters to developer genesis

### DIFF
--- a/libraries/egenesis/genesis-dev.json
+++ b/libraries/egenesis/genesis-dev.json
@@ -237,7 +237,12 @@
     "accounts_per_fee_scale": 1000,
     "account_fee_scale_bitshifts": 4,
     "max_authority_depth": 2,
-    "extensions": []
+    "extensions": {
+        "updatable_htlc_options": {
+            "max_timeout_secs": 2592000,
+            "max_preimage_size": 1024000
+        }
+    }
   },
   "initial_accounts": [{
       "name": "init0",


### PR DESCRIPTION
In a private testnet HTLC commands will fail due to the related missing committee member parameters.

The easier to do is to add them to the genesis file. This pull add the needed ones to developer genesis version. `htlc_create` just works with this addition and a new private testnet using this genesis.