### PR TITLE
Skip secondary indexes during replay

### DIFF
--- a/libraries/chain/account_object.cpp
+++ b/libraries/chain/account_object.cpp
@@ -256,19 +256,6 @@ void account_member_index::object_modified(const object& after)
 
 }
 
-void account_referrer_index::object_inserted( const object& obj )
-{
-}
-void account_referrer_index::object_removed( const object& obj )
-{
-}
-void account_referrer_index::about_to_modify( const object& before )
-{
-}
-void account_referrer_index::object_modified( const object& after  )
-{
-}
-
 const uint8_t  balances_by_account_index::bits = 20;
 const uint64_t balances_by_account_index::mask = (1ULL << balances_by_account_index::bits) - 1;
 

--- a/libraries/chain/db_init.cpp
+++ b/libraries/chain/db_init.cpp
@@ -189,9 +189,7 @@ void database::initialize_indexes()
    add_index< primary_index<asset_index, 13> >(); // 8192 assets per chunk
    add_index< primary_index<force_settlement_index> >();
 
-   auto acnt_index = add_index< primary_index<account_index, 20> >(); // ~1 million accounts per chunk
-   acnt_index->add_secondary_index<account_member_index>();
-
+   add_index< primary_index<account_index, 20> >(); // ~1 million accounts per chunk
    add_index< primary_index<committee_member_index, 8> >(); // 256 members per chunk
    add_index< primary_index<witness_index, 10> >(); // 1024 witnesses per chunk
    add_index< primary_index<limit_order_index > >();

--- a/libraries/chain/db_init.cpp
+++ b/libraries/chain/db_init.cpp
@@ -194,10 +194,7 @@ void database::initialize_indexes()
    add_index< primary_index<witness_index, 10> >(); // 1024 witnesses per chunk
    add_index< primary_index<limit_order_index > >();
    add_index< primary_index<call_order_index > >();
-
-   auto prop_index = add_index< primary_index<proposal_index > >();
-   prop_index->add_secondary_index<required_approval_index>();
-
+   add_index< primary_index<proposal_index > >();
    add_index< primary_index<withdraw_permission_index > >();
    add_index< primary_index<vesting_balance_index> >();
    add_index< primary_index<worker_index> >();

--- a/libraries/chain/db_init.cpp
+++ b/libraries/chain/db_init.cpp
@@ -191,7 +191,6 @@ void database::initialize_indexes()
 
    auto acnt_index = add_index< primary_index<account_index, 20> >(); // ~1 million accounts per chunk
    acnt_index->add_secondary_index<account_member_index>();
-   acnt_index->add_secondary_index<account_referrer_index>();
 
    add_index< primary_index<committee_member_index, 8> >(); // 256 members per chunk
    add_index< primary_index<witness_index, 10> >(); // 1024 witnesses per chunk

--- a/libraries/chain/include/graphene/chain/account_object.hpp
+++ b/libraries/chain/include/graphene/chain/account_object.hpp
@@ -325,22 +325,6 @@ namespace graphene { namespace chain {
 
 
    /**
-    *  @brief This secondary index will allow a reverse lookup of all accounts that have been referred by
-    *  a particular account.
-    */
-   class account_referrer_index : public secondary_index
-   {
-      public:
-         virtual void object_inserted( const object& obj ) override;
-         virtual void object_removed( const object& obj ) override;
-         virtual void about_to_modify( const object& before ) override;
-         virtual void object_modified( const object& after  ) override;
-
-         /** maps the referrer to the set of accounts that they have referred */
-         map< account_id_type, set<account_id_type> > referred_by;
-   };
-
-   /**
     *  @brief This secondary index will allow fast access to the balance objects
     *         that belonging to an account.
     */

--- a/libraries/plugins/api_helper_indexes/api_helper_indexes.cpp
+++ b/libraries/plugins/api_helper_indexes/api_helper_indexes.cpp
@@ -24,6 +24,7 @@
 
 #include <graphene/api_helper_indexes/api_helper_indexes.hpp>
 #include <graphene/chain/market_object.hpp>
+#include <graphene/chain/proposal_object.hpp>
 
 namespace graphene { namespace api_helper_indexes {
 
@@ -153,6 +154,10 @@ void api_helper_indexes::plugin_startup()
    auto& account_members = *database().add_secondary_index< primary_index<account_index>, account_member_index >();
    for( const auto& account : database().get_index_type< account_index >().indices() )
       account_members.object_inserted( account );
+
+   auto& approvals = *database().add_secondary_index< primary_index<proposal_index>, required_approval_index >();
+   for( const auto& proposal : database().get_index_type< proposal_index >().indices() )
+      approvals.object_inserted( proposal );
 }
 
 } }

--- a/libraries/plugins/api_helper_indexes/api_helper_indexes.cpp
+++ b/libraries/plugins/api_helper_indexes/api_helper_indexes.cpp
@@ -149,6 +149,10 @@ void api_helper_indexes::plugin_startup()
    amount_in_collateral = database().add_secondary_index< primary_index<call_order_index>, amount_in_collateral_index >();
    for( const auto& call : database().get_index_type<call_order_index>().indices() )
       amount_in_collateral->object_inserted( call );
+
+   auto& account_members = *database().add_secondary_index< primary_index<account_index>, account_member_index >();
+   for( const auto& account : database().get_index_type< account_index >().indices() )
+      account_members.object_inserted( account );
 }
 
 } }

