### PR TITLE
Fix #831 - check witness signature before adding block to fork db

### DIFF
--- a/libraries/chain/db_block.cpp
+++ b/libraries/chain/db_block.cpp
@@ -228,7 +228,7 @@ bool database::_push_block(const signed_block& new_block)
 
 void database::verify_signing_witness( const signed_block& new_block, const fork_item& fork_entry )const
 {
-   FC_ASSERT( new_block.timestamp > fork_entry.data.timestamp );
+   FC_ASSERT( new_block.timestamp >= fork_entry.next_block_time );
    uint32_t slot_num = ( new_block.timestamp - fork_entry.next_block_time ).to_seconds() / block_interval();
    uint64_t index = ( fork_entry.next_block_aslot + slot_num ) % fork_entry.scheduled_witnesses->size();
    const auto& scheduled_witness = (*fork_entry.scheduled_witnesses)[index];

--- a/libraries/chain/db_block.cpp
+++ b/libraries/chain/db_block.cpp
@@ -132,7 +132,8 @@ bool database::_push_block(const signed_block& new_block)
 { try {
    uint32_t skip = get_node_properties().skip_flags;
 
-   if( _fork_db.head() && new_block.timestamp.sec_since_epoch() > fc::time_point::now().sec_since_epoch() - 86400 )
+   const auto now = fc::time_point::now().sec_since_epoch();
+   if( _fork_db.head() && new_block.timestamp.sec_since_epoch() > now - 86400 )
    {
       // verify that the block signer is in the current set of active witnesses.
       shared_ptr<fork_item> prev_block = _fork_db.fetch_block( new_block.previous );
@@ -212,7 +213,8 @@ bool database::_push_block(const signed_block& new_block)
    try {
       auto session = _undo_db.start_undo_session();
       apply_block(new_block, skip);
-      update_witnesses( *new_head );
+      if( new_block.timestamp.sec_since_epoch() > now - 86400 )
+         update_witnesses( *new_head );
       _block_id_to_block.store(new_block.id(), new_block);
       session.commit();
    } catch ( const fc::exception& e ) {

--- a/libraries/chain/db_block.cpp
+++ b/libraries/chain/db_block.cpp
@@ -132,7 +132,7 @@ bool database::_push_block(const signed_block& new_block)
 { try {
    uint32_t skip = get_node_properties().skip_flags;
 
-   if( _fork_db.head() && new_block.block_num() > 1 )
+   if( _fork_db.head() && new_block.timestamp.sec_since_epoch() > fc::time_point::now().sec_since_epoch() - 86400 )
    {
       // verify that the block signer is in the current set of active witnesses.
       shared_ptr<fork_item> prev_block = _fork_db.fetch_block( new_block.previous );

--- a/libraries/chain/include/graphene/chain/database.hpp
+++ b/libraries/chain/include/graphene/chain/database.hpp
@@ -499,6 +499,8 @@ namespace graphene { namespace chain {
 
          const witness_object& validate_block_header( uint32_t skip, const signed_block& next_block )const;
          const witness_object& _validate_block_header( const signed_block& next_block )const;
+         void verify_signing_witness( const signed_block& new_block, const fork_item& fork_entry )const;
+         void update_witnesses( fork_item& fork_entry )const;
          void create_block_summary(const signed_block& next_block);
 
          //////////////////// db_witness_schedule.cpp ////////////////////

--- a/libraries/chain/include/graphene/chain/fork_database.hpp
+++ b/libraries/chain/include/graphene/chain/fork_database.hpp
@@ -22,6 +22,7 @@
  * THE SOFTWARE.
  */
 #pragma once
+
 #include <graphene/protocol/block.hpp>
 
 #include <graphene/chain/types.hpp>
@@ -31,7 +32,6 @@
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/mem_fun.hpp>
-
 
 namespace graphene { namespace chain {
    using boost::multi_index_container;
@@ -48,6 +48,11 @@ namespace graphene { namespace chain {
       uint32_t              num;    // initialized in ctor
       block_id_type         id;
       signed_block          data;
+
+      // contains witness block signing keys scheduled *after* the block has been applied
+      shared_ptr< vector< pair< witness_id_type, public_key_type > > > scheduled_witnesses;
+      uint64_t                                                         next_block_aslot;
+      fc::time_point_sec                                               next_block_time;
    };
    typedef shared_ptr<fork_item> item_ptr;
 

--- a/libraries/chain/include/graphene/chain/fork_database.hpp
+++ b/libraries/chain/include/graphene/chain/fork_database.hpp
@@ -51,7 +51,7 @@ namespace graphene { namespace chain {
 
       // contains witness block signing keys scheduled *after* the block has been applied
       shared_ptr< vector< pair< witness_id_type, public_key_type > > > scheduled_witnesses;
-      uint64_t                                                         next_block_aslot;
+      uint64_t                                                         next_block_aslot = 0;
       fc::time_point_sec                                               next_block_time;
    };
    typedef shared_ptr<fork_item> item_ptr;


### PR DESCRIPTION
Attempt at a better alternative to #884 (for issue #831).

The idea is to attach some meta information to fork db entries that allows us to validate witness signatures for incoming blocks. Should handle maintenance intervals and witness re-schedule correctly.

Also has limited support for forks, i. e. it will validate the first block of a minority fork, which should greatly reduce the attack surface.

~~Will try to optimize a little, i. e. re-use `scheduled_witnesses` from previous block when unchanged.~~