### PR TITLE
Add stacktrace on SIGSEGV

### DIFF
--- a/programs/cli_wallet/main.cpp
+++ b/programs/cli_wallet/main.cpp
@@ -32,6 +32,7 @@
 #include <fc/network/http/websocket.hpp>
 #include <fc/rpc/cli.hpp>
 #include <fc/rpc/websocket_api.hpp>
+#include <fc/stacktrace.hpp>
 
 #include <graphene/app/api.hpp>
 #include <graphene/chain/config.hpp>
@@ -124,6 +125,7 @@ void setup_logging(string console_level, bool file_logger, string file_level, st
 
 int main( int argc, char** argv )
 {
+   fc::print_stacktrace_on_segfault();
    try {
 
       boost::program_options::options_description opts;

--- a/programs/delayed_node/main.cpp
+++ b/programs/delayed_node/main.cpp
@@ -34,6 +34,7 @@
 #include <fc/log/file_appender.hpp>
 #include <fc/log/logger.hpp>
 #include <fc/log/logger_config.hpp>
+#include <fc/stacktrace.hpp>
 
 #include <boost/filesystem.hpp>
 
@@ -59,6 +60,7 @@ void write_default_logging_config_to_stream(std::ostream& out);
 fc::optional<fc::logging_config> load_logging_config_from_ini_file(const fc::path& config_ini_filename);
 
 int main(int argc, char** argv) {
+   fc::print_stacktrace_on_segfault();
    try {
       app::application node;
       bpo::options_description app_options("Graphene Delayed Node");

--- a/programs/witness_node/main.cpp
+++ b/programs/witness_node/main.cpp
@@ -37,6 +37,7 @@
 
 #include <fc/thread/thread.hpp>
 #include <fc/interprocess/signals.hpp>
+#include <fc/stacktrace.hpp>
 
 #include <boost/filesystem.hpp>
 #include <boost/property_tree/ptree.hpp>
@@ -59,6 +60,7 @@ using namespace graphene;
 namespace bpo = boost::program_options;
 
 int main(int argc, char** argv) {
+   fc::print_stacktrace_on_segfault();
    app::application* node = new app::application();
    fc::oexception unhandled_exception;
    try {


### PR DESCRIPTION
This will enable a stacktrace dump when the SIGSEGV signal is raised.

The stacktrace will be written to the log if Boost is version 1.65 or greater, and the OS is Linux or Windows. Nothing will be written to the log if the Boost version is below 1.65.

To make the output human-legible, compile with at least some debug information (i.e. RelWithDebInfo or Debug)