### PR TITLE
Implement BSIP47

### DIFF
--- a/libraries/chain/account_evaluator.cpp
+++ b/libraries/chain/account_evaluator.cpp
@@ -448,8 +448,8 @@ void_result account_upgrade_evaluator::do_apply(const account_upgrade_evaluator:
 void_result account_update_votes_evaluator::do_evaluate(const account_update_votes_operation& o)
 { try {
    database& d = db();
+   FC_ASSERT(d.head_block_time() >= HARDFORK_BSIP_47_TIME, "Not allowed until BSIP47 HARDFORK"); // can be removed after HF date pass
    account = &o.account(d);
-
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (o) ) }
 

--- a/libraries/chain/account_evaluator.cpp
+++ b/libraries/chain/account_evaluator.cpp
@@ -473,25 +473,22 @@ void_result account_update_votes_evaluator::do_apply(const account_update_votes_
       if(o.committee_voting_account.valid())
          a.options.extensions.value.committee_voting_account = *o.committee_voting_account;
 
-      if(a.options.voting_account == GRAPHENE_PROXY_TO_SELF_ACCOUNT)
-      {
-         if(o.num_witness.valid())
-            a.options.num_witness = std::min(*o.num_witness, chain_parameters.maximum_witness_count);
-         if(o.num_committee.valid())
-            a.options.num_committee = std::min(*o.num_committee, chain_parameters.maximum_committee_count);
+      if(o.num_witness.valid())
+         a.options.num_witness = std::min(*o.num_witness, chain_parameters.maximum_witness_count);
+      if(o.num_committee.valid())
+         a.options.num_committee = std::min(*o.num_committee, chain_parameters.maximum_committee_count);
 
-         auto current_votes = a.options.votes;
-         if(o.votes_to_add.valid()) {
-            for(auto const& add: *o.votes_to_add) {
-               current_votes.insert(add);
-               a.options.votes = current_votes;
-            }
+      auto current_votes = a.options.votes;
+      if(o.votes_to_add.valid()) {
+         for(auto const& add: *o.votes_to_add) {
+            current_votes.insert(add);
+            a.options.votes = current_votes;
          }
-         if(o.votes_to_remove.valid()) {
-            for (auto const &remove: *o.votes_to_remove) {
-               current_votes.erase(remove);
-               a.options.votes = current_votes;
-            }
+      }
+      if(o.votes_to_remove.valid()) {
+         for (auto const &remove: *o.votes_to_remove) {
+            current_votes.erase(remove);
+            a.options.votes = current_votes;
          }
       }
    });

--- a/libraries/chain/account_evaluator.cpp
+++ b/libraries/chain/account_evaluator.cpp
@@ -445,4 +445,18 @@ void_result account_upgrade_evaluator::do_apply(const account_upgrade_evaluator:
    return {};
 } FC_RETHROW_EXCEPTIONS( error, "Unable to upgrade account '${a}'", ("a",o.account_to_upgrade(db()).name) ) }
 
+void_result account_update_votes_evaluator::do_evaluate(const account_update_votes_operation& o)
+{ try {
+   database& d = db();
+
+   return void_result();
+} FC_CAPTURE_AND_RETHROW( (o) ) }
+
+void_result account_update_votes_evaluator::do_apply(const account_update_votes_operation& o)
+{ try {
+   database& d = db();
+
+   return void_result();
+} FC_CAPTURE_AND_RETHROW( (o) ) }
+
 } } // graphene::chain

--- a/libraries/chain/db_init.cpp
+++ b/libraries/chain/db_init.cpp
@@ -178,6 +178,7 @@ void database::initialize_evaluators()
    register_evaluator<htlc_create_evaluator>();
    register_evaluator<htlc_redeem_evaluator>();
    register_evaluator<htlc_extend_evaluator>();
+   register_evaluator<account_update_votes_evaluator>();
 }
 
 void database::initialize_indexes()

