### PR TITLE
Fix chain_test: Committee and witnesses initialization in genesis

### DIFF
--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -91,6 +91,9 @@ database_fixture::database_fixture(const fc::time_point_sec &initial_timestamp)
    else
       genesis_state.initial_active_witnesses = 10;
 
+   genesis_state.immutable_parameters.min_committee_member_count = INITIAL_COMMITTEE_MEMBER_COUNT;
+   genesis_state.immutable_parameters.min_witness_count = INITIAL_WITNESS_COUNT;
+
    for( unsigned int i = 0; i < genesis_state.initial_active_witnesses; ++i )
    {
       auto name = "init"+fc::to_string(i);
@@ -309,6 +312,46 @@ database_fixture::~database_fixture()
       BOOST_FAIL( "Uncaught exception in ~database_fixture" );
    }
 } 
+
+void database_fixture::vote_for_committee_and_witnesses(uint16_t num_committee, uint16_t num_witness)
+{ try {
+
+   auto &init0 = get_account("init0");
+   fund(init0, asset(10));
+
+   flat_set<vote_id_type> votes;
+
+   const auto& wits = db.get_index_type<witness_index>().indices().get<by_id>();
+   num_witness = std::min(num_witness, (uint16_t) wits.size());
+   auto wit_end = wits.begin();
+   std::advance(wit_end, num_witness);
+   std::transform(wits.begin(), wit_end,
+                  std::inserter(votes, votes.end()),
+                  [](const witness_object& w) { return w.vote_id; });
+
+   const auto& comms = db.get_index_type<committee_member_index>().indices().get<by_id>();
+   num_committee = std::min(num_committee, (uint16_t) comms.size());
+   auto comm_end = comms.begin();
+   std::advance(comm_end, num_committee);
+   std::transform(comms.begin(), comm_end,
+                  std::inserter(votes, votes.end()),
+                  [](const committee_member_object& cm) { return cm.vote_id; });
+
+   account_update_operation op;
+   op.account = init0.get_id();
+   op.new_options = init0.options;
+   op.new_options->votes = votes;
+   op.new_options->num_witness = num_witness;
+   op.new_options->num_committee = num_committee;
+
+   op.fee = db.current_fee_schedule().calculate_fee( op );
+
+   trx.operations.push_back(op);
+   trx.validate();
+   PUSH_TX(db, trx, ~0);
+   trx.operations.clear();
+
+} FC_CAPTURE_AND_RETHROW() }
 
 fc::ecc::private_key database_fixture::generate_private_key(string seed)
 {

--- a/tests/common/database_fixture.hpp
+++ b/tests/common/database_fixture.hpp
@@ -171,6 +171,9 @@ extern uint32_t GRAPHENE_TESTING_GENESIS_TIMESTAMP;
 #define ACTORS_IMPL(r, data, elem) ACTOR(elem)
 #define ACTORS(names) BOOST_PP_SEQ_FOR_EACH(ACTORS_IMPL, ~, names)
 
+#define INITIAL_WITNESS_COUNT (9u)
+#define INITIAL_COMMITTEE_MEMBER_COUNT INITIAL_WITNESS_COUNT
+
 namespace graphene { namespace chain {
 
 class clearable_block : public signed_block {
@@ -205,6 +208,7 @@ struct database_fixture {
    string generate_anon_acct_name();
    static void verify_asset_supplies( const database& db );
    void open_database();
+   void vote_for_committee_and_witnesses(uint16_t num_committee, uint16_t num_witness);
    signed_block generate_block(uint32_t skip = ~0,
                                const fc::ecc::private_key& key = generate_private_key("null_key"),
                                int miss_blocks = 0);

--- a/tests/tests/bitasset_tests.cpp
+++ b/tests/tests/bitasset_tests.cpp
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE( reset_backing_asset_on_witness_asset )
    std::vector<account_id_type> active_witnesses;
    for(const witness_id_type& wit_id : global_props.active_witnesses)
       active_witnesses.push_back(wit_id(db).witness_account);
-   BOOST_REQUIRE_EQUAL(active_witnesses.size(), 10lu);
+   BOOST_REQUIRE_EQUAL(active_witnesses.size(), INITIAL_WITNESS_COUNT);
 
    {
       BOOST_TEST_MESSAGE("Adding price feed 1");

--- a/tests/tests/block_tests.cpp
+++ b/tests/tests/block_tests.cpp
@@ -52,6 +52,9 @@ genesis_state_type make_genesis() {
 
    auto init_account_priv_key = fc::ecc::private_key::regenerate(fc::sha256::hash(string("null_key")));
    genesis_state.initial_active_witnesses = 10;
+   genesis_state.immutable_parameters.min_committee_member_count = INITIAL_COMMITTEE_MEMBER_COUNT;
+   genesis_state.immutable_parameters.min_witness_count = INITIAL_WITNESS_COUNT;
+
    for( unsigned int i = 0; i < genesis_state.initial_active_witnesses; ++i )
    {
       auto name = "init"+fc::to_string(i);
@@ -1418,25 +1421,33 @@ BOOST_AUTO_TEST_CASE( genesis_reserve_ids )
 
 BOOST_FIXTURE_TEST_CASE( miss_some_blocks, database_fixture )
 { try {
+   // Witnesses scheduled incorrectly in genesis block - reschedule
+   generate_blocks( witness_schedule_id_type()(db).current_shuffled_witnesses.size() );
+   generate_blocks( db.get_dynamic_global_properties().next_maintenance_time );
+
    std::vector<witness_id_type> witnesses = witness_schedule_id_type()(db).current_shuffled_witnesses;
-   BOOST_CHECK_EQUAL( 10u, witnesses.size() );
+   BOOST_CHECK_EQUAL( INITIAL_WITNESS_COUNT, witnesses.size() );
    // database_fixture constructor calls generate_block once, signed by witnesses[0]
    generate_block(); // witnesses[1]
    generate_block(); // witnesses[2]
    for( const auto& id : witnesses )
       BOOST_CHECK_EQUAL( 0, id(db).total_missed );
    // generate_blocks generates another block *now* (witnesses[3])
-   // and one at now+10 blocks (witnesses[12%10])
-   generate_blocks( db.head_block_time() + db.get_global_properties().parameters.block_interval * 10, true );
-   // i. e. 8 blocks are missed in between by witness[4..11%10]
+   // and one at now+9 blocks (witnesses[12%9])
+   generate_blocks( db.head_block_time() + db.get_global_properties().parameters.block_interval * 9, true );
+   // i. e. 7 blocks are missed in between by witness[4..11%9]
    for( uint32_t i = 0; i < witnesses.size(); i++ )
-      BOOST_CHECK_EQUAL( (i+7) % 10 < 2 ? 0 : 1, witnesses[i](db).total_missed );
+      BOOST_CHECK_EQUAL( (i+6) % 9 < 2 ? 0 : 1, witnesses[i](db).total_missed );
 } FC_LOG_AND_RETHROW() }
 
 BOOST_FIXTURE_TEST_CASE( miss_many_blocks, database_fixture )
 {
    try
    {
+      // Witnesses scheduled incorrectly in genesis block - reschedule
+      generate_blocks( witness_schedule_id_type()(db).current_shuffled_witnesses.size() );
+      generate_blocks( db.get_dynamic_global_properties().next_maintenance_time );
+
       auto get_misses = []( database& db ) {
          std::map< witness_id_type, uint32_t > misses;
          for( const auto& witness_id : witness_schedule_id_type()(db).current_shuffled_witnesses )
@@ -1447,8 +1458,8 @@ BOOST_FIXTURE_TEST_CASE( miss_many_blocks, database_fixture )
       generate_block();
       generate_block();
       auto missed_before = get_misses( db );
-      // miss 10 maintenance intervals
-      generate_blocks( db.get_dynamic_global_properties().next_maintenance_time + db.get_global_properties().parameters.maintenance_interval * 10, true );
+      // miss 9 maintenance intervals
+      generate_blocks( db.get_dynamic_global_properties().next_maintenance_time + db.get_global_properties().parameters.maintenance_interval * 9, true );
       generate_block();
       generate_block();
       generate_block();

--- a/tests/tests/block_tests.cpp
+++ b/tests/tests/block_tests.cpp
@@ -1459,7 +1459,8 @@ BOOST_FIXTURE_TEST_CASE( miss_many_blocks, database_fixture )
       generate_block();
       auto missed_before = get_misses( db );
       // miss 9 maintenance intervals
-      generate_blocks( db.get_dynamic_global_properties().next_maintenance_time + db.get_global_properties().parameters.maintenance_interval * 9, true );
+      generate_blocks( db.get_dynamic_global_properties().next_maintenance_time + 
+                       db.get_global_properties().parameters.maintenance_interval * 9, true );
       generate_block();
       generate_block();
       generate_block();

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -1705,7 +1705,7 @@ BOOST_AUTO_TEST_CASE( witness_feeds )
       vector<account_id_type> active_witnesses;
       for( const witness_id_type& wit_id : global_props.active_witnesses )
          active_witnesses.push_back( wit_id(db).witness_account );
-      BOOST_REQUIRE_EQUAL(active_witnesses.size(), 10u);
+      BOOST_REQUIRE_EQUAL(active_witnesses.size(), INITIAL_WITNESS_COUNT);
 
       asset_publish_feed_operation op;
       op.publisher = active_witnesses[0];

--- a/tests/tests/smartcoin_tests.cpp
+++ b/tests/tests/smartcoin_tests.cpp
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(bsip36)
 
       // Check current default witnesses, default chain is configured with 10 witnesses
       auto witnesses = db.get_global_properties().active_witnesses;
-      BOOST_CHECK_EQUAL(witnesses.size(), 10u);
+      BOOST_CHECK_EQUAL(witnesses.size(), INITIAL_WITNESS_COUNT);
       BOOST_CHECK_EQUAL(witnesses.begin()[0].instance.value, 1u);
       BOOST_CHECK_EQUAL(witnesses.begin()[1].instance.value, 2u);
       BOOST_CHECK_EQUAL(witnesses.begin()[2].instance.value, 3u);
@@ -142,13 +142,18 @@ BOOST_AUTO_TEST_CASE(bsip36)
       BOOST_CHECK_EQUAL(witnesses.begin()[6].instance.value, 7u);
       BOOST_CHECK_EQUAL(witnesses.begin()[7].instance.value, 8u);
       BOOST_CHECK_EQUAL(witnesses.begin()[8].instance.value, 9u);
-      BOOST_CHECK_EQUAL(witnesses.begin()[9].instance.value, 10u);
 
       // We need to activate 11 witnesses by voting for each of them.
       // Each witness is voted with incremental stake so last witness created will be the ones with more votes
+
+      // by default we have 9 witnesses, we need to vote for desired witness count (11) to increase them
+      vote_for_committee_and_witnesses(9, 11);
+
       int c = 0;
       for (auto l : witness_map) {
-         int stake = 100 + c + 1;
+         // voting stake have step of 100
+         // so vote_for_committee_and_witnesses() with stake=10 does not affect the expected result
+         int stake = 100 * (c + 1);
          transfer(committee_account, l.first, asset(stake));
          {
             account_update_operation op;
@@ -206,7 +211,7 @@ BOOST_AUTO_TEST_CASE(bsip36)
       BOOST_CHECK_EQUAL(itr[1].first.instance.value, 17u);
 
       // Activate witness11 with voting stake, will kick the witness with less votes(witness0) out of the active list
-      transfer(committee_account, witness11_id, asset(121));
+      transfer(committee_account, witness11_id, asset(1200));
       set_expiration(db, trx);
       {
          account_update_operation op;
@@ -328,7 +333,7 @@ BOOST_AUTO_TEST_CASE(bsip36)
       BOOST_CHECK_EQUAL(itr[0].first.instance.value, 17u);
 
       // Reactivate witness0
-      transfer(committee_account, witness0_id, asset(100));
+      transfer(committee_account, witness0_id, asset(1000));
       set_expiration(db, trx);
       {
          account_update_operation op;

--- a/tests/tests/voting_tests.cpp
+++ b/tests/tests/voting_tests.cpp
@@ -26,6 +26,7 @@
 
 #include <graphene/app/database_api.hpp>
 #include <graphene/chain/exceptions.hpp>
+#include <graphene/chain/hardfork.hpp>
 
 #include <iostream>
 
@@ -37,12 +38,53 @@ using namespace graphene::chain::test;
 
 BOOST_FIXTURE_TEST_SUITE(voting_tests, database_fixture)
 
+BOOST_FIXTURE_TEST_CASE( committee_account_initialization_test, database_fixture )
+{ try {
+   // Check current default committee
+   // By default chain is configured with INITIAL_COMMITTEE_MEMBER_COUNT=9 members
+   const auto &committee_members = db.get_global_properties().active_committee_members;
+   const auto &committee = committee_account(db);
+
+   BOOST_CHECK_EQUAL(committee_members.size(), INITIAL_COMMITTEE_MEMBER_COUNT);
+   BOOST_CHECK_EQUAL(committee.active.num_auths(), INITIAL_COMMITTEE_MEMBER_COUNT);
+
+   generate_blocks(HARDFORK_533_TIME);
+   generate_blocks(db.get_dynamic_global_properties().next_maintenance_time);
+   generate_block();
+   set_expiration(db, trx);
+
+   // Check that committee not changed after 533 hardfork
+   // vote counting method changed, but any votes are absent
+   const auto &committee_members_after_hf533 = db.get_global_properties().active_committee_members;
+   const auto &committee_after_hf533 = committee_account(db);
+   BOOST_CHECK_EQUAL(committee_members_after_hf533.size(), INITIAL_COMMITTEE_MEMBER_COUNT);
+   BOOST_CHECK_EQUAL(committee_after_hf533.active.num_auths(), INITIAL_COMMITTEE_MEMBER_COUNT);
+
+   // You can't use uninitialized committee after 533 hardfork
+   // when any user with stake created (create_account method automatically set up votes for committee)
+   // committee is incomplete and consist of random active members
+   ACTOR(alice);
+   fund(alice);
+   generate_blocks(db.get_dynamic_global_properties().next_maintenance_time);
+
+   const auto &committee_after_hf533_with_stake = committee_account(db);
+   BOOST_CHECK_LT(committee_after_hf533_with_stake.active.num_auths(), INITIAL_COMMITTEE_MEMBER_COUNT);
+
+   // Initialize committee by voting for each memeber and for desired count
+   vote_for_committee_and_witnesses(INITIAL_COMMITTEE_MEMBER_COUNT, INITIAL_WITNESS_COUNT);
+   generate_blocks(db.get_dynamic_global_properties().next_maintenance_time);
+
+   const auto &committee_members_after_hf533_and_init = db.get_global_properties().active_committee_members;
+   const auto &committee_after_hf533_and_init = committee_account(db);
+   BOOST_CHECK_EQUAL(committee_members_after_hf533_and_init.size(), INITIAL_COMMITTEE_MEMBER_COUNT);
+   BOOST_CHECK_EQUAL(committee_after_hf533_and_init.active.num_auths(), INITIAL_COMMITTEE_MEMBER_COUNT);
+
+} FC_LOG_AND_RETHROW() }
+
 BOOST_AUTO_TEST_CASE(put_my_witnesses)
 {
    try
    {
-      graphene::app::database_api db_api1(db);
-
       ACTORS( (witness0)
               (witness1)
               (witness2)
@@ -90,7 +132,7 @@ BOOST_AUTO_TEST_CASE(put_my_witnesses)
       const witness_id_type witness12_witness_id = create_witness(witness12_id, witness12_private_key).id;
       const witness_id_type witness13_witness_id = create_witness(witness13_id, witness13_private_key).id;
 
-      // Create a vector with private key of all witnesses, will be used to activate 11 witnesses at a time
+      // Create a vector with private key of all witnesses, will be used to activate 9 witnesses at a time
       const vector <fc::ecc::private_key> private_keys = {
             witness0_private_key,
             witness1_private_key,
@@ -109,7 +151,7 @@ BOOST_AUTO_TEST_CASE(put_my_witnesses)
 
       };
 
-      // create a map with account id and witness id of the first 11 witnesses
+      // create a map with account id and witness id
       const flat_map <account_id_type, witness_id_type> witness_map = {
             {witness0_id, witness0_witness_id},
             {witness1_id, witness1_witness_id},
@@ -127,9 +169,9 @@ BOOST_AUTO_TEST_CASE(put_my_witnesses)
             {witness13_id, witness13_witness_id}
       };
 
-      // Check current default witnesses, default chain is configured with 10 witnesses
+      // Check current default witnesses, default chain is configured with 9 witnesses
       auto witnesses = db.get_global_properties().active_witnesses;
-      BOOST_CHECK_EQUAL(witnesses.size(), 10u);
+      BOOST_CHECK_EQUAL(witnesses.size(), INITIAL_WITNESS_COUNT);
       BOOST_CHECK_EQUAL(witnesses.begin()[0].instance.value, 1u);
       BOOST_CHECK_EQUAL(witnesses.begin()[1].instance.value, 2u);
       BOOST_CHECK_EQUAL(witnesses.begin()[2].instance.value, 3u);
@@ -139,7 +181,6 @@ BOOST_AUTO_TEST_CASE(put_my_witnesses)
       BOOST_CHECK_EQUAL(witnesses.begin()[6].instance.value, 7u);
       BOOST_CHECK_EQUAL(witnesses.begin()[7].instance.value, 8u);
       BOOST_CHECK_EQUAL(witnesses.begin()[8].instance.value, 9u);
-      BOOST_CHECK_EQUAL(witnesses.begin()[9].instance.value, 10u);
 
       // Activate all witnesses
       // Each witness is voted with incremental stake so last witness created will be the ones with more votes
@@ -168,18 +209,16 @@ BOOST_AUTO_TEST_CASE(put_my_witnesses)
 
       // Check my witnesses are now in control of the system
       witnesses = db.get_global_properties().active_witnesses;
-      BOOST_CHECK_EQUAL(witnesses.size(), 11u);
-      BOOST_CHECK_EQUAL(witnesses.begin()[0].instance.value, 14u);
-      BOOST_CHECK_EQUAL(witnesses.begin()[1].instance.value, 15u);
-      BOOST_CHECK_EQUAL(witnesses.begin()[2].instance.value, 16u);
-      BOOST_CHECK_EQUAL(witnesses.begin()[3].instance.value, 17u);
-      BOOST_CHECK_EQUAL(witnesses.begin()[4].instance.value, 18u);
-      BOOST_CHECK_EQUAL(witnesses.begin()[5].instance.value, 19u);
-      BOOST_CHECK_EQUAL(witnesses.begin()[6].instance.value, 20u);
-      BOOST_CHECK_EQUAL(witnesses.begin()[7].instance.value, 21u);
-      BOOST_CHECK_EQUAL(witnesses.begin()[8].instance.value, 22u);
-      BOOST_CHECK_EQUAL(witnesses.begin()[9].instance.value, 23u);
-      BOOST_CHECK_EQUAL(witnesses.begin()[10].instance.value, 24u);
+      BOOST_CHECK_EQUAL(witnesses.size(), INITIAL_WITNESS_COUNT);
+      BOOST_CHECK_EQUAL(witnesses.begin()[0].instance.value, 16u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[1].instance.value, 17u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[2].instance.value, 18u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[3].instance.value, 19u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[4].instance.value, 20u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[5].instance.value, 21u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[6].instance.value, 22u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[7].instance.value, 23u);
+      BOOST_CHECK_EQUAL(witnesses.begin()[8].instance.value, 24u);
 
    } FC_LOG_AND_RETHROW()
 }
@@ -218,8 +257,6 @@ BOOST_AUTO_TEST_CASE(put_my_committee_members)
 {
    try
    {
-      graphene::app::database_api db_api1(db);
-
       ACTORS( (committee0)
               (committee1)
               (committee2)
@@ -267,7 +304,7 @@ BOOST_AUTO_TEST_CASE(put_my_committee_members)
       const committee_member_id_type committee12_committee_id = create_committee_member(committee12_id(db)).id;
       const committee_member_id_type committee13_committee_id = create_committee_member(committee13_id(db)).id;
 
-      // Create a vector with private key of all witnesses, will be used to activate 11 witnesses at a time
+      // Create a vector with private key of all committee members, will be used to activate 9 members at a time
       const vector <fc::ecc::private_key> private_keys = {
             committee0_private_key,
             committee1_private_key,
@@ -285,7 +322,7 @@ BOOST_AUTO_TEST_CASE(put_my_committee_members)
             committee13_private_key
       };
 
-      // create a map with account id and committee id of the first 11 witnesses
+      // create a map with account id and committee member id
       const flat_map <account_id_type, committee_member_id_type> committee_map = {
             {committee0_id, committee0_committee_id},
             {committee1_id, committee1_committee_id},
@@ -303,10 +340,10 @@ BOOST_AUTO_TEST_CASE(put_my_committee_members)
             {committee13_id, committee13_committee_id}
       };
 
-      // Check current default witnesses, default chain is configured with 10 witnesses
+      // Check current default committee, default chain is configured with 9 committee members
       auto committee_members = db.get_global_properties().active_committee_members;
 
-      BOOST_CHECK_EQUAL(committee_members.size(), 10u);
+      BOOST_CHECK_EQUAL(committee_members.size(), INITIAL_COMMITTEE_MEMBER_COUNT);
       BOOST_CHECK_EQUAL(committee_members.begin()[0].instance.value, 0u);
       BOOST_CHECK_EQUAL(committee_members.begin()[1].instance.value, 1u);
       BOOST_CHECK_EQUAL(committee_members.begin()[2].instance.value, 2u);
@@ -316,10 +353,9 @@ BOOST_AUTO_TEST_CASE(put_my_committee_members)
       BOOST_CHECK_EQUAL(committee_members.begin()[6].instance.value, 6u);
       BOOST_CHECK_EQUAL(committee_members.begin()[7].instance.value, 7u);
       BOOST_CHECK_EQUAL(committee_members.begin()[8].instance.value, 8u);
-      BOOST_CHECK_EQUAL(committee_members.begin()[9].instance.value, 9u);
 
       // Activate all committee
-      // Each witness is voted with incremental stake so last witness created will be the ones with more votes
+      // Each committee is voted with incremental stake so last member created will be the ones with more votes
       int c = 0;
       for (auto committee : committee_map) {
          int stake = 100 + c + 10;
@@ -329,7 +365,10 @@ BOOST_AUTO_TEST_CASE(put_my_committee_members)
             account_update_operation op;
             op.account = committee.first;
             op.new_options = committee.first(db).options;
+
+            op.new_options->votes.clear();
             op.new_options->votes.insert(committee.second(db).vote_id);
+            op.new_options->num_committee = 1;
 
             trx.operations.push_back(op);
             sign(trx, private_keys.at(c));
@@ -345,21 +384,21 @@ BOOST_AUTO_TEST_CASE(put_my_committee_members)
 
       // Check my witnesses are now in control of the system
       committee_members = db.get_global_properties().active_committee_members;
-      BOOST_CHECK_EQUAL(committee_members.size(), 11u);
+      std::sort(committee_members.begin(), committee_members.end());
 
-      /* TODO we are not in full control, seems to committee members have votes by default
-      BOOST_CHECK_EQUAL(committee_members.begin()[0].instance.value, 14);
-      BOOST_CHECK_EQUAL(committee_members.begin()[1].instance.value, 15);
-      BOOST_CHECK_EQUAL(committee_members.begin()[2].instance.value, 16);
-      BOOST_CHECK_EQUAL(committee_members.begin()[3].instance.value, 17);
-      BOOST_CHECK_EQUAL(committee_members.begin()[4].instance.value, 18);
-      BOOST_CHECK_EQUAL(committee_members.begin()[5].instance.value, 19);
-      BOOST_CHECK_EQUAL(committee_members.begin()[6].instance.value, 20);
-      BOOST_CHECK_EQUAL(committee_members.begin()[7].instance.value, 21);
-      BOOST_CHECK_EQUAL(committee_members.begin()[8].instance.value, 22);
-      BOOST_CHECK_EQUAL(committee_members.begin()[9].instance.value, 23);
-      BOOST_CHECK_EQUAL(committee_members.begin()[10].instance.value, 24);
-      */
+      BOOST_CHECK_EQUAL(committee_members.size(), INITIAL_COMMITTEE_MEMBER_COUNT);
+
+      // Check my committee members are now in control of the system
+      BOOST_CHECK_EQUAL(committee_members.begin()[0].instance.value, 15);
+      BOOST_CHECK_EQUAL(committee_members.begin()[1].instance.value, 16);
+      BOOST_CHECK_EQUAL(committee_members.begin()[2].instance.value, 17);
+      BOOST_CHECK_EQUAL(committee_members.begin()[3].instance.value, 18);
+      BOOST_CHECK_EQUAL(committee_members.begin()[4].instance.value, 19);
+      BOOST_CHECK_EQUAL(committee_members.begin()[5].instance.value, 20);
+      BOOST_CHECK_EQUAL(committee_members.begin()[6].instance.value, 21);
+      BOOST_CHECK_EQUAL(committee_members.begin()[7].instance.value, 22);
+      BOOST_CHECK_EQUAL(committee_members.begin()[8].instance.value, 23);
+
    } FC_LOG_AND_RETHROW()
 }
 


### PR DESCRIPTION
This issue was caused by a sporadic fail of the htlc_expires test on our CI. However, later this test was fixed. While we were researching the problem, we found out that committee proposals aren't always authorized. In the case of htlc_expires this was caused by installing updatable_htlc_options in global parameters. As a result, it was decided to write a unit test which demonstrates the problem and also to make a correction that fixes it.

There are oddity checks in database::init_genesis():
 ```
FC_ASSERT( (genesis_state.immutable_parameters.min_witness_count & 1) == 1, "min_witness_count must be odd" );
FC_ASSERT( (genesis_state.immutable_parameters.min_committee_member_count & 1) == 1, "min_committee_member_count must be odd" );
```
But size of containers genesis_state.initial_witness_candidates and genesis_state.initial_committee_candidates are not checked. So, all candidates become witnesses and committee members. In database_fixture these containers are initialized with 10 elements. In some tests committee can't make decision without correct initialization.