### PR TITLE
Requires api_helper_indexes plugin to start node

### DIFF
--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -428,7 +428,6 @@ database_api_impl::database_api_impl( graphene::chain::database& db, const appli
    }
    catch( fc::assert_exception& e )
    {
-      wlog( "amount_in_collateral_index not found - please enable api_helper_indexes plugin!" );
       amount_in_collateral_index = nullptr;
    }
 }

--- a/programs/witness_node/main.cpp
+++ b/programs/witness_node/main.cpp
@@ -71,7 +71,8 @@ int main(int argc, char** argv) {
             ("version,v", "Display version information")
             ("plugins", bpo::value<std::string>()
                             ->default_value("witness account_history market_history grouped_orders api_helper_indexes"),
-                    "Space-separated list of plugins to activate");
+                    "Space-separated list of plugins to activate")
+            ("ignore-api-helper-indexes-warning", "Do not exit if api_helper_indexes plugin is not enabled.");
 
       bpo::variables_map options;
 
@@ -82,7 +83,8 @@ int main(int argc, char** argv) {
       cfg_options.add_options()
               ("plugins", bpo::value<std::string>()
 	                      ->default_value("witness account_history market_history grouped_orders api_helper_indexes"),
-               "Space-separated list of plugins to activate");
+               "Space-separated list of plugins to activate")
+            ("ignore-api-helper-indexes-warning", "Do not exit if api_helper_indexes plugin is not enabled.");
 
       auto witness_plug = node->register_plugin<witness_plugin::witness_plugin>();
       auto debug_witness_plug = node->register_plugin<debug_witness_plugin::debug_witness_plugin>();
@@ -140,6 +142,14 @@ int main(int argc, char** argv) {
 
       if(plugins.count("account_history") && plugins.count("elasticsearch")) {
          std::cerr << "Plugin conflict: Cannot load both account_history plugin and elasticsearch plugin\n";
+         return 1;
+      }
+
+      if( !plugins.count("api_helper_indexes") && !options.count("ignore-api-helper-indexes-warning") )
+      {
+         std::cerr << "\nIf this is an API node, please enable api_helper_indexes plugin."
+                      "\nIf this is not an API node, please start with \"--ignore-api-helper-indexes-warning\""
+                      " or enable it in config.ini file.\n\n";
          return 1;
       }
 

--- a/programs/witness_node/main.cpp
+++ b/programs/witness_node/main.cpp
@@ -145,7 +145,8 @@ int main(int argc, char** argv) {
          return 1;
       }
 
-      if( !plugins.count("api_helper_indexes") && !options.count("ignore-api-helper-indexes-warning") )
+      if( !plugins.count("api_helper_indexes") && !options.count("ignore-api-helper-indexes-warning")
+          && ( options.count("rpc-endpoint") || options.count("rpc-tls-endpoint") ) )
       {
          std::cerr << "\nIf this is an API node, please enable api_helper_indexes plugin."
                       "\nIf this is not an API node, please start with \"--ignore-api-helper-indexes-warning\""


### PR DESCRIPTION
#1836 introduced a `wlog` in constructor of `database_api_impl`, this PR changes it to `dlog` because `wlog` will cause disk space issue on API nodes (see https://github.com/bitshares/bitshares-core/pull/1799 and https://github.com/bitshares/bitshares-core/issues/1798).