### PR TITLE
Bump FC for Reflection/static_variant updates

### DIFF
--- a/libraries/protocol/include/graphene/protocol/base.hpp
+++ b/libraries/protocol/include/graphene/protocol/base.hpp
@@ -117,7 +117,7 @@ namespace graphene { namespace protocol {
     *  @note static_variant compares only the type tag and not the 
     *  content.
     */
-   typedef flat_set<future_extensions> extensions_type;
+   using extensions_type = future_extensions::flat_set_type;
 
    ///@}
 

--- a/libraries/protocol/include/graphene/protocol/fee_schedule.hpp
+++ b/libraries/protocol/include/graphene/protocol/fee_schedule.hpp
@@ -30,14 +30,14 @@ namespace graphene { namespace protocol {
    template<typename ...T>
    struct transform_to_fee_parameters<fc::static_variant<T...>>
    {
-      typedef fc::static_variant< typename T::fee_parameters_type... > type;
+      using type = fc::static_variant< typename T::fee_parameters_type... >;
    };
-   typedef transform_to_fee_parameters<operation>::type fee_parameters;
+   using fee_parameters = transform_to_fee_parameters<operation>::type;
 
    template<typename Operation>
    class fee_helper {
      public:
-      const typename Operation::fee_parameters_type& cget(const flat_set<fee_parameters>& parameters)const
+      const typename Operation::fee_parameters_type& cget(const fee_parameters::flat_set_type& parameters)const
       {
          auto itr = parameters.find( typename Operation::fee_parameters_type() );
          FC_ASSERT( itr != parameters.end() );
@@ -48,13 +48,13 @@ namespace graphene { namespace protocol {
    template<>
    class fee_helper<account_create_operation> {
      public:
-      const account_create_operation::fee_parameters_type& cget(const flat_set<fee_parameters>& parameters)const
+      const account_create_operation::fee_parameters_type& cget(const fee_parameters::flat_set_type& parameters)const
       {
          auto itr = parameters.find( account_create_operation::fee_parameters_type() );
          FC_ASSERT( itr != parameters.end() );
          return itr->get<account_create_operation::fee_parameters_type>();
       }
-      typename account_create_operation::fee_parameters_type& get(flat_set<fee_parameters>& parameters)const
+      typename account_create_operation::fee_parameters_type& get(fee_parameters::flat_set_type& parameters)const
       {
          auto itr = parameters.find( account_create_operation::fee_parameters_type() );
          FC_ASSERT( itr != parameters.end() );
@@ -65,7 +65,7 @@ namespace graphene { namespace protocol {
    template<>
    class fee_helper<bid_collateral_operation> {
      public:
-      const bid_collateral_operation::fee_parameters_type& cget(const flat_set<fee_parameters>& parameters)const
+      const bid_collateral_operation::fee_parameters_type& cget(const fee_parameters::flat_set_type& parameters)const
       {
          auto itr = parameters.find( bid_collateral_operation::fee_parameters_type() );
          if ( itr != parameters.end() )
@@ -80,7 +80,7 @@ namespace graphene { namespace protocol {
    template<>
    class fee_helper<asset_update_issuer_operation> {
      public:
-      const asset_update_issuer_operation::fee_parameters_type& cget(const flat_set<fee_parameters>& parameters)const
+      const asset_update_issuer_operation::fee_parameters_type& cget(const fee_parameters::flat_set_type& parameters)const
       {
          auto itr = parameters.find( asset_update_issuer_operation::fee_parameters_type() );
          if ( itr != parameters.end() )
@@ -95,7 +95,7 @@ namespace graphene { namespace protocol {
    template<>
    class fee_helper<asset_claim_pool_operation> {
      public:
-      const asset_claim_pool_operation::fee_parameters_type& cget(const flat_set<fee_parameters>& parameters)const
+      const asset_claim_pool_operation::fee_parameters_type& cget(const fee_parameters::flat_set_type& parameters)const
       {
          auto itr = parameters.find( asset_claim_pool_operation::fee_parameters_type() );
          if ( itr != parameters.end() )
@@ -110,7 +110,7 @@ namespace graphene { namespace protocol {
    template<>
    class fee_helper<htlc_create_operation> {
      public:
-      const htlc_create_operation::fee_parameters_type& cget(const flat_set<fee_parameters>& parameters)const
+      const htlc_create_operation::fee_parameters_type& cget(const fee_parameters::flat_set_type& parameters)const
       {
          auto itr = parameters.find( htlc_create_operation::fee_parameters_type() );
          if ( itr != parameters.end() )
@@ -124,7 +124,7 @@ namespace graphene { namespace protocol {
    template<>
    class fee_helper<htlc_redeem_operation> {
      public:
-      const htlc_redeem_operation::fee_parameters_type& cget(const flat_set<fee_parameters>& parameters)const
+      const htlc_redeem_operation::fee_parameters_type& cget(const fee_parameters::flat_set_type& parameters)const
       {
          auto itr = parameters.find( htlc_redeem_operation::fee_parameters_type() );
          if ( itr != parameters.end() )
@@ -137,7 +137,7 @@ namespace graphene { namespace protocol {
    template<>
    class fee_helper<htlc_extend_operation> {
      public:
-      const htlc_extend_operation::fee_parameters_type& cget(const flat_set<fee_parameters>& parameters)const
+      const htlc_extend_operation::fee_parameters_type& cget(const fee_parameters::flat_set_type& parameters)const
       {
          auto itr = parameters.find( htlc_extend_operation::fee_parameters_type() );
          if ( itr != parameters.end() )
@@ -190,7 +190,7 @@ namespace graphene { namespace protocol {
          return fee_helper<Operation>().get(parameters);
       }
       template<typename Operation>
-      const bool exists()const
+      bool exists()const
       {
          auto itr = parameters.find(typename Operation::fee_parameters_type());
          return itr != parameters.end();
@@ -199,7 +199,7 @@ namespace graphene { namespace protocol {
       /**
        *  @note must be sorted by fee_parameters.which() and have no duplicates
        */
-      flat_set<fee_parameters> parameters;
+      fee_parameters::flat_set_type parameters;
       uint32_t                 scale = GRAPHENE_100_PERCENT; ///< fee * scale / GRAPHENE_100_PERCENT
       private:
       static void set_fee_parameters(fee_schedule& sched);

--- a/libraries/protocol/include/graphene/protocol/types.hpp
+++ b/libraries/protocol/include/graphene/protocol/types.hpp
@@ -72,28 +72,6 @@ namespace raw { \
 #define GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION(type) GRAPHENE_EXTERNAL_SERIALIZATION(extern, type)
 #define GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION(type) GRAPHENE_EXTERNAL_SERIALIZATION(/*not extern*/, type)
 
-#define FC_REFLECT_DERIVED_NO_TYPENAME( TYPE, INHERITS, MEMBERS ) \
-namespace fc { \
-template<> struct reflector<TYPE> {\
-    typedef TYPE type; \
-    typedef std::true_type is_defined; \
-    using native_members = \
-       typename typelist::builder<>::type \
-          BOOST_PP_SEQ_FOR_EACH_I( FC_CONCAT_MEMBER_REFLECTION, TYPE, MEMBERS ) ::finalize; \
-    using inherited_members = \
-       typename typelist::builder<>::type \
-          BOOST_PP_SEQ_FOR_EACH( FC_CONCAT_BASE_MEMBER_REFLECTIONS, TYPE, INHERITS ) ::finalize; \
-    using members = typename typelist::concat<inherited_members, native_members>::type; \
-    using base_classes = typename typelist::builder<>::type \
-          BOOST_PP_SEQ_FOR_EACH( FC_CONCAT_TYPE, x, INHERITS ) ::finalize; \
-    enum  member_count_enum {  \
-      local_member_count = typelist::length<native_members>(), \
-      total_member_count = typelist::length<members>() \
-    }; \
-    FC_REFLECT_DERIVED_IMPL_INLINE( TYPE, INHERITS, MEMBERS ) \
-}; \
-} // fc
-
 #define GRAPHENE_NAME_TO_OBJECT_TYPE(x, prefix, name) BOOST_PP_CAT(prefix, BOOST_PP_CAT(name, _object_type))
 #define GRAPHENE_NAME_TO_ID_TYPE(x, y, name) BOOST_PP_CAT(name, _id_type)
 #define GRAPHENE_DECLARE_ID(x, space_prefix_seq, name) \

--- a/libraries/protocol/include/graphene/protocol/types.hpp
+++ b/libraries/protocol/include/graphene/protocol/types.hpp
@@ -77,9 +77,18 @@ namespace fc { \
 template<> struct reflector<TYPE> {\
     typedef TYPE type; \
     typedef std::true_type is_defined; \
+    using native_members = \
+       typename typelist::builder<>::type \
+          BOOST_PP_SEQ_FOR_EACH_I( FC_CONCAT_MEMBER_REFLECTION, TYPE, MEMBERS ) ::finalize; \
+    using inherited_members = \
+       typename typelist::builder<>::type \
+          BOOST_PP_SEQ_FOR_EACH( FC_CONCAT_BASE_MEMBER_REFLECTIONS, TYPE, INHERITS ) ::finalize; \
+    using members = typename typelist::concat<inherited_members, native_members>::type; \
+    using base_classes = typename typelist::builder<>::type \
+          BOOST_PP_SEQ_FOR_EACH( FC_CONCAT_TYPE, x, INHERITS ) ::finalize; \
     enum  member_count_enum {  \
-      local_member_count = 0  BOOST_PP_SEQ_FOR_EACH( FC_REFLECT_MEMBER_COUNT, +, MEMBERS ),\
-      total_member_count = local_member_count BOOST_PP_SEQ_FOR_EACH( FC_REFLECT_BASE_MEMBER_COUNT, +, INHERITS )\
+      local_member_count = typelist::length<native_members>(), \
+      total_member_count = typelist::length<members>() \
     }; \
     FC_REFLECT_DERIVED_IMPL_INLINE( TYPE, INHERITS, MEMBERS ) \
 }; \

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -798,7 +798,7 @@ void database_fixture::issue_uia( account_id_type recipient_id, asset amount )
 }
 
 void database_fixture::change_fees(
-   const flat_set< fee_parameters >& new_params,
+   const fee_parameters::flat_set_type& new_params,
    uint32_t new_scale /* = 0 */
    )
 {

--- a/tests/common/database_fixture.hpp
+++ b/tests/common/database_fixture.hpp
@@ -353,7 +353,7 @@ struct database_fixture {
     * finish creating a block
     */
    void enable_fees();
-   void change_fees( const flat_set< fee_parameters >& new_params, uint32_t new_scale = 0 );
+   void change_fees( const fee_parameters::flat_set_type& new_params, uint32_t new_scale = 0 );
    void upgrade_to_lifetime_member( account_id_type account );
    void upgrade_to_lifetime_member( const account_object& account );
    void upgrade_to_annual_member( account_id_type account );

--- a/tests/tests/bitasset_tests.cpp
+++ b/tests/tests/bitasset_tests.cpp
@@ -648,7 +648,7 @@ BOOST_AUTO_TEST_CASE( bitasset_evaluator_test_before_922_931 )
 
    // this should pass
    BOOST_TEST_MESSAGE( "Evaluating a good operation" );
-   BOOST_CHECK( evaluator.evaluate(op) == void_result() );
+   BOOST_CHECK( evaluator.evaluate(op).is_type<void_result>() );
 
    // test with a market issued asset
    BOOST_TEST_MESSAGE( "Sending a non-bitasset." );
@@ -677,25 +677,25 @@ BOOST_AUTO_TEST_CASE( bitasset_evaluator_test_before_922_931 )
    // back by self
    BOOST_TEST_MESSAGE( "Message should contain: op.new_options.short_backing_asset == asset_obj.get_id()" );
    op.new_options.short_backing_asset = bit_usd_id;
-   BOOST_CHECK( evaluator.evaluate(op) == void_result() );
+   BOOST_CHECK( evaluator.evaluate(op).is_type<void_result>() );
    op.new_options.short_backing_asset = correct_asset_id;
 
    // prediction market with different precision
    BOOST_TEST_MESSAGE( "Message should contain: for a PM, asset_obj.precision != new_backing_asset.precision" );
    op.asset_to_update = asset_objs.prediction;
    op.issuer = asset_objs.prediction(db).issuer;
-   BOOST_CHECK( evaluator.evaluate(op) == void_result() );
+   BOOST_CHECK( evaluator.evaluate(op).is_type<void_result>() );
    op.asset_to_update = bit_usd_id;
    op.issuer = asset_objs.bit_usd(db).issuer;
 
    // checking old backing asset instead of new backing asset
    BOOST_TEST_MESSAGE( "Message should contain: to be backed by an asset which is not market issued asset nor CORE" );
    op.new_options.short_backing_asset = asset_objs.six_precision;
-   BOOST_CHECK( evaluator.evaluate(op) == void_result() );
+   BOOST_CHECK( evaluator.evaluate(op).is_type<void_result>() );
    BOOST_TEST_MESSAGE( "Message should contain: modified a blockchain-controlled market asset to be backed by an asset "
          "which is not backed by CORE" );
    op.new_options.short_backing_asset = asset_objs.prediction;
-   BOOST_CHECK( evaluator.evaluate(op) == void_result() );
+   BOOST_CHECK( evaluator.evaluate(op).is_type<void_result>() );
    op.new_options.short_backing_asset = correct_asset_id;
 
    // CHILDUSER is a non-committee asset backed by PARENT which is backed by CORE
@@ -707,15 +707,15 @@ BOOST_AUTO_TEST_CASE( bitasset_evaluator_test_before_922_931 )
    op.issuer = asset_objs.bit_parent(db).issuer;
    op.new_options.short_backing_asset = asset_objs.bit_usdbacked;
    // this should generate a warning in the log, but not fail.
-   BOOST_CHECK( evaluator.evaluate(op) == void_result() );
+   BOOST_CHECK( evaluator.evaluate(op).is_type<void_result>() );
    // changing the backing asset to a UIA should work
    BOOST_TEST_MESSAGE( "Switching to a backing asset that is a UIA should work. No warning should be produced." );
    op.new_options.short_backing_asset = asset_objs.user_issued;
-   BOOST_CHECK( evaluator.evaluate(op) == void_result() );
+   BOOST_CHECK( evaluator.evaluate(op).is_type<void_result>() );
    // A -> B -> C, change B to be backed by A (circular backing)
    BOOST_TEST_MESSAGE( "Message should contain: A cannot be backed by B which is backed by A." );
    op.new_options.short_backing_asset = asset_objs.bit_child_bitasset;
-   BOOST_CHECK( evaluator.evaluate(op) == void_result() );
+   BOOST_CHECK( evaluator.evaluate(op).is_type<void_result>() );
    op.new_options.short_backing_asset = asset_objs.user_issued;
    BOOST_TEST_MESSAGE( "Message should contain: but this asset is a backing asset for a committee-issued asset." );
    // CHILDCOMMITTEE is a committee asset backed by PARENT which is backed by CORE
@@ -724,7 +724,7 @@ BOOST_AUTO_TEST_CASE( bitasset_evaluator_test_before_922_931 )
    create_bitasset( "CHILDCOMMITTEE", GRAPHENE_COMMITTEE_ACCOUNT, 100, charge_market_fee, 2,
          asset_objs.bit_parent );
    // it should again work, generating 2 warnings in the log. 1 for the above, and 1 new one.
-   BOOST_CHECK( evaluator.evaluate(op) == void_result() );
+   BOOST_CHECK( evaluator.evaluate(op).is_type<void_result>() );
    op.asset_to_update = asset_objs.bit_usd;
    op.issuer = asset_objs.bit_usd(db).issuer;
    op.new_options.short_backing_asset = correct_asset_id;
@@ -738,7 +738,7 @@ BOOST_AUTO_TEST_CASE( bitasset_evaluator_test_before_922_931 )
    op.asset_to_update = asset_objs.bit_usdbacked2;
    op.issuer = asset_objs.bit_usdbacked2(db).issuer;
    op.new_options.short_backing_asset = asset_objs.bit_usdbacked;
-   BOOST_CHECK( evaluator.evaluate(op) == void_result() );
+   BOOST_CHECK( evaluator.evaluate(op).is_type<void_result>() );
    // set everything to a more normal state
    op.asset_to_update = asset_objs.bit_usdbacked;
    op.issuer = asset_objs.bit_usd(db).issuer;
@@ -748,25 +748,25 @@ BOOST_AUTO_TEST_CASE( bitasset_evaluator_test_before_922_931 )
    BOOST_TEST_MESSAGE( "Message should contain: op.new_options.feed_lifetime_sec <= chain_parameters.block_interval" );
    const auto good_feed_lifetime = op.new_options.feed_lifetime_sec;
    op.new_options.feed_lifetime_sec = db.get_global_properties().parameters.block_interval;
-   BOOST_CHECK( evaluator.evaluate(op) == void_result() );
+   BOOST_CHECK( evaluator.evaluate(op).is_type<void_result>() );
    BOOST_TEST_MESSAGE( "Message should contain: op.new_options.feed_lifetime_sec <= chain_parameters.block_interval" );
    op.new_options.feed_lifetime_sec = db.get_global_properties().parameters.block_interval - 1; // default interval > 1
-   BOOST_CHECK( evaluator.evaluate(op) == void_result() );
+   BOOST_CHECK( evaluator.evaluate(op).is_type<void_result>() );
    op.new_options.feed_lifetime_sec = good_feed_lifetime;
 
    // Force settlement delay must exceed block interval.
    BOOST_TEST_MESSAGE( "Message should contain: op.new_options.force_settlement_delay_sec <= chain_parameters.block_interval" );
    const auto good_force_settlement_delay_sec = op.new_options.force_settlement_delay_sec;
    op.new_options.force_settlement_delay_sec = db.get_global_properties().parameters.block_interval;
-   BOOST_CHECK( evaluator.evaluate(op) == void_result() );
+   BOOST_CHECK( evaluator.evaluate(op).is_type<void_result>() );
    BOOST_TEST_MESSAGE( "Message should contain: op.new_options.force_settlement_delay_sec <= chain_parameters.block_interval" );
    op.new_options.force_settlement_delay_sec = db.get_global_properties().parameters.block_interval - 1; // default interval > 1
-   BOOST_CHECK( evaluator.evaluate(op) == void_result() );
+   BOOST_CHECK( evaluator.evaluate(op).is_type<void_result>() );
    op.new_options.force_settlement_delay_sec = good_force_settlement_delay_sec;
 
    // this should pass
    BOOST_TEST_MESSAGE( "We should be all good again." );
-   BOOST_CHECK( evaluator.evaluate(op) == void_result() );
+   BOOST_CHECK( evaluator.evaluate(op).is_type<void_result>() );
 }
 
 /******
@@ -794,7 +794,7 @@ BOOST_AUTO_TEST_CASE( bitasset_evaluator_test_after_922_931 )
 
    // this should pass
    BOOST_TEST_MESSAGE( "Evaluating a good operation" );
-   BOOST_CHECK( evaluator.evaluate(op) == void_result() );
+   BOOST_CHECK( evaluator.evaluate(op).is_type<void_result>() );
 
    // test with a market issued asset
    BOOST_TEST_MESSAGE( "Sending a non-bitasset." );
@@ -853,13 +853,13 @@ BOOST_AUTO_TEST_CASE( bitasset_evaluator_test_after_922_931 )
    // changing the backing asset to a UIA should work
    BOOST_TEST_MESSAGE( "Switching to a backing asset that is a UIA should work." );
    op.new_options.short_backing_asset = asset_objs.user_issued;
-   BOOST_CHECK( evaluator.evaluate(op) == void_result() );
+   BOOST_CHECK( evaluator.evaluate(op).is_type<void_result>() );
    // A -> B -> C, change B to be backed by A (circular backing)
    BOOST_TEST_MESSAGE( "Check for circular backing. This should generate an exception" );
    op.new_options.short_backing_asset = asset_objs.bit_child_bitasset;
    REQUIRE_EXCEPTION_WITH_TEXT( evaluator.evaluate(op), "'A' backed by 'B' backed by 'A'" );
    op.new_options.short_backing_asset = asset_objs.user_issued;
-   BOOST_CHECK( evaluator.evaluate(op) == void_result() );
+   BOOST_CHECK( evaluator.evaluate(op).is_type<void_result>() );
    BOOST_TEST_MESSAGE( "Creating CHILDCOMMITTEE" );
    // CHILDCOMMITTEE is a committee asset backed by PARENT which is backed by CORE
    // Cannot change PARENT's backing asset from CORE to something else because that will make CHILDCOMMITTEE
@@ -907,7 +907,7 @@ BOOST_AUTO_TEST_CASE( bitasset_evaluator_test_after_922_931 )
 
    // this should pass
    BOOST_TEST_MESSAGE( "We should be all good again." );
-   BOOST_CHECK( evaluator.evaluate(op) == void_result() );
+   BOOST_CHECK( evaluator.evaluate(op).is_type<void_result>() );
 
 }
 

--- a/tests/tests/fee_tests.cpp
+++ b/tests/tests/fee_tests.cpp
@@ -763,7 +763,7 @@ BOOST_AUTO_TEST_CASE( fee_refund_test )
          // C++ -- The above commented out statement doesn't work, I don't know why
          // so we will use the following rather lengthy initialization instead
          {
-            flat_set< fee_parameters > new_fees;
+            fee_parameters::flat_set_type new_fees;
             {
                limit_order_create_operation::fee_parameters_type create_fee_params;
                create_fee_params.fee = order_create_fee;
@@ -880,7 +880,7 @@ BOOST_AUTO_TEST_CASE( non_core_fee_refund_test )
 
       generate_block( skip );
 
-      flat_set< fee_parameters > new_fees;
+      fee_parameters::flat_set_type new_fees;
       {
          limit_order_create_operation::fee_parameters_type create_fee_params;
          create_fee_params.fee = order_create_fee;
@@ -1266,7 +1266,7 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
 
       generate_block( skip );
 
-      flat_set< fee_parameters > new_fees;
+      fee_parameters::flat_set_type new_fees;
       {
          limit_order_create_operation::fee_parameters_type create_fee_params;
          create_fee_params.fee = order_create_fee;
@@ -1772,9 +1772,9 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_test )
 
       generate_block( skip );
 
-      flat_set< fee_parameters > new_fees;
-      flat_set< fee_parameters > new_fees1;
-      flat_set< fee_parameters > new_fees2;
+      fee_parameters::flat_set_type new_fees;
+      fee_parameters::flat_set_type new_fees1;
+      fee_parameters::flat_set_type new_fees2;
       {
          limit_order_create_operation::fee_parameters_type create_fee_params;
          create_fee_params.fee = order_create_fee;
@@ -2329,7 +2329,7 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
 
       generate_block( skip );
 
-      flat_set< fee_parameters > new_fees;
+      fee_parameters::flat_set_type new_fees;
       {
          limit_order_create_operation::fee_parameters_type create_fee_params;
          create_fee_params.fee = order_create_fee;


### PR DESCRIPTION
This bumps FC to HEAD of master, adding support for the new reflection information and updated `static_variant` which now has a working `operator==` and no longer has a default `operator<`.

Ref https://github.com/bitshares/bitshares-fc/pull/156 & https://github.com/bitshares/bitshares-fc/pull/154