### PR TITLE
Fix broken build

### DIFF
--- a/tests/tests/database_api_tests.cpp
+++ b/tests/tests/database_api_tests.cpp
@@ -28,9 +28,11 @@
 #include <graphene/chain/hardfork.hpp>
 
 #include <fc/crypto/digest.hpp>
-
 #include <fc/crypto/hex.hpp>
+
 #include "../common/database_fixture.hpp"
+
+#include <random>
 
 using namespace graphene::chain;
 using namespace graphene::chain::test;


### PR DESCRIPTION
Current `develop` branch is broken (depending on compiler). This PR adds a missing include.