--- a/libraries/chain/db_maint.cpp
+++ b/libraries/chain/db_maint.cpp
@@ -1193,16 +1193,17 @@ void database::perform_chain_maintenance(const signed_block& next_block, const g
 
             if(dgpo.next_maintenance_time >= HARDFORK_BSIP_47_TIME) {
                if (stake_account.options.voting_account == GRAPHENE_PROXY_PER_CATEGORY_ACCOUNT) {
-                  if (stake_account.options.extensions.value.committee_voting_account.valid()) {
-                     auto committee_voting_account = d.get(*stake_account.options.extensions.value.committee_voting_account);
+                  const auto& extensions = stake_account.options.extensions.value;
+                  if (extensions.committee_voting_account.valid()) {
+                     auto committee_voting_account = d.get(*extensions.committee_voting_account);
                      fill_buffer(committee_voting_account.options.votes, voting_stake, vote_id_type::committee);
                   }
-                  if (stake_account.options.extensions.value.witness_voting_account.valid()) {
-                     auto witness_voting_account = d.get(*stake_account.options.extensions.value.witness_voting_account);
+                  if (extensions.witness_voting_account.valid()) {
+                     auto witness_voting_account = d.get(*extensions.witness_voting_account);
                      fill_buffer(witness_voting_account.options.votes, voting_stake, vote_id_type::witness);
                   }
-                  if (stake_account.options.extensions.value.worker_voting_account.valid()) {
-                     auto worker_voting_account = d.get(*stake_account.options.extensions.value.worker_voting_account);
+                  if (extensions.worker_voting_account.valid()) {
+                     auto worker_voting_account = d.get(*extensions.worker_voting_account);
                      fill_buffer(worker_voting_account.options.votes, voting_stake, vote_id_type::worker);
                   }
                }

--- a/libraries/chain/db_maint.cpp
+++ b/libraries/chain/db_maint.cpp
@@ -1184,8 +1184,8 @@ void database::perform_chain_maintenance(const signed_block& next_block, const g
             // If the stake account has specified a voting_account, that account is the one specifying the opinions.
             // If the stake account has specified a committee_voting_account, witness_voting_account or
             // worker_voting_account, those will be the accounts voting for the corresponding referendum category.
-            // A user specifying 1 or 2 category voting accounts will not be voting for any referendum in the categories
-            // not specified.
+            // A user specifying 1 or 2 category voting accounts will delegate opinion only for specified referendums
+            // while can express own opinions in the others.
 
             const auto& dgpo = d.get_dynamic_global_properties();
             const auto& opinion_account = (stake_account.options.voting_account == GRAPHENE_PROXY_TO_SELF_ACCOUNT) ?
@@ -1199,15 +1199,18 @@ void database::perform_chain_maintenance(const signed_block& next_block, const g
                   stake_account.options.voting_account == GRAPHENE_PROXY_PER_CATEGORY_ACCOUNT) {
                const auto& extensions = stake_account.options.extensions.value;
                if (extensions.committee_voting_account.valid()) {
-                  auto committee_voting_account = d.get(*extensions.committee_voting_account);
+                  auto committee_voting_account = *extensions.committee_voting_account == GRAPHENE_PROXY_TO_SELF_ACCOUNT ?
+                        stake_account : d.get(*extensions.committee_voting_account);
                   fill_buffer(committee_voting_account.options.votes, voting_stake, vote_id_type::committee);
                }
                if (extensions.witness_voting_account.valid()) {
-                  auto witness_voting_account = d.get(*extensions.witness_voting_account);
+                  auto witness_voting_account = *extensions.witness_voting_account == GRAPHENE_PROXY_TO_SELF_ACCOUNT ?
+                        stake_account : d.get(*extensions.witness_voting_account);
                   fill_buffer(witness_voting_account.options.votes, voting_stake, vote_id_type::witness);
                }
                if (extensions.worker_voting_account.valid()) {
-                  auto worker_voting_account = d.get(*extensions.worker_voting_account);
+                  auto worker_voting_account = *extensions.worker_voting_account == GRAPHENE_PROXY_TO_SELF_ACCOUNT ?
+                        stake_account : d.get(*extensions.worker_voting_account);
                   fill_buffer(worker_voting_account.options.votes, voting_stake, vote_id_type::worker);
                }
             }

--- a/libraries/chain/db_notify.cpp
+++ b/libraries/chain/db_notify.cpp
@@ -289,6 +289,10 @@ struct get_impacted_account_visitor
    { 
       _impacted.insert( op.fee_payer() );
    }
+   void operator()( const account_update_votes_operation& op )
+   {
+      _impacted.insert( op.fee_payer() );
+   }
 };
 
 void graphene::chain::operation_get_impacted_accounts( const operation& op, flat_set<account_id_type>& result, bool ignore_custom_operation_required_auths ) {

--- a/libraries/chain/hardfork.d/BSIP_47.hf
+++ b/libraries/chain/hardfork.d/BSIP_47.hf
@@ -1,0 +1,4 @@
+// BSIP47 - Vote Proxies for Different Referendum Categories and explicit voting operation
+#ifndef HARDFORK_BSIP_47_TIME
+#define HARDFORK_BSIP_47_TIME (fc::time_point_sec( 1600000000 ) ) // Sep 2020
+#endif

--- a/libraries/chain/include/graphene/chain/account_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/account_evaluator.hpp
@@ -69,4 +69,15 @@ public:
    const account_object* listed_account;
 };
 
+class account_update_votes_evaluator: public evaluator<account_update_votes_evaluator>
+{
+public:
+   typedef account_update_votes_operation operation_type;
+
+   void_result do_evaluate( const account_update_votes_operation& o);
+   void_result do_apply( const account_update_votes_operation& o);
+
+   const account_object* account;
+};
+
 } } // graphene::chain

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -110,6 +110,11 @@ struct proposal_operation_hardfork_visitor
    void operator()(const graphene::chain::htlc_extend_operation &op) const {
       FC_ASSERT( block_time >= HARDFORK_CORE_1468_TIME, "Not allowed until hardfork 1468" );
    }
+   // bsip 47
+   void operator()(const graphene::chain::account_update_votes_operation &op) const {
+      FC_ASSERT( block_time >= HARDFORK_BSIP_47_TIME, "Not allowed until BSIP47 hardfork" );
+   }
+
    // loop and self visit in proposals
    void operator()(const graphene::chain::proposal_create_operation &v) const {
       bool already_contains_proposal_update = false;

--- a/libraries/protocol/account.cpp
+++ b/libraries/protocol/account.cpp
@@ -276,6 +276,11 @@ void account_transfer_operation::validate()const
    FC_ASSERT( fee.amount >= 0 );
 }
 
+void account_update_votes_operation::validate()const
+{
+   FC_ASSERT( fee.amount >= 0 );
+}
+
 
 } } // graphene::protocol
 
@@ -285,8 +290,10 @@ GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::protocol::account_whitelist
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::protocol::account_update_operation::fee_parameters_type )
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::protocol::account_upgrade_operation::fee_parameters_type )
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::protocol::account_transfer_operation::fee_parameters_type )
+GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::protocol::account_update_votes_operation::fee_parameters_type )
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::protocol::account_create_operation )
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::protocol::account_whitelist_operation )
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::protocol::account_update_operation )
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::protocol::account_upgrade_operation )
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::protocol::account_transfer_operation )
+GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::protocol::account_update_votes_operation )

