### PR TITLE
Add optional subscribe param to some database APIs

### DIFF
--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -89,7 +89,8 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       account_id_type get_account_id_from_string(const std::string& name_or_id)const;
       vector<optional<account_object>> get_accounts( const vector<std::string>& account_names_or_ids,
                                                      optional<bool> subscribe )const;
-      std::map<string,full_account> get_full_accounts( const vector<string>& names_or_ids, optional<bool> subscribe );
+      std::map<string,full_account> get_full_accounts( const vector<string>& names_or_ids,
+                                                       optional<bool> subscribe );
       optional<account_object> get_account_by_name( string name )const;
       vector<account_id_type> get_account_references( const std::string account_id_or_name )const;
       vector<optional<account_object>> lookup_account_names(const vector<string>& account_names)const;
@@ -1198,7 +1199,7 @@ map<string,account_id_type> database_api_impl::lookup_accounts( const string& lo
 
    if( limit == 0 ) // shortcut to save a database query
       return result;
-   // auto-subscribe if only look for one account
+   // In addition to the common auto-subscription rules, here we auto-subscribe if only look for one account
    bool to_subscribe = (limit == 1 && get_whether_to_subscribe( subscribe ));
    for( auto itr = accounts_by_name.lower_bound(lower_bound_name);
         limit-- && itr != accounts_by_name.end();

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -156,11 +156,14 @@ class database_api
       /**
        * @brief Get the objects corresponding to the provided IDs
        * @param ids IDs of the objects to retrieve
+       * @param subscribe @a true to subscribe to the queried objects; @a false to not subscribe;
+       *                  @a null to subscribe or not subscribe according to current auto-subscription setting
+       *                  (see @ref set_auto_subscription)
        * @return The objects retrieved, in the order they are mentioned in ids
        *
        * If any of the provided IDs does not map to an object, a null variant is returned in its position.
        */
-      fc::variants get_objects(const vector<object_id_type>& ids)const;
+      fc::variants get_objects( const vector<object_id_type>& ids, optional<bool> subscribe = optional<bool>() )const;
 
       ///////////////////
       // Subscriptions //
@@ -187,9 +190,12 @@ class database_api
        * - get_assets
        * - get_objects
        * - lookup_accounts
-       *
-       * Does not impact this API:
        * - get_full_accounts
+       * - get_htlc
+       *
+       * Note: auto-subscription is enabled by default
+       *
+       * @see @ref set_subscribe_callback
        */
       void set_auto_subscription( bool enable );
       /**
@@ -321,16 +327,22 @@ class database_api
       /**
        * @brief Get a list of accounts by names or IDs
        * @param account_names_or_ids names or IDs of the accounts to retrieve
+       * @param subscribe @a true to subscribe to the queried account objects; @a false to not subscribe;
+       *                  @a null to subscribe or not subscribe according to current auto-subscription setting
+       *                  (see @ref set_auto_subscription)
        * @return The accounts corresponding to the provided names or IDs
        *
        * This function has semantics identical to @ref get_objects
        */
-      vector<optional<account_object>> get_accounts(const vector<std::string>& account_names_or_ids)const;
+      vector<optional<account_object>> get_accounts( const vector<std::string>& account_names_or_ids,
+                                                     optional<bool> subscribe = optional<bool>() )const;
 
       /**
        * @brief Fetch all objects relevant to the specified accounts and optionally subscribe to updates
        * @param names_or_ids Each item must be the name or ID of an account to retrieve
-       * @param subscribe whether subscribe to updates
+       * @param subscribe @a true to subscribe to the queried full account objects; @a false to not subscribe;
+       *                  @a null to subscribe or not subscribe according to current auto-subscription setting
+       *                  (see @ref set_auto_subscription)
        * @return Map of string from @p names_or_ids to the corresponding account
        *
        * This function fetches all relevant objects for the given accounts, and subscribes to updates to the given
@@ -338,7 +350,8 @@ class database_api
        * ignored. All other accounts will be retrieved and subscribed.
        *
        */
-      std::map<string,full_account> get_full_accounts( const vector<string>& names_or_ids, bool subscribe );
+      std::map<string,full_account> get_full_accounts( const vector<string>& names_or_ids,
+                                                       optional<bool> subscribe = optional<bool>() );
 
       /**
        * @brief Get info of an account by name
@@ -359,7 +372,7 @@ class database_api
        * @param account_names Names of the accounts to retrieve
        * @return The accounts holding the provided names
        *
-       * This function has semantics identical to @ref get_objects
+       * This function has semantics identical to @ref get_objects, but doesn't subscribe.
        */
       vector<optional<account_object>> lookup_account_names(const vector<string>& account_names)const;
 
@@ -367,9 +380,16 @@ class database_api
        * @brief Get names and IDs for registered accounts
        * @param lower_bound_name Lower bound of the first name to return
        * @param limit Maximum number of results to return -- must not exceed 1000
+       * @param subscribe @a true to subscribe to the queried account objects; @a false to not subscribe;
+       *                  @a null to subscribe or not subscribe according to current auto-subscription setting
+       *                  (see @ref set_auto_subscription)
        * @return Map of account names to corresponding IDs
+       *
+       * Note: this API will subscribe to the queried account only if @p limit is 1.
        */
-      map<string,account_id_type> lookup_accounts(const string& lower_bound_name, uint32_t limit)const;
+      map<string,account_id_type> lookup_accounts( const string& lower_bound_name,
+                                                   uint32_t limit,
+                                                   optional<bool> subscribe = optional<bool>() )const;
 
       //////////////
       // Balances //
@@ -428,11 +448,15 @@ class database_api
       /**
        * @brief Get a list of assets by symbol names or IDs
        * @param asset_symbols_or_ids symbol names or IDs of the assets to retrieve
+       * @param subscribe @a true to subscribe to the queried asset objects; @a false to not subscribe;
+       *                  @a null to subscribe or not subscribe according to current auto-subscription setting
+       *                  (see @ref set_auto_subscription)
        * @return The assets corresponding to the provided symbol names or IDs
        *
        * This function has semantics identical to @ref get_objects
        */
-      vector<optional<extended_asset_object>> get_assets(const vector<std::string>& asset_symbols_or_ids)const;
+      vector<optional<extended_asset_object>> get_assets( const vector<std::string>& asset_symbols_or_ids,
+                                                          optional<bool> subscribe = optional<bool>() )const;
 
       /**
        * @brief Get assets alphabetically by symbol name
@@ -658,7 +682,7 @@ class database_api
        * @param witness_ids IDs of the witnesses to retrieve
        * @return The witnesses corresponding to the provided IDs
        *
-       * This function has semantics identical to @ref get_objects
+       * This function has semantics identical to @ref get_objects, but doesn't subscribe
        */
       vector<optional<witness_object>> get_witnesses(const vector<witness_id_type>& witness_ids)const;
 
@@ -691,7 +715,7 @@ class database_api
        * @param committee_member_ids IDs of the committee_members to retrieve
        * @return The committee_members corresponding to the provided IDs
        *
-       * This function has semantics identical to @ref get_objects
+       * This function has semantics identical to @ref get_objects, but doesn't subscribe
        */
       vector<optional<committee_member_object>> get_committee_members(
             const vector<committee_member_id_type>& committee_member_ids)const;
@@ -898,9 +922,12 @@ class database_api
       /**
        *  @brief Get HTLC object
        *  @param id HTLC contract id
+       *  @param subscribe @a true to subscribe to the queried HTLC objects; @a false to not subscribe;
+       *                   @a null to subscribe or not subscribe according to current auto-subscription setting
+       *                   (see @ref set_auto_subscription)
        *  @return HTLC object for the id
        */
-      optional<htlc_object> get_htlc(htlc_id_type id) const;
+      optional<htlc_object> get_htlc( htlc_id_type id, optional<bool> subscribe = optional<bool>() ) const;
 
       /**
        *  @brief Get non expired HTLC objects using the sender account

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -160,10 +160,13 @@ class database_api
        *                  @a null to subscribe or not subscribe according to current auto-subscription setting
        *                  (see @ref set_auto_subscription)
        * @return The objects retrieved, in the order they are mentioned in ids
+       * @note operation_history_object (1.11.x) and account_transaction_history_object (2.9.x)
+       *       can not be subscribed.
        *
        * If any of the provided IDs does not map to an object, a null variant is returned in its position.
        */
-      fc::variants get_objects( const vector<object_id_type>& ids, optional<bool> subscribe = optional<bool>() )const;
+      fc::variants get_objects( const vector<object_id_type>& ids,
+                                optional<bool> subscribe = optional<bool>() )const;
 
       ///////////////////
       // Subscriptions //
@@ -385,7 +388,8 @@ class database_api
        *                  (see @ref set_auto_subscription)
        * @return Map of account names to corresponding IDs
        *
-       * Note: this API will subscribe to the queried account only if @p limit is 1.
+       * @note In addition to the common auto-subscription rules,
+       *       this API will subscribe to the returned account only if @p limit is 1.
        */
       map<string,account_id_type> lookup_accounts( const string& lower_bound_name,
                                                    uint32_t limit,

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -588,7 +588,7 @@ public:
    template<typename ID>
    graphene::db::object_downcast_t<ID> get_object(ID id)const
    {
-      auto ob = _remote_db->get_objects({id}).front();
+      auto ob = _remote_db->get_objects({id}, {}).front();
       return ob.template as<graphene::db::object_downcast_t<ID>>( GRAPHENE_MAX_NESTED_OBJECTS );
    }
 
@@ -680,7 +680,7 @@ public:
    {
       std::string account_id = account_id_to_string(id);
 
-      auto rec = _remote_db->get_accounts({account_id}).front();
+      auto rec = _remote_db->get_accounts({account_id}, {}).front();
       FC_ASSERT(rec);
       return *rec;
    }
@@ -711,7 +711,7 @@ public:
    }
    optional<extended_asset_object> find_asset(asset_id_type id)const
    {
-      auto rec = _remote_db->get_assets({asset_id_to_string(id)}).front();
+      auto rec = _remote_db->get_assets({asset_id_to_string(id)}, {}).front();
       return rec;
    }
    optional<extended_asset_object> find_asset(string asset_symbol_or_id)const
@@ -750,7 +750,7 @@ public:
    {
       htlc_id_type id;
       fc::from_variant(htlc_id, id);
-      auto obj = _remote_db->get_objects( { id }).front();
+      auto obj = _remote_db->get_objects( { id }, {}).front();
       if ( !obj.is_null() )
       {
          return fc::optional<htlc_object>(obj.template as<htlc_object>(GRAPHENE_MAX_NESTED_OBJECTS));
@@ -862,7 +862,7 @@ public:
             account_ids_to_send.push_back( account_id );
             ++it;
          }
-         std::vector< optional< account_object > > accounts = _remote_db->get_accounts(account_ids_to_send);
+         std::vector< optional< account_object > > accounts = _remote_db->get_accounts(account_ids_to_send, {});
          // server response should be same length as request
          FC_ASSERT( accounts.size() == account_ids_to_send.size() );
          size_t i = 0;
@@ -1842,7 +1842,7 @@ public:
 
       flat_set<vote_id_type> new_votes( acct.options.votes );
 
-      fc::variants objects = _remote_db->get_objects( query_ids );
+      fc::variants objects = _remote_db->get_objects( query_ids, {} );
       for( const variant& obj : objects )
       {
          worker_object wo;
@@ -3352,7 +3352,7 @@ vector<account_object> wallet_api::list_my_accounts()
 
 map<string,account_id_type> wallet_api::list_accounts(const string& lowerbound, uint32_t limit)
 {
-   return my->_remote_db->lookup_accounts(lowerbound, limit);
+   return my->_remote_db->lookup_accounts(lowerbound, limit, {});
 }
 
 vector<asset> wallet_api::list_account_balances(const string& id)
@@ -3653,7 +3653,7 @@ string wallet_api::serialize_transaction( signed_transaction tx )const
 
 variant wallet_api::get_object( object_id_type id ) const
 {
-   return my->_remote_db->get_objects({id});
+   return my->_remote_db->get_objects({id}, {});
 }
 
 string wallet_api::get_wallet_filename() const

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -40,6 +40,7 @@
 #include <graphene/chain/witness_object.hpp>
 #include <graphene/chain/worker_object.hpp>
 #include <graphene/chain/htlc_object.hpp>
+#include <graphene/chain/proposal_object.hpp>
 
 #include <graphene/utilities/tempdir.hpp>
 
@@ -1344,6 +1345,82 @@ vector< graphene::market_history::order_history_object > database_fixture::get_m
        ++itr;
    }
    return result;
+}
+
+flat_map< uint64_t, graphene::chain::fee_parameters > database_fixture::get_htlc_fee_parameters()
+{
+   flat_map<uint64_t, graphene::chain::fee_parameters> ret_val;
+
+   htlc_create_operation::fee_parameters_type create_param;
+   create_param.fee_per_day = 2 * GRAPHENE_BLOCKCHAIN_PRECISION;
+   create_param.fee = 2 * GRAPHENE_BLOCKCHAIN_PRECISION;
+   ret_val[((operation)htlc_create_operation()).which()] = create_param;
+
+   htlc_redeem_operation::fee_parameters_type redeem_param;
+   redeem_param.fee = 2 * GRAPHENE_BLOCKCHAIN_PRECISION;
+   redeem_param.fee_per_kb = 2 * GRAPHENE_BLOCKCHAIN_PRECISION;
+   ret_val[((operation)htlc_redeem_operation()).which()] = redeem_param;
+
+   htlc_extend_operation::fee_parameters_type extend_param;
+   extend_param.fee = 2 * GRAPHENE_BLOCKCHAIN_PRECISION;
+   extend_param.fee_per_day = 2 * GRAPHENE_BLOCKCHAIN_PRECISION;
+   ret_val[((operation)htlc_extend_operation()).which()] = extend_param;
+
+   return ret_val;
+}
+
+void database_fixture::set_htlc_committee_parameters()
+{
+   // htlc fees
+   // get existing fee_schedule
+   const chain_parameters& existing_params = db.get_global_properties().parameters;
+   const fee_schedule_type& existing_fee_schedule = *(existing_params.current_fees);
+   // create a new fee_shedule
+   std::shared_ptr<fee_schedule_type> new_fee_schedule = std::make_shared<fee_schedule_type>();
+   new_fee_schedule->scale = GRAPHENE_100_PERCENT;
+   // replace the old with the new
+   flat_map<uint64_t, graphene::chain::fee_parameters> params_map = get_htlc_fee_parameters();
+   for(auto param : existing_fee_schedule.parameters)
+   {
+      auto itr = params_map.find(param.which());
+      if (itr == params_map.end())
+         new_fee_schedule->parameters.insert(param);
+      else
+      {
+         new_fee_schedule->parameters.insert( (*itr).second);
+      }
+   }
+   // htlc parameters
+   proposal_create_operation cop = proposal_create_operation::committee_proposal(
+         db.get_global_properties().parameters, db.head_block_time());
+   cop.fee_paying_account = GRAPHENE_TEMP_ACCOUNT;
+   cop.expiration_time = db.head_block_time() + *cop.review_period_seconds + 10;
+   committee_member_update_global_parameters_operation uop;
+   graphene::chain::htlc_options new_params;
+   new_params.max_preimage_size = 19200;
+   new_params.max_timeout_secs = 60 * 60 * 24 * 28;
+   uop.new_parameters.extensions.value.updatable_htlc_options = new_params;
+   uop.new_parameters.current_fees = new_fee_schedule;
+   cop.proposed_ops.emplace_back(uop);
+
+   trx.operations.push_back(cop);
+   graphene::chain::processed_transaction proc_trx = db.push_transaction(trx);
+   trx.clear();
+   proposal_id_type good_proposal_id = proc_trx.operation_results[0].get<object_id_type>();
+
+   proposal_update_operation puo;
+   puo.proposal = good_proposal_id;
+   puo.fee_paying_account = GRAPHENE_TEMP_ACCOUNT;
+   puo.key_approvals_to_add.emplace( init_account_priv_key.get_public_key() );
+   trx.operations.push_back(puo);
+   sign( trx, init_account_priv_key );
+   db.push_transaction(trx);
+   trx.clear();
+
+   generate_blocks( good_proposal_id( db ).expiration_time + 5 );
+   generate_blocks( db.get_dynamic_global_properties().next_maintenance_time );
+   generate_block();   // get the maintenance skip slots out of the way
+
 }
 
 namespace test {

--- a/tests/common/database_fixture.hpp
+++ b/tests/common/database_fixture.hpp
@@ -371,6 +371,26 @@ struct database_fixture {
 
    vector< operation_history_object > get_operation_history( account_id_type account_id )const;
    vector< graphene::market_history::order_history_object > get_market_order_history( asset_id_type a, asset_id_type b )const;
+
+   /****
+    * @brief return htlc fee parameters
+    */
+   flat_map< uint64_t, graphene::chain::fee_parameters > get_htlc_fee_parameters();
+   /****
+    * @brief push through a proposal that sets htlc parameters and fees
+    */
+   void set_htlc_committee_parameters();
+   /****
+    * Hash the preimage and put it in a vector
+    * @param preimage the preimage
+    * @returns a vector that cointains the sha256 hash of the preimage
+    */
+   template<typename H>
+   H hash_it(std::vector<char> preimage)
+   {
+      return H::hash( (char*)preimage.data(), preimage.size() );
+   }
+
 };
 
 namespace test {

--- a/tests/tests/database_api_tests.cpp
+++ b/tests/tests/database_api_tests.cpp
@@ -791,8 +791,13 @@ BOOST_AUTO_TEST_CASE( subscription_notification_test )
 
       create_user_issued_asset( "UIATEST" );
 
-#define SUB_NOTIF_TEST_NUM_CALLBACKS_PLUS_ONE 8
+// declare db_api1 ~ db_api60
+#define SUB_NOTIF_TEST_NUM_CALLBACKS_PLUS_ONE 61
+// db_api1  ~ db_api30 auto-subscribe in the beginning,
+// db_api31 ~ db_api60 don't auto-subscribe
+#define SUB_NOTIF_TEST_START_ID_DISABLE_AUTO_SUB 31
 
+// create callback functions
 #define SUB_NOTIF_TEST_INIT_CALLBACKS(z, i, data) \
       uint32_t objects_changed ## i = 0; \
       auto callback ## i = [&]( const variant& v ) \
@@ -802,6 +807,7 @@ BOOST_AUTO_TEST_CASE( subscription_notification_test )
       }; \
       uint32_t expected_objects_changed ## i = 0;
 
+// create function to check results
 #define SUB_NOTIF_TEST_CHECK(z, i, data) \
       if( expected_objects_changed ## i > 0 ) { \
          BOOST_CHECK_LE( expected_objects_changed ## i, objects_changed ## i ); \
@@ -834,6 +840,7 @@ BOOST_AUTO_TEST_CASE( subscription_notification_test )
       graphene::app::database_api db_api2( db, &opt );
       db_api2.set_subscribe_callback( callback2, true ); // subscribing to all should succeed
 
+// declare the rest of API callers and initialize callbacks
 #define SUB_NOTIF_TEST_INIT_APIS(z, i, data) \
       graphene::app::database_api db_api ## i( db, &opt ); \
       db_api ## i.set_subscribe_callback( callback ## i, false );
@@ -841,32 +848,75 @@ BOOST_AUTO_TEST_CASE( subscription_notification_test )
       BOOST_PP_REPEAT_FROM_TO( 3, SUB_NOTIF_TEST_NUM_CALLBACKS_PLUS_ONE, SUB_NOTIF_TEST_INIT_APIS, unused );
 
 #undef SUB_NOTIF_TEST_INIT_APIS
+
+// disable auto-subscription for some API callers
+#define SUB_NOTIF_TEST_DISABLE_AUTO_SUB(z, i, data) \
+      db_api ## i.set_auto_subscription( false );
+
+      BOOST_PP_REPEAT_FROM_TO( SUB_NOTIF_TEST_START_ID_DISABLE_AUTO_SUB, SUB_NOTIF_TEST_NUM_CALLBACKS_PLUS_ONE,
+                               SUB_NOTIF_TEST_DISABLE_AUTO_SUB, unused );
+
+#undef SUB_NOTIF_TEST_DISABLE_AUTO_SUB
 #undef SUB_NOTIF_TEST_NUM_CALLBACKS_PLUS_ONE
+#undef SUB_NOTIF_TEST_START_ID_DISABLE_AUTO_SUB
 
       vector<object_id_type> account_ids;
       account_ids.push_back( alice_id );
-      db_api1.get_objects( account_ids ); // db_api1 subscribe to Alice
+      db_api1.get_objects( account_ids );         // db_api1  subscribe to Alice
+      db_api11.get_objects( account_ids, true );  // db_api11 subscribe to Alice
+      db_api21.get_objects( account_ids, false ); // db_api21 doesn't subscribe to Alice
+      db_api31.get_objects( account_ids );        // db_api31 doesn't subscribe to Alice
+      db_api41.get_objects( account_ids, true );  // db_api41 subscribe to Alice
+      db_api51.get_objects( account_ids, false ); // db_api51 doesn't subscribe to Alice
 
       vector<string> account_names;
       account_names.push_back( "alice" );
-      db_api4.get_accounts( account_names ); // db_api4 subscribe to Alice
+      db_api4.get_accounts( account_names );         // db_api4  subscribe to Alice
+      db_api14.get_accounts( account_names, true );  // db_api14 subscribe to Alice
+      db_api24.get_accounts( account_names, false ); // db_api24 doesn't subscribe to Alice
+      db_api34.get_accounts( account_names );        // db_api34 doesn't subscribe to Alice
+      db_api44.get_accounts( account_names, true );  // db_api44 subscribe to Alice
+      db_api54.get_accounts( account_names, false ); // db_api54 doesn't subscribe to Alice
 
-      db_api5.lookup_accounts( "ali", 1 ); // db_api5 subscribe to Alice
+      db_api5.lookup_accounts( "ali", 1 );         // db_api5  subscribe to Alice
+      db_api15.lookup_accounts( "ali", 1, true );  // db_api15 subscribe to Alice
+      db_api25.lookup_accounts( "ali", 1, false ); // db_api25 doesn't subscribe to Alice
+      db_api35.lookup_accounts( "ali", 1 );        // db_api35 doesn't subscribe to Alice
+      db_api45.lookup_accounts( "ali", 1, true );  // db_api45 subscribe to Alice
+      db_api55.lookup_accounts( "ali", 1, false ); // db_api55 doesn't subscribe to Alice
 
-      db_api6.lookup_accounts( "alice", 3 ); // db_api6 does not subscribe to Alice
+      db_api6.lookup_accounts( "alice", 3 );         // db_api6  does not subscribe to Alice
+      db_api16.lookup_accounts( "alice", 3, true );  // db_api16 does not subscribe to Alice
+      db_api26.lookup_accounts( "alice", 3, false ); // db_api26 does not subscribe to Alice
+      db_api36.lookup_accounts( "alice", 3 );        // db_api36 does not subscribe to Alice
+      db_api46.lookup_accounts( "alice", 3, true );  // db_api46 does not subscribe to Alice
+      db_api56.lookup_accounts( "alice", 3, false ); // db_api56 does not subscribe to Alice
 
       vector<string> asset_names;
       asset_names.push_back( "UIATEST" );
-      db_api7.get_assets( asset_names ); // db_api7 subscribe to UIA
+      db_api7.get_assets( asset_names );         // db_api7  subscribe to UIA
+      db_api17.get_assets( asset_names, true );  // db_api17 subscribe to UIA
+      db_api27.get_assets( asset_names, false ); // db_api27 doesn't subscribe to UIA
+      db_api37.get_assets( asset_names );        // db_api37 doesn't subscribe to UIA
+      db_api47.get_assets( asset_names, true );  // db_api47 subscribe to UIA
+      db_api57.get_assets( asset_names, false ); // db_api57 doesn't subscribe to UIA
 
       generate_block();
       ++expected_objects_changed1; // db_api1 subscribed to Alice, notify Alice account creation
+      ++expected_objects_changed11; // db_api11 subscribed to Alice, notify Alice account creation
+      ++expected_objects_changed41; // db_api41 subscribed to Alice, notify Alice account creation
       ++expected_objects_changed2; // db_api2 subscribed to all, notify new objects
       // db_api3 didn't subscribe to anything, nothing would be notified
       ++expected_objects_changed4; // db_api4 subscribed to Alice, notify Alice account creation
+      ++expected_objects_changed14; // db_api14 subscribed to Alice, notify Alice account creation
+      ++expected_objects_changed44; // db_api44 subscribed to Alice, notify Alice account creation
       ++expected_objects_changed5; // db_api5 subscribed to Alice, notify Alice account creation
-      // db_api6 didn't subscribe to anything, nothing would be notified
+      ++expected_objects_changed15; // db_api15 subscribed to Alice, notify Alice account creation
+      ++expected_objects_changed45; // db_api45 subscribed to Alice, notify Alice account creation
+      // db_api*6 didn't subscribe to anything, nothing would be notified
       ++expected_objects_changed7; // db_api7 subscribed to UIA, notify asset creation
+      ++expected_objects_changed17; // db_api17 subscribed to UIA, notify asset creation
+      ++expected_objects_changed47; // db_api47 subscribed to UIA, notify asset creation
 
       fc::usleep(fc::milliseconds(200)); // sleep a while to execute callback in another thread
       check_results();
@@ -889,7 +939,13 @@ BOOST_AUTO_TEST_CASE( subscription_notification_test )
       obj_ids.push_back( db.get_dynamic_global_properties().id );
       db_api3.get_objects( obj_ids ); // db_api3 subscribe to dynamic global properties
 
-      db_api4.get_full_accounts( account_names, true );  // db_api4 subscribe to Alice with get_full_accounts
+      db_api4.get_full_accounts( account_names, true );   // db_api4 subscribe to Alice with get_full_accounts
+      db_api14.get_full_accounts( account_names, false ); // db_api14 doesn't subscribe
+      db_api24.get_full_accounts( account_names );        // db_api24 subscribe to Alice with get_full_accounts
+      db_api34.get_full_accounts( account_names, true );  // db_api34 subscribe to Alice with get_full_accounts
+      db_api44.get_full_accounts( account_names, false ); // db_api44 doesn't subscribe
+      db_api54.get_full_accounts( account_names );        // db_api54 doesn't subscribe
+
       db_api5.get_full_accounts( account_names, false ); // db_api5 doesn't subscribe
 
       transfer( account_id_type(), alice_id, asset(1) );
@@ -899,6 +955,8 @@ BOOST_AUTO_TEST_CASE( subscription_notification_test )
       ++expected_objects_changed2; // db_api2 subscribed to all, notify new history records and etc
       ++expected_objects_changed3; // db_api3 subscribed to dynamic global properties, would be notified
       ++expected_objects_changed4; // db_api4 subscribed to full account data of Alice, would be notified
+      ++expected_objects_changed24; // db_api24 subscribed to full account data of Alice, would be notified
+      ++expected_objects_changed34; // db_api34 subscribed to full account data of Alice, would be notified
       // db_api5 only subscribed to the account object of Alice, nothing notified
       // db_api6 didn't subscribe to anything, nothing would be notified
       // db_api7: no change on UIA, nothing would be notified
@@ -969,6 +1027,8 @@ BOOST_AUTO_TEST_CASE( subscription_notification_test )
       ++expected_objects_changed2; // db_api2 subscribed to all, notify new history records and etc
       ++expected_objects_changed3; // db_api3 subscribed to dynamic global properties, would be notified
       ++expected_objects_changed4; // db_api4 subscribed to full account data of Alice, would be notified
+      ++expected_objects_changed24; // db_api24 subscribed to full account data of Alice, would be notified
+      ++expected_objects_changed34; // db_api34 subscribed to full account data of Alice, would be notified
       // db_api5 subscribed to anything, nothing notified
       // db_api6 subscribed to anything, nothing notified
       // db_api7: no change on UIA, nothing would be notified

--- a/tests/tests/htlc_tests.cpp
+++ b/tests/tests/htlc_tests.cpp
@@ -63,102 +63,11 @@ void generate_random_preimage(uint16_t key_size, std::vector<char>& vec)
 	return;
 }
 
-/****
- * Hash the preimage and put it in a vector
- * @param preimage the preimage
- * @returns a vector that cointains the sha256 hash of the preimage
- */
-template<typename H>
-H hash_it(std::vector<char> preimage)
-{
-   return H::hash( (char*)preimage.data(), preimage.size() );
-}
-
-flat_map< uint64_t, graphene::chain::fee_parameters > get_htlc_fee_parameters()
-{
-   flat_map<uint64_t, graphene::chain::fee_parameters> ret_val;
-
-   htlc_create_operation::fee_parameters_type create_param;
-   create_param.fee_per_day = 2 * GRAPHENE_BLOCKCHAIN_PRECISION;
-   create_param.fee = 2 * GRAPHENE_BLOCKCHAIN_PRECISION;
-   ret_val[((operation)htlc_create_operation()).which()] = create_param;
-
-   htlc_redeem_operation::fee_parameters_type redeem_param;
-   redeem_param.fee = 2 * GRAPHENE_BLOCKCHAIN_PRECISION;
-   redeem_param.fee_per_kb = 2 * GRAPHENE_BLOCKCHAIN_PRECISION;
-   ret_val[((operation)htlc_redeem_operation()).which()] = redeem_param;
-
-   htlc_extend_operation::fee_parameters_type extend_param;
-   extend_param.fee = 2 * GRAPHENE_BLOCKCHAIN_PRECISION;
-   extend_param.fee_per_day = 2 * GRAPHENE_BLOCKCHAIN_PRECISION;
-   ret_val[((operation)htlc_extend_operation()).which()] = extend_param;
-
-   return ret_val;
-}
-
-/****
- * @brief push through a proposal that sets htlc parameters and fees
- * @param db_fixture the database connection
- */
-void set_committee_parameters(database_fixture* db_fixture)
-{
-   // htlc fees
-   // get existing fee_schedule
-   const chain_parameters& existing_params = db_fixture->db.get_global_properties().parameters;
-   const fee_schedule_type& existing_fee_schedule = *(existing_params.current_fees);
-   // create a new fee_shedule
-   std::shared_ptr<fee_schedule_type> new_fee_schedule = std::make_shared<fee_schedule_type>();
-   new_fee_schedule->scale = GRAPHENE_100_PERCENT;
-   // replace the old with the new
-   flat_map<uint64_t, graphene::chain::fee_parameters> params_map = get_htlc_fee_parameters();
-   for(auto param : existing_fee_schedule.parameters)
-   {
-      auto itr = params_map.find(param.which());
-      if (itr == params_map.end())
-         new_fee_schedule->parameters.insert(param);
-      else
-      {
-         new_fee_schedule->parameters.insert( (*itr).second);
-      }
-   }
-   // htlc parameters
-   proposal_create_operation cop = proposal_create_operation::committee_proposal(
-         db_fixture->db.get_global_properties().parameters, db_fixture->db.head_block_time());
-   cop.fee_paying_account = GRAPHENE_TEMP_ACCOUNT;
-   cop.expiration_time = db_fixture->db.head_block_time() + *cop.review_period_seconds + 10;
-   committee_member_update_global_parameters_operation uop;
-   graphene::chain::htlc_options new_params;
-   new_params.max_preimage_size = 19200;
-   new_params.max_timeout_secs = 60 * 60 * 24 * 28;
-   uop.new_parameters.extensions.value.updatable_htlc_options = new_params;
-   uop.new_parameters.current_fees = new_fee_schedule;
-   cop.proposed_ops.emplace_back(uop);
-   
-   db_fixture->trx.operations.push_back(cop);
-   graphene::chain::processed_transaction proc_trx =db_fixture->db.push_transaction(db_fixture->trx);
-   db_fixture->trx.clear();
-   proposal_id_type good_proposal_id = proc_trx.operation_results[0].get<object_id_type>();
-
-   proposal_update_operation puo;
-   puo.proposal = good_proposal_id;
-   puo.fee_paying_account = GRAPHENE_TEMP_ACCOUNT;
-   puo.key_approvals_to_add.emplace( db_fixture->init_account_priv_key.get_public_key() );
-   db_fixture->trx.operations.push_back(puo);
-   db_fixture->sign( db_fixture->trx, db_fixture->init_account_priv_key );
-   db_fixture->db.push_transaction(db_fixture->trx);
-   db_fixture->trx.clear();
-
-   db_fixture->generate_blocks( good_proposal_id( db_fixture->db ).expiration_time + 5 );
-   db_fixture->generate_blocks( db_fixture->db.get_dynamic_global_properties().next_maintenance_time );
-   db_fixture->generate_block();   // get the maintenance skip slots out of the way
-
-}
-
 void advance_past_hardfork(database_fixture* db_fixture)
 {
    db_fixture->generate_blocks(HARDFORK_CORE_1468_TIME);
    set_expiration(db_fixture->db, db_fixture->trx);
-   set_committee_parameters(db_fixture);
+   db_fixture->set_htlc_committee_parameters();
    set_expiration(db_fixture->db, db_fixture->trx);
 }
 
@@ -844,7 +753,7 @@ try {
    generate_blocks(HARDFORK_CORE_1468_TIME);
    set_expiration( db, trx );
 
-   set_committee_parameters(this);
+   set_htlc_committee_parameters();
 
    uint16_t preimage_size = 256;
    std::vector<char> pre_image(256);


### PR DESCRIPTION
PR for #1819.

These APIs are updated:
- added a `subscribe` parameter with type `optional<bool>`
  - get_objects `( vector ids, optional<bool> subscribe )`
  - get_assets `( vector symbols_or_ids, optional<bool> subscribe )`
  - get_accounts `( vector names_or_ids, optional<bool> subscribe )`
  - lookup_accounts `( string lower_bound, int limit, optional<bool> subscribe )`
  - get_htlc `( htlc_id id, optional<bool> subscribe )`
- changed type of `subscribe` parameter to `optional<bool>`
  - get_full_accounts `( vector names_or_ids, optional<bool> subscribe )`

```
* @param subscribe @a true to subscribe to the queried objects;
*                  @a false to not subscribe;
*                  @a omit or null to subscribe or not subscribe according to current
*                     auto-subscription setting (see @ref set_auto_subscription)
```
