### PR TITLE
Signals for the external acquisition of an api_access_info

### DIFF
--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -66,9 +66,17 @@ namespace graphene { namespace app {
 
     bool login_api::login(const string& user, const string& password)
     {
-       optional< api_access_info > acc = _app.get_api_access_info( user );
+       optional< api_access_info > acc;
+       // signal to connect to for the external acquisition of an api_access_info
+       api_access_info_external( user, acc );
+
        if( !acc.valid() )
-          return false;
+       {
+          acc = _app.get_api_access_info( user );
+          if( !acc.valid() )
+            return false;
+       }
+
        if( acc->password_hash_b64 != "*" )
        {
           std::string password_salt = fc::base64_decode( acc->password_salt_b64 );

--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -255,7 +255,11 @@ void application_impl::new_connection( const fc::http::websocket_connection_ptr&
       password = parts[1];
    }
 
-   login->login(username, password);
+   bool external_login_active = false;
+   // signal to pass the login_api to an external login service
+   _self->login_attempt( external_login_active, username, password, *login );
+   if( !external_login_active )
+      login->login(username, password);
 }
 
 void application_impl::reset_websocket_server()
@@ -406,7 +410,7 @@ void application_impl::startup()
             modified_genesis = true;
 
             ilog(
-               "Used genesis timestamp:  ${timestamp} (PLEASE RECORD THIS)", 
+               "Used genesis timestamp:  ${timestamp} (PLEASE RECORD THIS)",
                ("timestamp", genesis.initial_timestamp.to_iso_string())
             );
          }
@@ -514,7 +518,7 @@ void application_impl::startup()
 
       fc::path api_access_file = _options->at("api-access").as<boost::filesystem::path>();
 
-      FC_ASSERT( fc::exists(api_access_file), 
+      FC_ASSERT( fc::exists(api_access_file),
             "Failed to load file from ${path}", ("path", api_access_file) );
 
       _apiaccess = fc::json::from_file( api_access_file ).as<api_access>( 20 );

--- a/libraries/app/include/graphene/app/api.hpp
+++ b/libraries/app/include/graphene/app/api.hpp
@@ -602,6 +602,10 @@ namespace graphene { namespace app {
 
          /// @brief Called to enable an API, not reflected.
          void enable_api( const string& api_name );
+
+         /// @brief Can be used to externally acquire the api_access_info for a user
+         boost::signals2::signal<void(const string&, fc::optional<api_access_info>&)> api_access_info_external;
+
       private:
 
          application& _app;

--- a/libraries/app/include/graphene/app/application.hpp
+++ b/libraries/app/include/graphene/app/application.hpp
@@ -69,6 +69,7 @@ namespace graphene { namespace app {
          uint64_t api_limit_get_withdraw_permissions_by_recipient = 101;
    };
 
+   class login_api;
    class application
    {
       public:
@@ -140,6 +141,9 @@ namespace graphene { namespace app {
          bool is_plugin_enabled(const string& name) const;
 
          std::shared_ptr<fc::thread> elasticsearch_thread;
+
+         /// Signal to reroute login requests
+         boost::signals2::signal< void(bool&, const string&, const string&, login_api&) > login_attempt;
 
    private:
          void add_available_plugin( std::shared_ptr<abstract_plugin> p );


### PR DESCRIPTION
With this PR I would like to introduce two new signals, to enable the api login process through an `external_service`.

Signal1: `application::login_attempt` emitted at the end of `application_impl::new_connection`. 

    Signature:     
    bool& // should be set by the external service to true, if it is active. 
          // It's bool& to avoid return types 
          // cause this would result in returning a boost::optional
    string& // username
    string& // password
    login_api& // the created login_api (needed to connect the second signal)

Signal2: `login_api::api_access_info_external` emitted at the beginning of `login_api::login`.
       
    Signature:
    string& // username
    fc::optional<api_access_info>& // to be filled by the `external_service`

Logic:
   
    signal::login_attempt is emitted
        => if no service connected: default login
            => signal::api_access_info_external emitted
               => does not set the optional 
               => from here default login
        => else: rerouted login through the external_service
           => service connects to login_api::signal::api_access_info_external           
              => singal::api_access_info_external emitted
                 => service trys to find api_access_info to given user
                    => if found: login with found
                    => else default login

       
Alternatively this could be done with the first signal alone, but then the service would have to implement the login logic, which I tried to avoid here.

What do you think? Would this be a way to implement that? Open for any discussion.