--- a/libraries/protocol/include/graphene/protocol/account.hpp
+++ b/libraries/protocol/include/graphene/protocol/account.hpp
@@ -36,10 +36,6 @@ namespace graphene { namespace protocol {
       optional<account_id_type> committee_voting_account;
       optional<account_id_type> witness_voting_account;
       optional<account_id_type> worker_voting_account;
-
-      optional<flat_set<vote_id_type>> committee_votes;
-      optional<flat_set<vote_id_type>> witness_votes;
-      optional<flat_set<vote_id_type>> worker_votes;
    };
    typedef extension<additional_account_options> additional_account_options_t;
 
@@ -292,8 +288,8 @@ namespace graphene { namespace protocol {
       account_id_type account;
 
       /// New account options
-      flat_set<vote_id_type> votes_to_add;
-      flat_set<vote_id_type> votes_to_remove;
+      optional<flat_set<vote_id_type>> votes_to_add;
+      optional<flat_set<vote_id_type>> votes_to_remove;
 
       // A new voting account to set
       optional<account_id_type> committee_voting_account;
@@ -316,7 +312,7 @@ namespace graphene { namespace protocol {
 } } // graphene::protocol
 
 FC_REFLECT( graphene::protocol::additional_account_options,
-        (committee_voting_account)(witness_voting_account)(worker_voting_account)(committee_votes)(witness_votes)(worker_votes))
+        (committee_voting_account)(witness_voting_account)(worker_voting_account))
 FC_REFLECT(graphene::protocol::account_options, (memo_key)(voting_account)(num_witness)(num_committee)(votes)(extensions))
 FC_REFLECT_ENUM( graphene::protocol::account_whitelist_operation::account_listing,
                 (no_listing)(white_listed)(black_listed)(white_and_black_listed))

--- a/libraries/protocol/include/graphene/protocol/account.hpp
+++ b/libraries/protocol/include/graphene/protocol/account.hpp
@@ -279,6 +279,40 @@ namespace graphene { namespace protocol {
       void        validate()const;
    };
 
+   /*
+    * @brief
+    */
+   struct account_update_votes_operation : public base_operation
+   {
+      struct fee_parameters_type { uint64_t fee = 500 * GRAPHENE_BLOCKCHAIN_PRECISION; };
+
+      asset fee;
+
+      /// The account to update
+      account_id_type account;
+
+      /// New account options
+      flat_set<vote_id_type> votes_to_add;
+      flat_set<vote_id_type> votes_to_remove;
+
+      // A new voting account to set
+      optional<account_id_type> committee_voting_account;
+      optional<account_id_type> witness_voting_account;
+      optional<account_id_type> worker_voting_account;
+
+      // A new number of witness_votes to set
+      optional<uint16_t> num_witness;
+
+      // A new number of committee_votes to set
+      optional<uint16_t> num_committee;
+
+      // For future extensions (see account_update_operation)
+      extensions_type extensions;
+
+      account_id_type fee_payer()const { return account; }
+      void        validate()const;
+   };
+
 } } // graphene::protocol
 
 FC_REFLECT( graphene::protocol::additional_account_options,
@@ -311,8 +345,13 @@ FC_REFLECT( graphene::protocol::account_whitelist_operation::fee_parameters_type
 FC_REFLECT( graphene::protocol::account_update_operation::fee_parameters_type, (fee)(price_per_kbyte) )
 FC_REFLECT( graphene::protocol::account_upgrade_operation::fee_parameters_type, (membership_annual_fee)(membership_lifetime_fee) )
 FC_REFLECT( graphene::protocol::account_transfer_operation::fee_parameters_type, (fee) )
+FC_REFLECT( graphene::protocol::account_update_votes_operation::fee_parameters_type, (fee) )
 
 FC_REFLECT( graphene::protocol::account_transfer_operation, (fee)(account_id)(new_owner)(extensions) )
+FC_REFLECT( graphene::protocol::account_update_votes_operation, (fee)(account)(votes_to_add)(votes_to_remove)
+                                                                (committee_voting_account)(witness_voting_account)
+                                                                (worker_voting_account)(num_witness)(num_committee)
+                                                                (extensions))
 
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::protocol::additional_account_options )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::protocol::account_options )
@@ -321,8 +360,10 @@ GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::protocol::account_whitelist_o
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::protocol::account_update_operation::fee_parameters_type )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::protocol::account_upgrade_operation::fee_parameters_type )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::protocol::account_transfer_operation::fee_parameters_type )
+GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::protocol::account_update_votes_operation::fee_parameters_type )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::protocol::account_create_operation )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::protocol::account_whitelist_operation )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::protocol::account_update_operation )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::protocol::account_upgrade_operation )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::protocol::account_transfer_operation )
+GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::protocol::account_update_votes_operation )

