### PR TITLE
Allow windows build on Visual Studio 2017

### DIFF
--- a/tests/tests/htlc_tests.cpp
+++ b/tests/tests/htlc_tests.cpp
@@ -848,7 +848,7 @@ try {
 
    uint16_t preimage_size = 256;
    std::vector<char> pre_image(256);
-   std::independent_bits_engine<std::default_random_engine, CHAR_BIT, unsigned char> rbe;
+   std::independent_bits_engine<std::default_random_engine, sizeof(unsigned), unsigned int> rbe;
    std::generate(begin(pre_image), end(pre_image), std::ref(rbe));
    graphene::chain::htlc_id_type alice_htlc_id_bob;
    graphene::chain::htlc_id_type alice_htlc_id_carl;

--- a/tests/tests/htlc_tests.cpp
+++ b/tests/tests/htlc_tests.cpp
@@ -58,7 +58,7 @@ BOOST_FIXTURE_TEST_SUITE( htlc_tests, database_fixture )
 
 void generate_random_preimage(uint16_t key_size, std::vector<char>& vec)
 {
-	std::independent_bits_engine<std::default_random_engine, CHAR_BIT, unsigned int> rbe;
+	std::independent_bits_engine<std::default_random_engine, sizeof(unsigned), unsigned int> rbe;
 	std::generate(begin(vec), end(vec), std::ref(rbe));
 	return;
 }


### PR DESCRIPTION
Fixes #1646 

TODO: update wiki for building with Visual Studio 2017.

This small fix allows building the chain_test on Windows using Visual Studio 2017.

Requirements:

- Visual Studio 2017 15.9 (15.0 will not work)
- Boost 1.69

**Note:** Boost is required for compiling BitShares. Visual Studio 2019 requires a minimum version of Boost of 1.70. Boost 1.70 conflicts with the websocket library that is being used by BitShares. Hence, BitShares can not currently be compiled from the ground up with Visual Studio 2019. However, I was able to successfully compile BitShares with Visual Studio 2019 by compiling Boost 1.69 with Visual Studio 2017 and using those libraries with Visual Studio 2017. Such a setup is not recommended nor supported.

Adjustments to the wiki for building with Visual Studio 2017 are being prepared at https://github.com/jmjatlanta/bitshares-core-wiki/blob/jmj_v3.3.0/BUILD_WIN32.md