### PR TITLE
Fix warnings

### DIFF
--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -2738,7 +2738,7 @@ public:
          return ss.str();
       };
 
-      m["sign_message"] = [this](variant result, const fc::variants& a)
+      m["sign_message"] = [](variant result, const fc::variants& a)
       {
          auto r = result.as<signed_message>( GRAPHENE_MAX_NESTED_OBJECTS );
 

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -1130,10 +1130,10 @@ BOOST_FIXTURE_TEST_CASE( cli_sign_message, cli_fixture )
 
    // change account, verify failure
    msg.meta.account = "dan";
-   BOOST_REQUIRE_THROW( !con.wallet_api_ptr->verify_message( msg.message, msg.meta.account, msg.meta.block,
-                                                             msg.meta.time, *msg.signature ), fc::assert_exception );
-   BOOST_REQUIRE_THROW( !con.wallet_api_ptr->verify_signed_message( msg ), fc::assert_exception );
-   BOOST_REQUIRE_THROW( !con.wallet_api_ptr->verify_encapsulated_message( encapsulate( msg ) ), fc::assert_exception);
+   BOOST_REQUIRE_THROW( con.wallet_api_ptr->verify_message( msg.message, msg.meta.account, msg.meta.block,
+                                                            msg.meta.time, *msg.signature ), fc::assert_exception );
+   BOOST_REQUIRE_THROW( con.wallet_api_ptr->verify_signed_message( msg ), fc::assert_exception );
+   BOOST_REQUIRE_THROW( con.wallet_api_ptr->verify_encapsulated_message( encapsulate( msg ) ), fc::assert_exception);
    msg.meta.account = "nathan";
 
    // change key, verify failure

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -1129,11 +1129,18 @@ BOOST_FIXTURE_TEST_CASE( cli_sign_message, cli_fixture )
    msg.message = "123";
 
    // change account, verify failure
+   // nonexistent account:
    msg.meta.account = "dan";
    BOOST_REQUIRE_THROW( con.wallet_api_ptr->verify_message( msg.message, msg.meta.account, msg.meta.block,
                                                             msg.meta.time, *msg.signature ), fc::assert_exception );
    BOOST_REQUIRE_THROW( con.wallet_api_ptr->verify_signed_message( msg ), fc::assert_exception );
    BOOST_REQUIRE_THROW( con.wallet_api_ptr->verify_encapsulated_message( encapsulate( msg ) ), fc::assert_exception);
+   // existing, but wrong account:
+   msg.meta.account = "committee-account";
+   BOOST_CHECK( !con.wallet_api_ptr->verify_message( msg.message, msg.meta.account, msg.meta.block,
+                                                     msg.meta.time, *msg.signature ) );
+   BOOST_CHECK( !con.wallet_api_ptr->verify_signed_message( msg ) );
+   BOOST_CHECK( !con.wallet_api_ptr->verify_encapsulated_message( encapsulate( msg ) ) );
    msg.meta.account = "nathan";
 
    // change key, verify failure

--- a/tests/tests/database_api_tests.cpp
+++ b/tests/tests/database_api_tests.cpp
@@ -1958,7 +1958,7 @@ BOOST_AUTO_TEST_CASE(api_limit_get_collateral_bids) {
 
       // this sell order is designed to trigger a black swan
 
-      create_sell_order( borrower2_id(db), swan(db).amount(1), back(db).amount(3) )->id;
+      create_sell_order( borrower2_id(db), swan(db).amount(1), back(db).amount(3) );
       BOOST_CHECK( swan(db).bitasset_data(db).has_settlement() );
       //making 3 collateral bids
       for (int i=0; i<3; i++) {


### PR DESCRIPTION
This fixes an "unused lambda capture" and several "expression result unused" warnings.