--- a/libraries/protocol/include/graphene/protocol/account.hpp
+++ b/libraries/protocol/include/graphene/protocol/account.hpp
@@ -33,9 +33,9 @@
 namespace graphene { namespace protocol {
    struct additional_account_options
    {
-      optional<account_id_type> committee_voting_account;
-      optional<account_id_type> witness_voting_account;
-      optional<account_id_type> worker_voting_account;
+      optional<account_id_type> committee_voting_account = GRAPHENE_PROXY_TO_SELF_ACCOUNT;
+      optional<account_id_type> witness_voting_account = GRAPHENE_PROXY_TO_SELF_ACCOUNT;
+      optional<account_id_type> worker_voting_account = GRAPHENE_PROXY_TO_SELF_ACCOUNT;
    };
    typedef extension<additional_account_options> additional_account_options_t;
 

--- a/libraries/protocol/include/graphene/protocol/account.hpp
+++ b/libraries/protocol/include/graphene/protocol/account.hpp
@@ -300,7 +300,7 @@ namespace graphene { namespace protocol {
       // A new voting account
       optional<account_id_type> voting_account;
 
-      // Voting account by referendum category
+      // Voting accounts by referendum category
       optional<account_id_type> committee_voting_account;
       optional<account_id_type> witness_voting_account;
       optional<account_id_type> worker_voting_account;

--- a/libraries/protocol/include/graphene/protocol/account.hpp
+++ b/libraries/protocol/include/graphene/protocol/account.hpp
@@ -321,7 +321,7 @@ namespace graphene { namespace protocol {
 } } // graphene::protocol
 
 FC_REFLECT( graphene::protocol::additional_account_options,
-        (committee_voting_account)(witness_voting_account)(worker_voting_account))
+            (committee_voting_account)(witness_voting_account)(worker_voting_account))
 FC_REFLECT(graphene::protocol::account_options, (memo_key)(voting_account)(num_witness)(num_committee)(votes)(extensions))
 FC_REFLECT_ENUM( graphene::protocol::account_whitelist_operation::account_listing,
                 (no_listing)(white_listed)(black_listed)(white_and_black_listed))

--- a/libraries/protocol/include/graphene/protocol/account.hpp
+++ b/libraries/protocol/include/graphene/protocol/account.hpp
@@ -31,6 +31,13 @@
 #include <graphene/protocol/vote.hpp>
 
 namespace graphene { namespace protocol {
+   struct additional_account_options
+   {
+      optional<account_id_type> committee_voting_account;
+      optional<account_id_type> witness_voting_account;
+      optional<account_id_type> worker_voting_account;
+   };
+   typedef extension<additional_account_options> additional_account_options_t;
 
    bool is_valid_name( const string& s );
    bool is_cheap_name( const string& n );
@@ -56,7 +63,7 @@ namespace graphene { namespace protocol {
       /// This is the list of vote IDs this account votes for. The weight of these votes is determined by this
       /// account's balance of core asset.
       flat_set<vote_id_type> votes;
-      extensions_type        extensions;
+      additional_account_options_t extensions;
 
       /// Whether this account is voting
       inline bool is_voting() const
@@ -270,6 +277,7 @@ namespace graphene { namespace protocol {
 
 } } // graphene::protocol
 
+FC_REFLECT( graphene::protocol::additional_account_options, (committee_voting_account)(witness_voting_account)(worker_voting_account) )
 FC_REFLECT(graphene::protocol::account_options, (memo_key)(voting_account)(num_witness)(num_committee)(votes)(extensions))
 FC_REFLECT_ENUM( graphene::protocol::account_whitelist_operation::account_listing,
                 (no_listing)(white_listed)(black_listed)(white_and_black_listed))
@@ -301,6 +309,7 @@ FC_REFLECT( graphene::protocol::account_transfer_operation::fee_parameters_type,
 
 FC_REFLECT( graphene::protocol::account_transfer_operation, (fee)(account_id)(new_owner)(extensions) )
 
+GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::protocol::additional_account_options )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::protocol::account_options )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::protocol::account_create_operation::fee_parameters_type )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::protocol::account_whitelist_operation::fee_parameters_type )

--- a/libraries/protocol/include/graphene/protocol/account.hpp
+++ b/libraries/protocol/include/graphene/protocol/account.hpp
@@ -276,7 +276,13 @@ namespace graphene { namespace protocol {
    };
 
    /*
-    * @brief
+    * @brief explicit operation for voting
+    * @ingroup operations
+    *
+    * Vote for the 3 referendum categories(committee, witness, worker), the number of witnesses
+    * and committee members the blockchain can have, update your proxy.
+    *
+    * Additionally the operation will allow the user to select specific proxies for each of the 3 referendum categories.
     */
    struct account_update_votes_operation : public base_operation
    {
@@ -287,22 +293,25 @@ namespace graphene { namespace protocol {
       /// The account to update
       account_id_type account;
 
-      /// New account options
+      /// Votes to add or remove
       optional<flat_set<vote_id_type>> votes_to_add;
       optional<flat_set<vote_id_type>> votes_to_remove;
 
-      // A new voting account to set
+      // A new voting account
+      optional<account_id_type> voting_account;
+
+      // Voting account by referendum category
       optional<account_id_type> committee_voting_account;
       optional<account_id_type> witness_voting_account;
       optional<account_id_type> worker_voting_account;
 
-      // A new number of witness_votes to set
+      // A new number of witness
       optional<uint16_t> num_witness;
 
-      // A new number of committee_votes to set
+      // A new number of committee member
       optional<uint16_t> num_committee;
 
-      // For future extensions (see account_update_operation)
+      // For future extensions
       extensions_type extensions;
 
       account_id_type fee_payer()const { return account; }
@@ -344,7 +353,8 @@ FC_REFLECT( graphene::protocol::account_transfer_operation::fee_parameters_type,
 FC_REFLECT( graphene::protocol::account_update_votes_operation::fee_parameters_type, (fee) )
 
 FC_REFLECT( graphene::protocol::account_transfer_operation, (fee)(account_id)(new_owner)(extensions) )
-FC_REFLECT( graphene::protocol::account_update_votes_operation, (fee)(account)(votes_to_add)(votes_to_remove)
+FC_REFLECT( graphene::protocol::account_update_votes_operation, (fee)(account)(votes_to_add)
+                                                                (votes_to_remove)(voting_account)
                                                                 (committee_voting_account)(witness_voting_account)
                                                                 (worker_voting_account)(num_witness)(num_committee)
                                                                 (extensions))

--- a/libraries/protocol/include/graphene/protocol/account.hpp
+++ b/libraries/protocol/include/graphene/protocol/account.hpp
@@ -36,6 +36,10 @@ namespace graphene { namespace protocol {
       optional<account_id_type> committee_voting_account;
       optional<account_id_type> witness_voting_account;
       optional<account_id_type> worker_voting_account;
+
+      optional<flat_set<vote_id_type>> committee_votes;
+      optional<flat_set<vote_id_type>> witness_votes;
+      optional<flat_set<vote_id_type>> worker_votes;
    };
    typedef extension<additional_account_options> additional_account_options_t;
 
@@ -277,7 +281,8 @@ namespace graphene { namespace protocol {
 
 } } // graphene::protocol
 
-FC_REFLECT( graphene::protocol::additional_account_options, (committee_voting_account)(witness_voting_account)(worker_voting_account) )
+FC_REFLECT( graphene::protocol::additional_account_options,
+        (committee_voting_account)(witness_voting_account)(worker_voting_account)(committee_votes)(witness_votes)(worker_votes))
 FC_REFLECT(graphene::protocol::account_options, (memo_key)(voting_account)(num_witness)(num_committee)(votes)(extensions))
 FC_REFLECT_ENUM( graphene::protocol::account_whitelist_operation::account_listing,
                 (no_listing)(white_listed)(black_listed)(white_and_black_listed))

--- a/libraries/protocol/include/graphene/protocol/config.hpp
+++ b/libraries/protocol/include/graphene/protocol/config.hpp
@@ -133,6 +133,8 @@
 #define GRAPHENE_TEMP_ACCOUNT (graphene::protocol::account_id_type(4))
 /// Represents the canonical account for specifying you will vote directly (as opposed to a proxy)
 #define GRAPHENE_PROXY_TO_SELF_ACCOUNT (graphene::protocol::account_id_type(5))
+/// Represents the canonical account for specifying you will vote per referendum category
+#define GRAPHENE_PROXY_PER_CATEGORY_ACCOUNT (graphene::protocol::account_id_type(6))
 /// Sentinel value used in the scheduler.
 #define GRAPHENE_NULL_WITNESS (graphene::protocol::witness_id_type(0))
 ///@}

--- a/libraries/protocol/include/graphene/protocol/operations.hpp
+++ b/libraries/protocol/include/graphene/protocol/operations.hpp
@@ -101,7 +101,8 @@ namespace graphene { namespace protocol {
             htlc_redeem_operation,
             htlc_redeemed_operation,         // VIRTUAL
             htlc_extend_operation,
-            htlc_refund_operation            // VIRTUAL
+            htlc_refund_operation,           // VIRTUAL
+            account_update_votes_operation
          > operation;
 
    /// @} // operations group

--- a/tests/tests/voting_tests.cpp
+++ b/tests/tests/voting_tests.cpp
@@ -587,7 +587,7 @@ BOOST_AUTO_TEST_CASE(simple_account_update_votes_operation)
       generate_block();
       set_expiration( db, trx );
 
-      ACTORS((alice));
+      ACTORS((alice)(bob));
       fund(alice);
 
       auto alice_object = get_account("alice");
@@ -673,6 +673,21 @@ BOOST_AUTO_TEST_CASE(simple_account_update_votes_operation)
 
       BOOST_CHECK_EQUAL(alice_object.options.voting_account.instance.value, 5);
 
+      // change voting account
+      {
+         graphene::chain::account_update_votes_operation op;
+         op.account = alice_id;
+         op.voting_account = bob_id;
+         trx.operations.push_back(op);
+         sign(trx, alice_private_key);
+         PUSH_TX(db, trx, ~0);
+         trx.clear();
+      }
+      generate_block();
+
+      alice_object = get_account("alice");
+
+      BOOST_CHECK_EQUAL(alice_object.options.voting_account.instance.value, bob_id.instance.value);
    } FC_LOG_AND_RETHROW()
 }
 

--- a/tests/tests/voting_tests.cpp
+++ b/tests/tests/voting_tests.cpp
@@ -595,11 +595,10 @@ BOOST_AUTO_TEST_CASE(simple_account_update_votes_operation)
       BOOST_CHECK_EQUAL(alice_object.options.num_witness , 0);
       BOOST_CHECK_EQUAL(alice_object.options.num_committee , alice_object.options.votes.size());
 
-      // a few votable witnesses
+      // a few votable objects
       auto witness1 = witness_id_type(1)(db);
       auto witness2 = witness_id_type(2)(db);
       auto witness3 = witness_id_type(3)(db);
-
       auto committee1 = committee_member_id_type(1)(db);
 
       // add votes
@@ -620,11 +619,11 @@ BOOST_AUTO_TEST_CASE(simple_account_update_votes_operation)
          PUSH_TX(db, trx, ~0);
          trx.clear();
       }
-
       generate_block();
-      BOOST_CHECK_EQUAL(alice_object.options.voting_account.instance.value, 5);
 
       alice_object = get_account("alice");
+
+      BOOST_CHECK_EQUAL(alice_object.options.voting_account.instance.value, 5);
 
       auto itr = alice_object.options.votes.find(witness1.vote_id);
       BOOST_CHECK(itr != alice_object.options.votes.end());
@@ -656,7 +655,6 @@ BOOST_AUTO_TEST_CASE(simple_account_update_votes_operation)
          PUSH_TX(db, trx, ~0);
          trx.clear();
       }
-
       generate_block();
 
       alice_object = get_account("alice");

--- a/tests/tests/voting_tests.cpp
+++ b/tests/tests/voting_tests.cpp
@@ -589,7 +589,8 @@ BOOST_AUTO_TEST_CASE(account_update_votes_operation)
       transfer(committee_account, proxywitness_id, asset(300));
       transfer(committee_account, proxyworker_id, asset(300));
 
-      generate_block();
+      generate_blocks(HARDFORK_BSIP_47_TIME);
+      set_expiration( db, trx );
 
       // a few votable witnesses
       auto witness1 = witness_id_type(1)(db);
@@ -597,6 +598,7 @@ BOOST_AUTO_TEST_CASE(account_update_votes_operation)
       auto witness3 = witness_id_type(3)(db);
 
       auto alice_object = alice_id(db);
+      BOOST_CHECK_EQUAL(alice_object.options.votes.size(), 4); // 4 votes added by default
 
       // add votes
       {
@@ -630,7 +632,7 @@ BOOST_AUTO_TEST_CASE(account_update_votes_operation)
 
       BOOST_CHECK_EQUAL(alice_object.options.voting_account.instance.value, 6);
 
-      BOOST_CHECK_EQUAL(alice_object.options.votes.size(), 7); // 4 votes are already added by default
+      BOOST_CHECK_EQUAL(alice_object.options.votes.size(), 7); // 3 added by us
 
       trx.clear();
       set_expiration( db, trx );
@@ -653,7 +655,7 @@ BOOST_AUTO_TEST_CASE(account_update_votes_operation)
       alice_object = alice_id(db);
 
       BOOST_CHECK_EQUAL(alice_object.options.voting_account.instance.value, 6);
-      BOOST_CHECK_EQUAL(alice_object.options.votes.size(), 6);
+      BOOST_CHECK_EQUAL(alice_object.options.votes.size(), 6); // 1 gone
 
    } FC_LOG_AND_RETHROW()
 }


### PR DESCRIPTION
https://github.com/bitshares/bsips/blob/master/bsip-0047.md

Implemented following bsip specs but some things were changed. Most notably this implementation is not storing votes for each referendum categories in additional account object fields by filtering but keep using the same `options.votes` set. 
This will save us from adding new code to `account_create_operation` and `account_update_operation`.

I don't think this is ready however good enough i hope for some review.