### PR TITLE
Add `sign_message` command to `cli_wallet`

### DIFF
--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -271,7 +271,7 @@ struct signed_message_meta {
    string account;
    public_key_type memo_key;
    uint32_t block;
-   int64_t time;
+   string time;
 };
 
 class signed_message {
@@ -1089,7 +1089,7 @@ class wallet_api
        * @param sig the message signature
        * @return true if signature matches
        */
-      bool verify_message( string message, string account, int block, int time, compact_signature sig );
+      bool verify_message( string message, string account, int block, const string& time, compact_signature sig );
 
       /** Verify a message signed with sign_message
        *

--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -267,6 +267,11 @@ struct vesting_balance_object_with_info : public vesting_balance_object
    fc::time_point_sec allowed_withdraw_time;
 };
 
+struct signed_message {
+   fc::variants               payload;
+   fc::ecc::compact_signature signature;
+};
+
 namespace detail {
 class wallet_api_impl;
 }
@@ -1054,6 +1059,21 @@ class wallet_api
        */
       string read_memo(const memo_data& memo);
 
+
+      /** Sign a message using an account's memo key.
+       *
+       * @param signer the name or id of signing account
+       * @param message text to sign
+       * @return the signed message in the format used in https://github.com/xeroc/python-graphenelib/blob/d9634d74273ebacc92555499eca7c444217ecba0/graphenecommon/message.py#L64
+       */
+      signed_message sign_message(string signer, string message);
+
+      /** Verify a message signed with sign_message
+       *
+       * @param message JSON-encoded signed message in the format used in https://github.com/xeroc/python-graphenelib/blob/d9634d74273ebacc92555499eca7c444217ecba0/graphenecommon/message.py#L64
+       * @return true if signature matches
+       */
+      bool verify_message(signed_message message);
 
       /** These methods are used for stealth transfers */
       ///@{
@@ -2034,6 +2054,8 @@ FC_REFLECT(graphene::wallet::operation_detail_ex,
 FC_REFLECT( graphene::wallet::account_history_operation_detail,
         (total_count)(result_count)(details))
 
+FC_REFLECT( graphene::wallet::signed_message, (payload)(signature) )
+
 FC_API( graphene::wallet::wallet_api,
         (help)
         (gethelp)
@@ -2151,6 +2173,8 @@ FC_API( graphene::wallet::wallet_api,
         (network_get_connected_peers)
         (sign_memo)
         (read_memo)
+        (sign_message)
+        (verify_message)
         (set_key_label)
         (get_key_label)
         (get_public_key)

--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -1080,12 +1080,30 @@ class wallet_api
        */
       signed_message sign_message(string signer, string message);
 
-      /** Verify a message signed with sign_message
+      /** Verify a message signed with sign_message using the given account's memo key.
        *
-       * @param message either a JSON-encoded signed_message structure, or a signed message in encapsulated format
+       * @param message the message text
+       * @param account the account name of the message
+       * @param block the block number of the message
+       * @param time the timestamp of the message
+       * @param sig the message signature
        * @return true if signature matches
        */
-      bool verify_message(string message);
+      bool verify_message( string message, string account, int block, int time, compact_signature sig );
+
+      /** Verify a message signed with sign_message
+       *
+       * @param message the signed_message structure containing message, meta data and signature
+       * @return true if signature matches
+       */
+      bool verify_signed_message( signed_message message );
+
+      /** Verify a message signed with sign_message, in its encapsulated form.
+       *
+       * @param message the complete encapsulated message string including separators and line feeds
+       * @return true if signature matches
+       */
+      bool verify_encapsulated_message( string message );
 
       /** These methods are used for stealth transfers */
       ///@{
@@ -2188,6 +2206,8 @@ FC_API( graphene::wallet::wallet_api,
         (read_memo)
         (sign_message)
         (verify_message)
+        (verify_signed_message)
+        (verify_encapsulated_message)
         (set_key_label)
         (get_key_label)
         (get_public_key)

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2280,12 +2280,13 @@ public:
       msg.meta.account = from_account.name;
       msg.meta.memo_key = from_account.options.memo_key;
       msg.meta.block = 0;
-      msg.meta.time = 0;
+      msg.meta.time = "1970-01-01T00:00:00Z";
       msg.signature = get_private_key( from_account.options.memo_key ).sign_compact( msg.digest() );
       return msg;
    }
 
-   bool verify_message( const string& message, const string& account, int block, int time, const compact_signature& sig )
+   bool verify_message( const string& message, const string& account, int block, const string& time,
+                        const compact_signature& sig )
    {
       const account_object from_account = get_account( account );
 
@@ -2341,7 +2342,7 @@ public:
       msg.meta.account = meta_extract( meta, "account" );
       msg.meta.memo_key = public_key_type( meta_extract( meta, "memokey" ) );
       msg.meta.block = boost::lexical_cast<uint32_t>( meta_extract( meta, "block" ) );
-      msg.meta.time = boost::lexical_cast<uint64_t>( meta_extract( meta, "timestamp" ) );
+      msg.meta.time = meta_extract( meta, "timestamp" );
       msg.signature = variant(sig).as< fc::ecc::compact_signature >( 5 );
 
       return verify_signed_message( msg );
@@ -4619,7 +4620,7 @@ signed_message wallet_api::sign_message(string signer, string message)
    return my->sign_message(signer, message);
 }
 
-bool wallet_api::verify_message( string message, string account, int block, int time, compact_signature sig )
+bool wallet_api::verify_message( string message, string account, int block, const string& time, compact_signature sig )
 {
    return my->verify_message( message, account, block, time, sig );
 }

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2274,13 +2274,14 @@ public:
       FC_ASSERT( !self.is_locked() );
 
       const account_object from_account = get_account(signer);
+      auto dynamic_props = get_dynamic_global_properties();
 
       signed_message msg;
       msg.message = message;
       msg.meta.account = from_account.name;
       msg.meta.memo_key = from_account.options.memo_key;
-      msg.meta.block = 0;
-      msg.meta.time = "1970-01-01T00:00:00Z";
+      msg.meta.block = dynamic_props.head_block_number;
+      msg.meta.time = dynamic_props.time.to_iso_string() + "Z";
       msg.signature = get_private_key( from_account.options.memo_key ).sign_compact( msg.digest() );
       return msg;
    }

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2316,11 +2316,6 @@ public:
       return true;
    }
 
-   /** Verify a message signed with sign_message, in its encapsulated form.
-    *
-    * @param message the complete encapsulated message string including separators and line feeds
-    * @return true if signature matches
-    */
    bool verify_encapsulated_message( const string& message )
    {
       signed_message msg;

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -24,6 +24,7 @@
 #include <graphene/app/application.hpp>
 #include <graphene/app/plugin.hpp>
 
+#include <graphene/utilities/key_conversion.hpp>
 #include <graphene/utilities/tempdir.hpp>
 
 #include <graphene/account_history/account_history_plugin.hpp>
@@ -37,6 +38,7 @@
 #include <fc/rpc/websocket_api.hpp>
 #include <fc/rpc/cli.hpp>
 #include <fc/crypto/base58.hpp>
+#include <fc/crypto/hex.hpp>
 
 #include <fc/crypto/aes.hpp>
 
@@ -1084,3 +1086,99 @@ BOOST_AUTO_TEST_CASE( cli_create_htlc )
    }
    app1->shutdown();
 }
+
+static string encapsulate( const graphene::wallet::signed_message& msg )
+{
+   fc::stringstream encapsulated;
+   encapsulated << "-----BEGIN BITSHARES SIGNED MESSAGE-----\n"
+                << msg.message << '\n'
+                << "-----BEGIN META-----\n"
+                << "account=" << msg.meta.account << '\n'
+                << "memokey=" << std::string( msg.meta.memo_key ) << '\n'
+                << "block=" << msg.meta.block << '\n'
+                << "timestamp=" << msg.meta.time << '\n'
+                << "-----BEGIN SIGNATURE-----\n"
+                << fc::to_hex( (const char*)msg.signature->data, msg.signature->size() ) << '\n'
+                << "-----END BITSHARES SIGNED MESSAGE-----";
+   return encapsulated.str();
+}
+
+/******
+ * Check signing/verifying a message with a memo key
+ */
+BOOST_FIXTURE_TEST_CASE( cli_sign_message, cli_fixture )
+{ try {
+   const auto nathan_priv = *wif_to_key( nathan_keys[0] );
+   const public_key_type nathan_pub( nathan_priv.get_public_key() );
+
+   // account does not exist
+   BOOST_REQUIRE_THROW( con.wallet_api_ptr->sign_message( "dan", "123" ), fc::assert_exception );
+
+   // success
+   graphene::wallet::signed_message msg = con.wallet_api_ptr->sign_message( "nathan", "123" );
+   BOOST_CHECK_EQUAL( "123", msg.message );
+   BOOST_CHECK_EQUAL( "nathan", msg.meta.account );
+   BOOST_CHECK_EQUAL( std::string( nathan_pub ), std::string( msg.meta.memo_key ) );
+   BOOST_CHECK( msg.signature.valid() );
+
+   // change message, verify failure
+   msg.message = "124";
+   BOOST_CHECK( !con.wallet_api_ptr->verify_message( msg.message, msg.meta.account, msg.meta.block, msg.meta.time,
+                                                     *msg.signature ) );
+   BOOST_CHECK( !con.wallet_api_ptr->verify_signed_message( msg ) );
+   BOOST_CHECK( !con.wallet_api_ptr->verify_encapsulated_message( encapsulate( msg ) ) );
+   msg.message = "123";
+
+   // change account, verify failure
+   msg.meta.account = "dan";
+   BOOST_REQUIRE_THROW( !con.wallet_api_ptr->verify_message( msg.message, msg.meta.account, msg.meta.block,
+                                                             msg.meta.time, *msg.signature ), fc::assert_exception );
+   BOOST_REQUIRE_THROW( !con.wallet_api_ptr->verify_signed_message( msg ), fc::assert_exception );
+   BOOST_REQUIRE_THROW( !con.wallet_api_ptr->verify_encapsulated_message( encapsulate( msg ) ), fc::assert_exception);
+   msg.meta.account = "nathan";
+
+   // change key, verify failure
+   ++msg.meta.memo_key.key_data.data[1];
+   //BOOST_CHECK( !con.wallet_api_ptr->verify_message( msg.message, msg.meta.account, msg.meta.block, msg.meta.time,
+   //                                                  *msg.signature ) );
+   BOOST_CHECK( !con.wallet_api_ptr->verify_signed_message( msg ) );
+   BOOST_CHECK( !con.wallet_api_ptr->verify_encapsulated_message( encapsulate( msg ) ) );
+   --msg.meta.memo_key.key_data.data[1];
+
+   // change block, verify failure
+   ++msg.meta.block;
+   BOOST_CHECK( !con.wallet_api_ptr->verify_message( msg.message, msg.meta.account, msg.meta.block, msg.meta.time,
+                                                     *msg.signature ) );
+   BOOST_CHECK( !con.wallet_api_ptr->verify_signed_message( msg ) );
+   BOOST_CHECK( !con.wallet_api_ptr->verify_encapsulated_message( encapsulate( msg ) ) );
+   --msg.meta.block;
+
+   // change time, verify failure
+   ++msg.meta.time;
+   BOOST_CHECK( !con.wallet_api_ptr->verify_message( msg.message, msg.meta.account, msg.meta.block, msg.meta.time,
+                                                     *msg.signature ) );
+   BOOST_CHECK( !con.wallet_api_ptr->verify_signed_message( msg ) );
+   BOOST_CHECK( !con.wallet_api_ptr->verify_encapsulated_message( encapsulate( msg ) ) );
+   --msg.meta.time;
+
+   // change signature, verify failure
+   ++msg.signature->data[1];
+   try {
+      BOOST_CHECK( !con.wallet_api_ptr->verify_message( msg.message, msg.meta.account, msg.meta.block, msg.meta.time,
+                                                        *msg.signature ) );
+   } catch( const fc::assert_exception& ) {} // failure to reconstruct key from signature is ok as well
+   try {
+      BOOST_CHECK( !con.wallet_api_ptr->verify_signed_message( msg ) );
+   } catch( const fc::assert_exception& ) {} // failure to reconstruct key from signature is ok as well
+   try {
+      BOOST_CHECK( !con.wallet_api_ptr->verify_encapsulated_message( encapsulate( msg ) ) );
+   } catch( const fc::assert_exception& ) {} // failure to reconstruct key from signature is ok as well
+   --msg.signature->data[1];
+
+   // verify success
+   BOOST_CHECK( con.wallet_api_ptr->verify_message( msg.message, msg.meta.account, msg.meta.block, msg.meta.time,
+                                                    *msg.signature ) );
+   BOOST_CHECK( con.wallet_api_ptr->verify_signed_message( msg ) );
+   BOOST_CHECK( con.wallet_api_ptr->verify_encapsulated_message( encapsulate( msg ) ) );
+
+} FC_LOG_AND_RETHROW() }

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -1154,12 +1154,12 @@ BOOST_FIXTURE_TEST_CASE( cli_sign_message, cli_fixture )
    --msg.meta.block;
 
    // change time, verify failure
-   ++msg.meta.time;
+   ++msg.meta.time[0];
    BOOST_CHECK( !con.wallet_api_ptr->verify_message( msg.message, msg.meta.account, msg.meta.block, msg.meta.time,
                                                      *msg.signature ) );
    BOOST_CHECK( !con.wallet_api_ptr->verify_signed_message( msg ) );
    BOOST_CHECK( !con.wallet_api_ptr->verify_encapsulated_message( encapsulate( msg ) ) );
-   --msg.meta.time;
+   --msg.meta.time[0];
 
    // change signature, verify failure
    ++msg.signature->data[1];


### PR DESCRIPTION
Adds a command to sign a message using an account's memo key, as implemented in https://github.com/xeroc/python-graphenelib/blob/d9634d74273ebacc92555499eca7c444217ecba0/graphenecommon/message.py#L64 .
Also allows verifying such signatures.

Such messages can be used for authentication purposes, an example is https://workers.bitshares.foundation/ .

**Note:** a formal specification for such signatures is [in the works](https://github.com/bitshares/bsips/issues/158). The current draft of that specification is similar to the mechanism used here, but is not 100% compatible.