### PR TITLE
Fix Windows linker error

### DIFF
--- a/libraries/app/include/graphene/app/util.hpp
+++ b/libraries/app/include/graphene/app/util.hpp
@@ -30,7 +30,7 @@ namespace protocol {
    struct price;
 }
 namespace chain {
-   struct asset_object;
+   class asset_object;
 }
 
 namespace app {


### PR DESCRIPTION
The error was introduced by #1891.

>graphene_app.lib(database_api.obj) : error LNK2019: unresolved external symbol "class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl graphene::app::price_to_string(struct graphene::protocol::price const &,class graphene::chain::asset_object const &,class graphene::chain::asset_object const &)" (?price_to_string@app@graphene@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBUprice@protocol@2@AEBVasset_object@chain@2@1@Z) referenced in function "public: struct graphene::app::order_book __cdecl graphene::app::database_api_impl::get_order_book(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,unsigned int)const " (?get_order_book@database_api_impl@app@graphene@@QEBA?AUorder_book@23@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@0I@Z)
3>graphene_app.lib(api_objects.obj) : error LNK2001: unresolved external symbol "class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl graphene::app::price_to_string(struct graphene::protocol::price const &,class graphene::chain::asset_object const &,class graphene::chain::asset_object const &)" (?price_to_string@app@graphene@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBUprice@protocol@2@AEBVasset_object@chain@2@1@Z)
3>C:\Development\cpp\bitshares-core-develop\build\tests\generate_empty_blocks\Release\generate_empty_blocks.exe : fatal error LNK1120: 1 unresolved externals