### PR TITLE
Fix node crash

### DIFF
--- a/libraries/net/include/graphene/net/stcp_socket.hpp
+++ b/libraries/net/include/graphene/net/stcp_socket.hpp
@@ -26,8 +26,6 @@
 #include <fc/crypto/aes.hpp>
 #include <fc/crypto/elliptic.hpp>
 
-#include <array>
-
 namespace graphene { namespace net {
 
 /**

--- a/libraries/protocol/address.cpp
+++ b/libraries/protocol/address.cpp
@@ -89,12 +89,12 @@ namespace graphene { namespace protocol {
 
    address::operator std::string()const
    {
-        std::array<char,24> bin_addr;
-        static_assert( bin_addr.size() >= sizeof(addr) + 4, "address size mismatch" );
-        memcpy( bin_addr.data(), addr.data(), sizeof(addr) );
+        char bin_addr[24];
+        static_assert( sizeof(bin_addr) >= sizeof(addr) + 4, "address size mismatch" );
+        memcpy( bin_addr, addr.data(), sizeof(addr) );
         auto checksum = fc::ripemd160::hash( addr.data(), sizeof(addr) );
-        memcpy( bin_addr.data() + 20, (char*)&checksum._hash[0], 4 );
-        return GRAPHENE_ADDRESS_PREFIX + fc::to_base58( bin_addr.data(), bin_addr.size() );
+        memcpy( bin_addr + sizeof(addr), (char*)&checksum._hash[0], 4 );
+        return GRAPHENE_ADDRESS_PREFIX + fc::to_base58( bin_addr, sizeof(bin_addr) );
    }
 
 } } // namespace graphene::protocol

--- a/libraries/protocol/include/graphene/protocol/pts_address.hpp
+++ b/libraries/protocol/include/graphene/protocol/pts_address.hpp
@@ -49,7 +49,7 @@ namespace graphene { namespace protocol {
 
        operator std::string()const; ///< converts to base58 + checksum
 
-       std::array<char,25> addr; ///< binary representation of address
+       std::array<char,25> addr{}; ///< binary representation of address, 0-initialized
    };
 
    inline bool operator == ( const pts_address& a, const pts_address& b ) { return a.addr == b.addr; }


### PR DESCRIPTION
Theory:
Node is connecting to a peer that has recently requested a firewall check and was then disconnected. `initiate_connect_to` creates a new `peer_connection`, inserts it into `_handshaking_connections`, then creates `accept_or_connect_task` to create the actual stcp connection, wherein `sock.connect()` will yield.
Suppose that while we're waiting for the connection, we receive the result of the firewall check from another peer. `on_check_firewall_reply_message` will look up the originating peer (to which we're still connecting) in `_handshaking_connections` and call `send_message` on it. This goes down to `stcp_socket.writesome`, which sends the message through `_send_aes` for encryption.
The problem is, because the connection has not been set up yet and there has been no key exchange, `_send_aes` hasn't been initialized yet.