### PR TITLE
Remove witness plugin from cli test

### DIFF
--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -28,7 +28,6 @@
 #include <graphene/utilities/tempdir.hpp>
 
 #include <graphene/account_history/account_history_plugin.hpp>
-#include <graphene/witness/witness.hpp>
 #include <graphene/market_history/market_history_plugin.hpp>
 #include <graphene/egenesis/egenesis.hpp>
 #include <graphene/wallet/wallet.hpp>
@@ -125,7 +124,6 @@ std::shared_ptr<graphene::app::application> start_application(fc::temp_directory
 
    app1->register_plugin<graphene::account_history::account_history_plugin>(true);
    app1->register_plugin< graphene::market_history::market_history_plugin >(true);
-   app1->register_plugin< graphene::witness_plugin::witness_plugin >(true);
    app1->register_plugin< graphene::grouped_orders::grouped_orders_plugin>(true);
    app1->startup_plugins();
    boost::program_options::variables_map cfg;


### PR DESCRIPTION
No need to load witness plugin in the cli tests.