### PR TITLE
Make Travis use multi-stage build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,19 +24,9 @@ env:
     - CCACHE_MAXSIZE=1Gi
     - CCACHE_SLOPPINESS=include_file_ctime,include_file_mtime,time_macros
 
-script:
- - programs/build_helpers/buildstep -s 3500
- - ccache -s
- - programs/build_helpers/buildstep Prepare 1 "sed -i '/tests/d' libraries/fc/CMakeLists.txt"
- - programs/build_helpers/buildstep cmake 5 "cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS=--coverage -DCMAKE_CXX_FLAGS=--coverage -DBoost_USE_STATIC_LIBS=OFF -DCMAKE_CXX_OUTPUT_EXTENSION_REPLACE=ON ."
- - programs/build_helpers/buildstep make.cli_wallet 2200 "programs/build_helpers/make_with_sonar bw-output -j 2 cli_wallet witness_node js_operation_serializer get_dev_key network_mapper"
- - programs/build_helpers/buildstep make.chain_test 1000 "make -j 2 chain_test"
- - programs/build_helpers/buildstep make.cli_test 200 "make -j 2 cli_test"
- - programs/build_helpers/buildstep make.perf_test 120 "make -j 2 performance_test"
- - set -o pipefail
- - programs/build_helpers/buildstep run.chain_test 240 "libraries/fc/tests/run-parallel-tests.sh tests/chain_test"
- - programs/build_helpers/buildstep run.cli_test 60 "libraries/fc/tests/run-parallel-tests.sh tests/cli_test"
- - 'programs/build_helpers/buildstep prepare.sonar 20 "find libraries/[acdenptuw]*/CMakeFiles/*.dir programs/[cdgjsw]*/CMakeFiles/*.dir -type d | while read d; do gcov -o \"\$d\" \"\${d/CMakeFiles*.dir//}\"/*.cpp; done >/dev/null; programs/build_helpers/set_sonar_branch sonar-project.properties" || true'
- - 'programs/build_helpers/buildstep run.sonar 1200 "which sonar-scanner && sonar-scanner" || true'
- - programs/build_helpers/buildstep end 0
- - ccache -s
+jobs:
+  include:
+    - stage: build for cache
+      script: ./programs/build_helpers/build_protocol
+    - stage: build and test
+      script: ./programs/build_helpers/build_and_test

--- a/programs/build_helpers/build_and_test
+++ b/programs/build_helpers/build_and_test
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+programs/build_helpers/buildstep -s 3500
+ccache -s
+programs/build_helpers/buildstep Prepare 1 "sed -i '/tests/d' libraries/fc/CMakeLists.txt"
+programs/build_helpers/buildstep cmake 5 "cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS=--coverage -DCMAKE_CXX_FLAGS=--coverage -DBoost_USE_STATIC_LIBS=OFF -DCMAKE_CXX_OUTPUT_EXTENSION_REPLACE=ON ."
+programs/build_helpers/buildstep make.everything 2400 "programs/build_helpers/make_with_sonar bw-output -j 2 witness_node chain_test cli_test"
+set -o pipefail
+programs/build_helpers/buildstep run.chain_test 240 "libraries/fc/tests/run-parallel-tests.sh tests/chain_test"
+programs/build_helpers/buildstep run.cli_test 60 "libraries/fc/tests/run-parallel-tests.sh tests/cli_test"
+'programs/build_helpers/buildstep prepare.sonar 20 "find libraries/[acdenptuw]*/CMakeFiles/*.dir programs/[cdgjsw]*/CMakeFiles/*.dir -type d -print | while read d; do gcov -o \"\$d\" \"\${d/CMakeFiles*.dir//}\"/*.cpp; done >/dev/null; programs/build_helpers/set_sonar_branch sonar-project.properties" || true'
+'programs/build_helpers/buildstep run.sonar 1200 "which sonar-scanner && sonar-scanner" || true'
+programs/build_helpers/buildstep end 0
+ccache -s
+

--- a/programs/build_helpers/build_protocol
+++ b/programs/build_helpers/build_protocol
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+programs/build_helpers/buildstep -s 3500
+ccache -s
+programs/build_helpers/buildstep Prepare 1 "sed -i '/tests/d' libraries/fc/CMakeLists.txt"
+programs/build_helpers/buildstep cmake 5 "cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS=--coverage -DCMAKE_CXX_FLAGS=--coverage -DBoost_USE_STATIC_LIBS=OFF -DCMAKE_CXX_OUTPUT_EXTENSION_REPLACE=ON ."
+programs/build_helpers/buildstep make.fc 200 "make -j 2 fc"
+programs/build_helpers/buildstep make.custom_auths 1000 "make -j 2 graphene_protocol"
+programs/build_helpers/buildstep end 0
+ccache -s


### PR DESCRIPTION
The multi-stage build makes Travis builds more reliable by building only
the protocol in the first stage, which reliably passes in time,
caching those binaries, and then building the rest and running
tests in the second stage, which uses the cache to complete in
time as well.