### PR TITLE
ES plugins default values

### DIFF
--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -56,9 +56,9 @@ class elasticsearch_plugin_impl
       bool _elasticsearch_visitor = false;
       std::string _elasticsearch_basic_auth = "";
       std::string _elasticsearch_index_prefix = "bitshares-";
-      bool _elasticsearch_operation_object = false;
+      bool _elasticsearch_operation_object = true;
       uint32_t _elasticsearch_start_es_after_block = 0;
-      bool _elasticsearch_operation_string = true;
+      bool _elasticsearch_operation_string = false;
       mode _elasticsearch_mode = mode::only_save;
       CURL *curl; // curl handler
       vector <string> bulk_lines; //  vector of op lines
@@ -441,11 +441,11 @@ void elasticsearch_plugin::plugin_set_program_options(
          ("elasticsearch-index-prefix", boost::program_options::value<std::string>(),
                "Add a prefix to the index(bitshares-)")
          ("elasticsearch-operation-object", boost::program_options::value<bool>(),
-               "Save operation as object(false)")
+               "Save operation as object(true)")
          ("elasticsearch-start-es-after-block", boost::program_options::value<uint32_t>(),
                "Start doing ES job after block(0)")
          ("elasticsearch-operation-string", boost::program_options::value<bool>(),
-               "Save operation as string. Needed to serve history api calls(true)")
+               "Save operation as string. Needed to serve history api calls(false)")
          ("elasticsearch-mode", boost::program_options::value<uint16_t>(),
                "Mode of operation: only_save(0), only_query(1), all(2) - Default: 0")
          ;

--- a/libraries/plugins/es_objects/es_objects.cpp
+++ b/libraries/plugins/es_objects/es_objects.cpp
@@ -59,7 +59,7 @@ class es_objects_plugin_impl
       bool _es_objects_accounts = true;
       bool _es_objects_assets = true;
       bool _es_objects_balances = true;
-      bool _es_objects_limit_orders = true;
+      bool _es_objects_limit_orders = false;
       bool _es_objects_asset_bitasset = true;
       std::string _es_objects_index_prefix = "objects-";
       uint32_t _es_objects_start_es_after_block = 0;
@@ -306,7 +306,7 @@ void es_objects_plugin::plugin_set_program_options(
          ("es-objects-accounts", boost::program_options::value<bool>(), "Store account objects(true)")
          ("es-objects-assets", boost::program_options::value<bool>(), "Store asset objects(true)")
          ("es-objects-balances", boost::program_options::value<bool>(), "Store balances objects(true)")
-         ("es-objects-limit-orders", boost::program_options::value<bool>(), "Store limit order objects(true)")
+         ("es-objects-limit-orders", boost::program_options::value<bool>(), "Store limit order objects(false)")
          ("es-objects-asset-bitasset", boost::program_options::value<bool>(), "Store feed data(true)")
          ("es-objects-index-prefix", boost::program_options::value<std::string>(),
                "Add a prefix to the index(objects-)")


### PR DESCRIPTION
**elasticsearch plugin**:
- `_elasticsearch_operation_object` is the most used option to have all operation fields indexed. Is what most operators are after this days. Changed to `true` by default.
- `_elasticsearch_operation_string` is the alternative to save the full operation as 1 field of type string. This is needed for `only_query` or `all` modes. Is not the most frequent use case at the moment, changed the default to `false`.

**es_objects plugin**:

- `_es_objects_limit_orders` is currently not used in the bitshares-rest-api. It eats too much space and also the updates to them are very frequent causing overhead. Turned this option to `false`
 by default.