### PR TITLE
add  api_helper_indexes plugin into README

### DIFF
--- a/libraries/plugins/README.md
+++ b/libraries/plugins/README.md
@@ -11,6 +11,7 @@ Plugins are optional to run by node operator according to their needs. However, 
 Folder                             | Name                     | Description                                                                 | Category       | Status        | SpaceID     
 -----------------------------------|--------------------------|-----------------------------------------------------------------------------|----------------|---------------|--------------|
 [account_history](account_history) | Account History          | Save account history data                                                   | History        | Stable        | 4
+[api_helper_indexes](api_helper_indexes) | API Helper Indexes | Provides some helper indexes used by various API calls                                                 | History        | Stable        | 
 [debug_witness](debug_witness)     | Debug Witness            | Run "what-if" tests                                                         | Debug          | Stable        |
 [delayed_node](delayed_node)       | Delayed Node             | Avoid forks by running a several times confirmed and delayed blockchain     | Business       | Stable        |
 [elasticsearch](elasticsearch)     | ElasticSearch Operations | Save account history data into elasticsearch database                       | History        | Experimental  | 6

--- a/libraries/plugins/README.md
+++ b/libraries/plugins/README.md
@@ -11,7 +11,7 @@ Plugins are optional to run by node operator according to their needs. However, 
 Folder                             | Name                     | Description                                                                 | Category       | Status        | SpaceID     
 -----------------------------------|--------------------------|-----------------------------------------------------------------------------|----------------|---------------|--------------|
 [account_history](account_history) | Account History          | Save account history data                                                   | History        | Stable        | 4
-[api_helper_indexes](api_helper_indexes) | API Helper Indexes | Provides some helper indexes used by various API calls                                                 | History        | Stable        | 
+[api_helper_indexes](api_helper_indexes) | API Helper Indexes | Provides some helper indexes used by various API calls                                                 | Helper         | Stable        | 
 [debug_witness](debug_witness)     | Debug Witness            | Run "what-if" tests                                                         | Debug          | Stable        |
 [delayed_node](delayed_node)       | Delayed Node             | Avoid forks by running a several times confirmed and delayed blockchain     | Business       | Stable        |
 [elasticsearch](elasticsearch)     | ElasticSearch Operations | Save account history data into elasticsearch database                       | History        | Experimental  | 6

--- a/libraries/plugins/README.md
+++ b/libraries/plugins/README.md
@@ -11,7 +11,7 @@ Plugins are optional to run by node operator according to their needs. However, 
 Folder                             | Name                     | Description                                                                 | Category       | Status        | SpaceID     
 -----------------------------------|--------------------------|-----------------------------------------------------------------------------|----------------|---------------|--------------|
 [account_history](account_history) | Account History          | Save account history data                                                   | History        | Stable        | 4
-[api_helper_indexes](api_helper_indexes) | API Helper Indexes | Provides some helper indexes used by various API calls                                                 | Helper         | Stable        | 
+[api_helper_indexes](api_helper_indexes) | API Helper Indexes | Provides some helper indexes used by various API calls                                                 | Database API   | Stable        | 
 [debug_witness](debug_witness)     | Debug Witness            | Run "what-if" tests                                                         | Debug          | Stable        |
 [delayed_node](delayed_node)       | Delayed Node             | Avoid forks by running a several times confirmed and delayed blockchain     | Business       | Stable        |
 [elasticsearch](elasticsearch)     | ElasticSearch Operations | Save account history data into elasticsearch database                       | History        | Experimental  | 6


### PR DESCRIPTION
Used description found in plugin(https://github.com/bitshares/bitshares-core/blob/develop/libraries/plugins/api_helper_indexes/api_helper_indexes.cpp#L132).

Added with `History` category, most sure if it is the most accurate.  Maybe just `Helper` ?

Issue https://github.com/bitshares/bitshares-core/issues/1893