--- a/libraries/plugins/grouped_orders/grouped_orders_plugin.cpp
+++ b/libraries/plugins/grouped_orders/grouped_orders_plugin.cpp
@@ -279,12 +279,13 @@ void grouped_orders_plugin::plugin_initialize(const boost::program_options::vari
    else
       my->_tracked_groups = fc::json::from_string("[10,100]").as<flat_set<uint16_t>>(2);
 
-   database().add_secondary_index< primary_index<limit_order_index>, detail::limit_order_group_index >( my->_tracked_groups );
-
 } FC_CAPTURE_AND_RETHROW() }
 
 void grouped_orders_plugin::plugin_startup()
 {
+   auto& groups = *database().add_secondary_index< primary_index<limit_order_index>, detail::limit_order_group_index >( my->_tracked_groups );
+   for( const auto& order : database().get_index_type< limit_order_index >().indices() )
+      groups.object_inserted( order );
 }
 
 const flat_set<uint16_t>& grouped_orders_plugin::tracked_groups() const

--- a/libraries/plugins/grouped_orders/grouped_orders_plugin.cpp
+++ b/libraries/plugins/grouped_orders/grouped_orders_plugin.cpp
@@ -283,7 +283,8 @@ void grouped_orders_plugin::plugin_initialize(const boost::program_options::vari
 
 void grouped_orders_plugin::plugin_startup()
 {
-   auto& groups = *database().add_secondary_index< primary_index<limit_order_index>, detail::limit_order_group_index >( my->_tracked_groups );
+   auto& groups = *database().add_secondary_index< primary_index<limit_order_index>,
+                                                   detail::limit_order_group_index >( my->_tracked_groups );
    for( const auto& order : database().get_index_type< limit_order_index >().indices() )
       groups.object_inserted( order );
 }

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -28,6 +28,7 @@
 #include <graphene/utilities/tempdir.hpp>
 
 #include <graphene/account_history/account_history_plugin.hpp>
+#include <graphene/api_helper_indexes/api_helper_indexes.hpp>
 #include <graphene/market_history/market_history_plugin.hpp>
 #include <graphene/egenesis/egenesis.hpp>
 #include <graphene/wallet/wallet.hpp>
@@ -125,6 +126,7 @@ std::shared_ptr<graphene::app::application> start_application(fc::temp_directory
    app1->register_plugin<graphene::account_history::account_history_plugin>(true);
    app1->register_plugin< graphene::market_history::market_history_plugin >(true);
    app1->register_plugin< graphene::grouped_orders::grouped_orders_plugin>(true);
+   app1->register_plugin< graphene::api_helper_indexes::api_helper_indexes>(true);
    app1->startup_plugins();
    boost::program_options::variables_map cfg;
 #ifdef _WIN32

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -325,7 +325,9 @@ database_fixture::database_fixture(const fc::time_point_sec &initial_timestamp)
       esobjects_plugin->plugin_initialize(options);
       esobjects_plugin->plugin_startup();
    }
-   else if( current_test_name == "asset_in_collateral" || current_suite_name == "database_api_tests" )
+   else if( current_test_name == "asset_in_collateral"
+            || current_test_name == "htlc_database_api"
+            || current_suite_name == "database_api_tests" )
    {
       auto ahiplugin = app.register_plugin<graphene::api_helper_indexes::api_helper_indexes>();
       ahiplugin->plugin_set_app(&app);

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -125,8 +125,10 @@ database_fixture::database_fixture(const fc::time_point_sec &initial_timestamp)
    /**
     * Test specific settings
     */
-   auto current_test_name = boost::unit_test::framework::current_test_case().p_name.value;
-   auto current_test_suite_id = boost::unit_test::framework::current_test_case().p_parent_id;
+   const auto current_test_name = boost::unit_test::framework::current_test_case().p_name.value;
+   const auto current_test_suite_id = boost::unit_test::framework::current_test_case().p_parent_id;
+   const auto current_suite_name = boost::unit_test::framework::get<boost::unit_test::test_suite>(current_test_suite_id)
+                                        .p_name.value;
    if (current_test_name == "get_account_history_operations")
    {
       options.insert(std::make_pair("max-ops-per-account", boost::program_options::variable_value((uint64_t)75, false)));
@@ -292,7 +294,7 @@ database_fixture::database_fixture(const fc::time_point_sec &initial_timestamp)
       esplugin->plugin_initialize(options);
       esplugin->plugin_startup();
    }
-   else if( boost::unit_test::framework::get<boost::unit_test::test_suite>(current_test_suite_id).p_name.value != "performance_tests" )
+   else if( current_suite_name != "performance_tests" )
    {
       auto ahplugin = app.register_plugin<graphene::account_history::account_history_plugin>();
       ahplugin->plugin_set_app(&app);
@@ -323,7 +325,7 @@ database_fixture::database_fixture(const fc::time_point_sec &initial_timestamp)
       esobjects_plugin->plugin_initialize(options);
       esobjects_plugin->plugin_startup();
    }
-   else if( current_test_name == "asset_in_collateral" )
+   else if( current_test_name == "asset_in_collateral" || current_suite_name == "database_api_tests" )
    {
       auto ahiplugin = app.register_plugin<graphene::api_helper_indexes::api_helper_indexes>();
       ahiplugin->plugin_set_app(&app);
@@ -431,7 +433,7 @@ string database_fixture::generate_anon_acct_name()
    //    to workaround issue #46
    return "anon-acct-x" + std::to_string( anon_acct_count++ );
 }
-bool database_fixture::validation_current_test_name_for_setting_api_limit(string & current_test_name) const
+bool database_fixture::validation_current_test_name_for_setting_api_limit( const string& current_test_name ) const
 {
    vector <string> valid_testcase {"api_limit_get_account_history_operations","api_limit_get_account_history"
       ,"api_limit_get_grouped_limit_orders","api_limit_get_relative_account_history"

--- a/tests/common/database_fixture.hpp
+++ b/tests/common/database_fixture.hpp
@@ -371,7 +371,7 @@ struct database_fixture {
 
    vector< operation_history_object > get_operation_history( account_id_type account_id )const;
    vector< graphene::market_history::order_history_object > get_market_order_history( asset_id_type a, asset_id_type b )const;
-   bool validation_current_test_name_for_setting_api_limit (string & current_test_name) const;
+   bool validation_current_test_name_for_setting_api_limit( const string& current_test_name )const;
 
    /****
     * @brief return htlc fee parameters

--- a/tests/tests/database_tests.cpp
+++ b/tests/tests/database_tests.cpp
@@ -229,8 +229,8 @@ BOOST_AUTO_TEST_CASE( required_approval_index_test ) // see https://github.com/b
 
    database db1;
    db1.initialize_indexes();
-   const auto& proposals = db1.get_index_type< primary_index< proposal_index > >();
-   const auto& required_approvals = proposals.get_secondary_index< required_approval_index >()._account_to_proposals;
+   const auto& required_approvals = db1.add_secondary_index<primary_index<proposal_index>, required_approval_index>()
+                                       ->_account_to_proposals;
 
    // Create a proposal
    const auto& prop = db1.create<proposal_object>( [this,alice_id,agnetha_id]( object& o ) {
@@ -279,8 +279,8 @@ BOOST_AUTO_TEST_CASE( required_approval_index_test ) // see https://github.com/b
    database db2;
    db2.initialize_indexes();
    const auto& reloaded_proposals = db2.get_index_type< primary_index< proposal_index > >();
-   const auto& reloaded_approvals = reloaded_proposals.get_secondary_index<required_approval_index>()
-                                                                                              ._account_to_proposals;
+   const auto& reloaded_approvals = db2.add_secondary_index<primary_index<proposal_index>, required_approval_index>()
+                                       ->_account_to_proposals;
    const_cast< primary_index< proposal_index >& >( reloaded_proposals ).load( serialized );
    const auto& prop2 = *reloaded_proposals.indices().begin();
 


### PR DESCRIPTION
Fixes #452 
Fixes #683

The indexes handled here are not used by consensus code. There's no need to update them during replay.
Two indexes have been moved into `api_helper_indexes` plugin.
The `grouped_orders` plugin has been modified to add its secondary index after replay, in the same way that `api_helper_indexes` does it.

I believe the risk I mentioned in https://github.com/bitshares/bitshares-core/issues/683#issuecomment-375018041 is sufficiently low.

Haven't measured speedup yet.