### PR TITLE
add optional subscribe option to get_ticker

### DIFF
--- a/libraries/app/database_api_impl.hxx
+++ b/libraries/app/database_api_impl.hxx
@@ -122,7 +122,8 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       void unsubscribe_from_market(const std::string& a, const std::string& b);
 
       market_ticker                      get_ticker( const string& base, const string& quote,
-                                                     bool skip_order_book = false )const;
+                                                     bool skip_order_book,
+                                                     optional<bool> subscribe )const;
       market_volume                      get_24_volume( const string& base, const string& quote )const;
       order_book                         get_order_book( const string& base, const string& quote,
                                                          unsigned limit = 50 )const;

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -539,9 +539,13 @@ class database_api
        * @brief Returns the ticker for the market assetA:assetB
        * @param base symbol name or ID of the base asset
        * @param quote symbol name or ID of the quote asset
+       * @param subscribe @a true to subscribe to the queried HTLC objects; @a false to not subscribe;
+       *                  @a null to subscribe or not subscribe according to current auto-subscription setting
+       *                  (see @ref set_auto_subscription)
        * @return The market ticker for the past 24 hours.
        */
-      market_ticker get_ticker( const string& base, const string& quote )const;
+      market_ticker get_ticker( const string& base, const string& quote,
+                                optional<bool> subscribe = optional<bool>() )const;
 
       /**
        * @brief Returns the 24 hour volume for the market assetA:assetB


### PR DESCRIPTION
For issue https://github.com/bitshares/bitshares-core/issues/1937

While testing this i found that all the apis that have subscribe in this manner is that it is actually true by default when the option is not present(`get_assets`, `get_accounts`, etc). 
Most probably nobody noticed as it will not start sending data without `set_subscribe_callback`.
Not sure if this is what we want, i was expecting a false by default. 