### PR TITLE
Use special container type for token balances

### DIFF
--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -592,7 +592,7 @@ namespace graphene { namespace app {
           if( result.size() >= limit )
              break;
 
-          if( bal.balance.value == 0 )
+          if( bal.balance.get_amount() == 0 )
              continue;
 
           if( index++ < start )
@@ -603,7 +603,7 @@ namespace graphene { namespace app {
           account_asset_balance aab;
           aab.name       = account->name;
           aab.account_id = account->id;
-          aab.amount     = bal.balance.value;
+          aab.amount     = bal.balance.get_amount();
 
           result.push_back(aab);
        }

--- a/libraries/app/api_objects.cpp
+++ b/libraries/app/api_objects.cpp
@@ -89,3 +89,37 @@ market_ticker::market_ticker(const fc::time_point_sec& now,
 }
 
 } } // graphene::app
+
+FC_REFLECT_DERIVED_NO_TYPENAME( graphene::app::account_balance_api_object,
+                    (graphene::chain::account_balance_master), (balance) );
+FC_REFLECT_DERIVED_NO_TYPENAME( graphene::app::account_statistics_api_object,
+                    (graphene::chain::account_statistics_master),
+                    (pending_fees)(pending_vested_fees) );
+FC_REFLECT_DERIVED_NO_TYPENAME( graphene::app::balance_api_object,
+                    (graphene::chain::balance_master), (balance) );
+FC_REFLECT_DERIVED_NO_TYPENAME( graphene::app::limit_order_api_object,
+                    (graphene::chain::limit_order_master), (for_sale)(deferred_fee)(deferred_paid_fee) );
+FC_REFLECT_DERIVED_NO_TYPENAME( graphene::app::call_order_api_object,
+                    (graphene::chain::call_order_master), (debt)(collateral) );
+FC_REFLECT_DERIVED_NO_TYPENAME( graphene::app::force_settlement_api_object,
+                    (graphene::chain::force_settlement_master), (balance) );
+FC_REFLECT_DERIVED_NO_TYPENAME( graphene::app::collateral_bid_api_object,
+                    (graphene::chain::collateral_bid_master), (inv_swan_price) );
+FC_REFLECT_DERIVED_NO_TYPENAME( graphene::app::htlc_api_object::transfer_info,
+                    (graphene::chain::htlc_master::transfer_info_master), (amount)(asset_id) );
+FC_REFLECT_DERIVED_NO_TYPENAME( graphene::app::htlc_api_object,
+                    (graphene::chain::htlc_master), (transfer) );
+FC_REFLECT_DERIVED_NO_TYPENAME( graphene::app::dynamic_global_property_api_object,
+                    (graphene::chain::dynamic_global_property_master), (witness_budget) );
+
+GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::app::account_balance_api_object )
+GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::app::account_statistics_api_object )
+GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::app::balance_api_object )
+GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::app::limit_order_api_object )
+GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::app::call_order_api_object )
+GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::app::force_settlement_api_object )
+GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::app::collateral_bid_api_object )
+GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::app::htlc_api_object::transfer_info )
+GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::app::htlc_api_object )
+GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::app::vesting_balance_api_object )
+GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::app::dynamic_global_property_api_object )

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -308,12 +308,12 @@ chain_id_type database_api_impl::get_chain_id()const
    return _db.get_chain_id();
 }
 
-dynamic_global_property_object database_api::get_dynamic_global_properties()const
+dynamic_global_property_api_object database_api::get_dynamic_global_properties()const
 {
    return my->get_dynamic_global_properties();
 }
 
-dynamic_global_property_object database_api_impl::get_dynamic_global_properties()const
+const dynamic_global_property_object& database_api_impl::get_dynamic_global_properties()const
 {
    return _db.get(dynamic_global_property_id_type());
 }
@@ -758,26 +758,26 @@ vector<asset> database_api::get_named_account_balances( const std::string& name,
    return my->get_account_balances( name, assets );
 }
 
-vector<balance_object> database_api::get_balance_objects( const vector<address>& addrs )const
+vector<balance_api_object> database_api::get_balance_objects( const vector<address>& addrs )const
 {
    return my->get_balance_objects( addrs );
 }
 
-vector<balance_object> database_api_impl::get_balance_objects( const vector<address>& addrs )const
+vector<balance_api_object> database_api_impl::get_balance_objects( const vector<address>& addrs )const
 {
    try
    {
       const auto& bal_idx = _db.get_index_type<balance_index>();
       const auto& by_owner_idx = bal_idx.indices().get<by_owner>();
 
-      vector<balance_object> result;
+      vector<balance_api_object> result;
 
       for( const auto& owner : addrs )
       {
          auto itr = by_owner_idx.lower_bound( boost::make_tuple( owner, asset_id_type(0) ) );
          while( itr != by_owner_idx.end() && itr->owner == owner )
          {
-            result.push_back( *itr );
+            result.emplace_back( *itr );
             ++itr;
          }
       }
@@ -804,21 +804,21 @@ vector<asset> database_api_impl::get_vested_balances( const vector<balance_id_ty
    } FC_CAPTURE_AND_RETHROW( (objs) )
 }
 
-vector<vesting_balance_object> database_api::get_vesting_balances( const std::string account_id_or_name )const
+vector<vesting_balance_api_object> database_api::get_vesting_balances( const std::string account_id_or_name )const
 {
    return my->get_vesting_balances( account_id_or_name );
 }
 
-vector<vesting_balance_object> database_api_impl::get_vesting_balances( const std::string account_id_or_name )const
+vector<vesting_balance_api_object> database_api_impl::get_vesting_balances( const std::string account_id_or_name )const
 {
    try
    {
       const account_id_type account_id = get_account_from_string(account_id_or_name)->id;
-      vector<vesting_balance_object> result;
+      vector<vesting_balance_api_object> result;
       auto vesting_range = _db.get_index_type<vesting_balance_index>().indices().get<by_account>()
                               .equal_range(account_id);
       std::for_each(vesting_range.first, vesting_range.second,
-                    [&result](const vesting_balance_object& balance) {
+                    [&result](const vesting_balance_api_object& balance) {
                        result.emplace_back(balance);
                     });
       return result;
@@ -954,12 +954,12 @@ vector<optional<extended_asset_object>> database_api_impl::lookup_asset_symbols(
 //                                                                  //
 //////////////////////////////////////////////////////////////////////
 
-vector<limit_order_object> database_api::get_limit_orders(std::string a, std::string b, uint32_t limit)const
+vector<limit_order_api_object> database_api::get_limit_orders(std::string a, std::string b, uint32_t limit)const
 {
    return my->get_limit_orders( a, b, limit );
 }
 
-vector<limit_order_object> database_api_impl::get_limit_orders( const std::string& a, const std::string& b,
+vector<limit_order_api_object> database_api_impl::get_limit_orders( const std::string& a, const std::string& b,
                                                                 uint32_t limit )const
 {
    uint64_t api_limit_get_limit_orders=_app_options->api_limit_get_limit_orders;
@@ -971,20 +971,20 @@ vector<limit_order_object> database_api_impl::get_limit_orders( const std::strin
    return get_limit_orders(asset_a_id, asset_b_id, limit);
 }
 
-vector<limit_order_object> database_api::get_account_limit_orders(
+vector<limit_order_api_object> database_api::get_account_limit_orders(
                               const string& account_name_or_id, const string &base, const string &quote,
                               uint32_t limit, optional<limit_order_id_type> ostart_id, optional<price> ostart_price )
 {
    return my->get_account_limit_orders( account_name_or_id, base, quote, limit, ostart_id, ostart_price );
 }
 
-vector<limit_order_object> database_api_impl::get_account_limit_orders(
+vector<limit_order_api_object> database_api_impl::get_account_limit_orders(
                               const string& account_name_or_id, const string &base, const string &quote,
                               uint32_t limit, optional<limit_order_id_type> ostart_id, optional<price> ostart_price )
 {
    FC_ASSERT( limit <= _app_options->api_limit_get_account_limit_orders );
 
-   vector<limit_order_object>   results;
+   vector<limit_order_api_object>   results;
    uint32_t                     count = 0;
 
    const account_object* account = get_account_from_string(account_name_or_id);
@@ -1059,12 +1059,12 @@ vector<limit_order_object> database_api_impl::get_account_limit_orders(
    return results;
 }
 
-vector<call_order_object> database_api::get_call_orders(const std::string& a, uint32_t limit)const
+vector<call_order_api_object> database_api::get_call_orders(const std::string& a, uint32_t limit)const
 {
    return my->get_call_orders( a, limit );
 }
 
-vector<call_order_object> database_api_impl::get_call_orders(const std::string& a, uint32_t limit)const
+vector<call_order_api_object> database_api_impl::get_call_orders(const std::string& a, uint32_t limit)const
 {
    uint64_t api_limit_get_call_orders = _app_options->api_limit_get_call_orders;
    FC_ASSERT( limit <= api_limit_get_call_orders );
@@ -1073,7 +1073,7 @@ vector<call_order_object> database_api_impl::get_call_orders(const std::string& 
    const auto& call_index = _db.get_index_type<call_order_index>().indices().get<by_collateral>();
    price index_price = price::min( mia->bitasset_data(_db).options.short_backing_asset, mia->get_id() );
 
-   vector< call_order_object> result;
+   vector< call_order_api_object> result;
    auto itr_min = call_index.lower_bound(index_price);
    auto itr_max = call_index.upper_bound(index_price.max());
    while( itr_min != itr_max && result.size() < limit )
@@ -1084,37 +1084,37 @@ vector<call_order_object> database_api_impl::get_call_orders(const std::string& 
    return result;
 }
 
-vector<call_order_object> database_api::get_call_orders_by_account(const std::string& account_name_or_id,
+vector<call_order_api_object> database_api::get_call_orders_by_account(const std::string& account_name_or_id,
                                                                    asset_id_type start, uint32_t limit)const
 {
    return my->get_call_orders_by_account( account_name_or_id, start, limit );
 }
 
-vector<call_order_object> database_api_impl::get_call_orders_by_account(const std::string& account_name_or_id,
+vector<call_order_api_object> database_api_impl::get_call_orders_by_account(const std::string& account_name_or_id,
                                                                         asset_id_type start, uint32_t limit)const
 {
    uint64_t api_limit_get_call_orders = _app_options->api_limit_get_call_orders;
    FC_ASSERT( limit <= api_limit_get_call_orders );
 
-   vector<call_order_object> result;
+   vector<call_order_api_object> result;
    const account_id_type account = get_account_from_string(account_name_or_id)->id;
    const auto& call_idx = _db.get_index_type<call_order_index>().indices().get<by_account>();
    auto call_index_end = call_idx.end();
    auto call_itr = call_idx.lower_bound(boost::make_tuple(account, start));
    while(call_itr != call_index_end && call_itr->borrower == account && result.size() < limit)
    {
-      result.push_back(*call_itr);
+      result.emplace_back(*call_itr);
       ++call_itr;
    }
    return result;
 }
 
-vector<force_settlement_object> database_api::get_settle_orders(const std::string& a, uint32_t limit)const
+vector<force_settlement_api_object> database_api::get_settle_orders(const std::string& a, uint32_t limit)const
 {
    return my->get_settle_orders( a, limit );
 }
 
-vector<force_settlement_object> database_api_impl::get_settle_orders(const std::string& a, uint32_t limit)const
+vector<force_settlement_api_object> database_api_impl::get_settle_orders(const std::string& a, uint32_t limit)const
 {
    uint64_t api_limit_get_settle_orders = _app_options->api_limit_get_settle_orders;
    FC_ASSERT( limit <= api_limit_get_settle_orders );
@@ -1123,7 +1123,7 @@ vector<force_settlement_object> database_api_impl::get_settle_orders(const std::
    const auto& settle_index = _db.get_index_type<force_settlement_index>().indices().get<by_expiration>();
    const asset_object& mia = _db.get(asset_a_id);
 
-   vector<force_settlement_object> result;
+   vector<force_settlement_api_object> result;
    auto itr_min = settle_index.lower_bound(mia.get_id());
    auto itr_max = settle_index.upper_bound(mia.get_id());
    while( itr_min != itr_max && result.size() < limit )
@@ -1134,7 +1134,7 @@ vector<force_settlement_object> database_api_impl::get_settle_orders(const std::
    return result;
 }
 
-vector<force_settlement_object> database_api::get_settle_orders_by_account(
+vector<force_settlement_api_object> database_api::get_settle_orders_by_account(
       const std::string& account_name_or_id,
       force_settlement_id_type start,
       uint32_t limit )const
@@ -1142,7 +1142,7 @@ vector<force_settlement_object> database_api::get_settle_orders_by_account(
    return my->get_settle_orders_by_account( account_name_or_id, start, limit);
 }
 
-vector<force_settlement_object> database_api_impl::get_settle_orders_by_account(
+vector<force_settlement_api_object> database_api_impl::get_settle_orders_by_account(
       const std::string& account_name_or_id,
       force_settlement_id_type start,
       uint32_t limit )const
@@ -1150,26 +1150,26 @@ vector<force_settlement_object> database_api_impl::get_settle_orders_by_account(
    uint64_t api_limit_get_settle_orders = _app_options->api_limit_get_settle_orders;
    FC_ASSERT( limit <= api_limit_get_settle_orders );
 
-   vector<force_settlement_object> result;
+   vector<force_settlement_api_object> result;
    const account_id_type account = get_account_from_string(account_name_or_id)->id;
    const auto& settle_idx = _db.get_index_type<force_settlement_index>().indices().get<by_account>();
    auto settle_index_end = settle_idx.end();
    auto settle_itr = settle_idx.lower_bound(boost::make_tuple(account, start));
    while(settle_itr != settle_index_end && settle_itr->owner == account && result.size() < limit)
    {
-      result.push_back(*settle_itr);
+      result.emplace_back(*settle_itr);
       ++settle_itr;
    }
    return result;
 }
 
 
-vector<call_order_object> database_api::get_margin_positions( const std::string account_id_or_name )const
+vector<call_order_api_object> database_api::get_margin_positions( const std::string account_id_or_name )const
 {
    return my->get_margin_positions( account_id_or_name );
 }
 
-vector<call_order_object> database_api_impl::get_margin_positions( const std::string account_id_or_name )const
+vector<call_order_api_object> database_api_impl::get_margin_positions( const std::string account_id_or_name )const
 {
    try
    {
@@ -1178,23 +1178,23 @@ vector<call_order_object> database_api_impl::get_margin_positions( const std::st
       const account_id_type id = get_account_from_string(account_id_or_name)->id;
       auto start = aidx.lower_bound( boost::make_tuple( id, asset_id_type(0) ) );
       auto end = aidx.lower_bound( boost::make_tuple( id+1, asset_id_type(0) ) );
-      vector<call_order_object> result;
+      vector<call_order_api_object> result;
       while( start != end )
       {
-         result.push_back(*start);
+         result.emplace_back(*start);
          ++start;
       }
       return result;
    } FC_CAPTURE_AND_RETHROW( (account_id_or_name) )
 }
 
-vector<collateral_bid_object> database_api::get_collateral_bids( const std::string& asset,
+vector<collateral_bid_api_object> database_api::get_collateral_bids( const std::string& asset,
                                                                  uint32_t limit, uint32_t start )const
 {
    return my->get_collateral_bids( asset, limit, start );
 }
 
-vector<collateral_bid_object> database_api_impl::get_collateral_bids( const std::string& asset,
+vector<collateral_bid_api_object> database_api_impl::get_collateral_bids( const std::string& asset,
                                                                       uint32_t limit, uint32_t skip )const
 { try {
    FC_ASSERT( limit <= _app_options->api_limit_get_collateral_bids );
@@ -1211,11 +1211,11 @@ vector<collateral_bid_object> database_api_impl::get_collateral_bids( const std:
    auto end = aidx.lower_bound( boost::make_tuple( asset_id,
                                                    price::min(back.id, asset_id),
                                                    collateral_bid_id_type(GRAPHENE_DB_MAX_INSTANCE_ID) ) );
-   vector<collateral_bid_object> result;
+   vector<collateral_bid_api_object> result;
    while( skip-- > 0 && start != end ) { ++start; }
    while( start != end && limit-- > 0)
    {
-      result.push_back(*start);
+      result.emplace_back(*start);
       ++start;
    }
    return result;
@@ -2253,32 +2253,32 @@ vector<withdraw_permission_object> database_api_impl::get_withdraw_permissions_b
 //                                                                  //
 //////////////////////////////////////////////////////////////////////
 
-optional<htlc_object> database_api::get_htlc( htlc_id_type id, optional<bool> subscribe )const
+optional<htlc_api_object> database_api::get_htlc( htlc_id_type id, optional<bool> subscribe )const
 {
    return my->get_htlc( id, subscribe );
 }
 
-fc::optional<htlc_object> database_api_impl::get_htlc( htlc_id_type id, optional<bool> subscribe )const
+fc::optional<htlc_api_object> database_api_impl::get_htlc( htlc_id_type id, optional<bool> subscribe )const
 {
    auto obj = get_objects( { id }, subscribe ).front();
    if ( !obj.is_null() )
-   {
-      return fc::optional<htlc_object>(obj.template as<htlc_object>(GRAPHENE_MAX_NESTED_OBJECTS));
+   { // FIXME
+      return fc::optional<htlc_api_object>(obj.template as<htlc_api_object>(GRAPHENE_MAX_NESTED_OBJECTS));
    }
-   return fc::optional<htlc_object>();
+   return fc::optional<htlc_api_object>();
 }
 
-vector<htlc_object> database_api::get_htlc_by_from( const std::string account_id_or_name,
+vector<htlc_api_object> database_api::get_htlc_by_from( const std::string account_id_or_name,
                                                     htlc_id_type start, uint32_t limit )const
 {
    return my->get_htlc_by_from(account_id_or_name, start, limit);
 }
 
-vector<htlc_object> database_api_impl::get_htlc_by_from( const std::string account_id_or_name,
+vector<htlc_api_object> database_api_impl::get_htlc_by_from( const std::string account_id_or_name,
                                                          htlc_id_type start, uint32_t limit ) const
 {
    FC_ASSERT( limit <= _app_options->api_limit_get_htlc_by );
-   vector<htlc_object> result;
+   vector<htlc_api_object> result;
 
    const auto& htlc_idx = _db.get_index_type< htlc_index >().indices().get< by_from_id >();
    auto htlc_index_end = htlc_idx.end();
@@ -2287,24 +2287,24 @@ vector<htlc_object> database_api_impl::get_htlc_by_from( const std::string accou
 
    while(htlc_itr != htlc_index_end && htlc_itr->transfer.from == account && result.size() < limit)
    {
-      result.push_back(*htlc_itr);
+      result.emplace_back(*htlc_itr);
       ++htlc_itr;
    }
    return result;
 }
 
-vector<htlc_object> database_api::get_htlc_by_to( const std::string account_id_or_name,
+vector<htlc_api_object> database_api::get_htlc_by_to( const std::string account_id_or_name,
                                                   htlc_id_type start, uint32_t limit )const
 {
    return my->get_htlc_by_to(account_id_or_name, start, limit);
 }
 
-vector<htlc_object> database_api_impl::get_htlc_by_to( const std::string account_id_or_name,
+vector<htlc_api_object> database_api_impl::get_htlc_by_to( const std::string account_id_or_name,
                                                        htlc_id_type start, uint32_t limit ) const
 {
 
    FC_ASSERT( limit <= _app_options->api_limit_get_htlc_by );
-   vector<htlc_object> result;
+   vector<htlc_api_object> result;
 
    const auto& htlc_idx = _db.get_index_type< htlc_index >().indices().get< by_to_id >();
    auto htlc_index_end = htlc_idx.end();
@@ -2313,27 +2313,27 @@ vector<htlc_object> database_api_impl::get_htlc_by_to( const std::string account
 
    while(htlc_itr != htlc_index_end && htlc_itr->transfer.to == account && result.size() < limit)
    {
-      result.push_back(*htlc_itr);
+      result.emplace_back(*htlc_itr);
       ++htlc_itr;
    }
    return result;
 }
 
-vector<htlc_object> database_api::list_htlcs(const htlc_id_type start, uint32_t limit)const
+vector<htlc_api_object> database_api::list_htlcs(const htlc_id_type start, uint32_t limit)const
 {
    return my->list_htlcs(start, limit);
 }
 
-vector<htlc_object> database_api_impl::list_htlcs(const htlc_id_type start, uint32_t limit) const
+vector<htlc_api_object> database_api_impl::list_htlcs(const htlc_id_type start, uint32_t limit) const
 {
    FC_ASSERT( limit <= _app_options->api_limit_list_htlcs );
 
-   vector<htlc_object> result;
+   vector<htlc_api_object> result;
    const auto& htlc_idx = _db.get_index_type<htlc_index>().indices().get<by_id>();
    auto itr = htlc_idx.lower_bound(start);
    while(itr != htlc_idx.end() && result.size() < limit)
    {
-      result.push_back(*itr);
+      result.emplace_back(*itr);
       ++itr;
    }
    return result;
@@ -2405,7 +2405,7 @@ vector<optional<extended_asset_object>> database_api_impl::get_assets( const vec
 }
 
 // helper function
-vector<limit_order_object> database_api_impl::get_limit_orders( const asset_id_type a, const asset_id_type b,
+vector<limit_order_api_object> database_api_impl::get_limit_orders( const asset_id_type a, const asset_id_type b,
                                                                 const uint32_t limit )const
 {
    uint64_t api_limit_get_limit_orders=_app_options->api_limit_get_limit_orders;
@@ -2414,7 +2414,7 @@ vector<limit_order_object> database_api_impl::get_limit_orders( const asset_id_t
    const auto& limit_order_idx = _db.get_index_type<limit_order_index>();
    const auto& limit_price_idx = limit_order_idx.indices().get<by_price>();
 
-   vector<limit_order_object> result;
+   vector<limit_order_api_object> result;
    result.reserve(limit*2);
 
    uint32_t count = 0;
@@ -2422,7 +2422,7 @@ vector<limit_order_object> database_api_impl::get_limit_orders( const asset_id_t
    auto limit_end = limit_price_idx.upper_bound(price::min(a,b));
    while(limit_itr != limit_end && count < limit)
    {
-      result.push_back(*limit_itr);
+      result.emplace_back(*limit_itr);
       ++limit_itr;
       ++count;
    }
@@ -2431,7 +2431,7 @@ vector<limit_order_object> database_api_impl::get_limit_orders( const asset_id_t
    limit_end = limit_price_idx.upper_bound(price::min(b,a));
    while(limit_itr != limit_end && count < limit)
    {
-      result.push_back(*limit_itr);
+      result.emplace_back(*limit_itr);
       ++limit_itr;
       ++count;
    }

--- a/libraries/app/database_api_impl.hxx
+++ b/libraries/app/database_api_impl.hxx
@@ -60,7 +60,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       global_property_object get_global_properties()const;
       fc::variant_object get_config()const;
       chain_id_type get_chain_id()const;
-      dynamic_global_property_object get_dynamic_global_properties()const;
+      const dynamic_global_property_object& get_dynamic_global_properties()const;
 
       // Keys
       vector<flat_set<account_id_type>> get_key_references( vector<public_key_type> key )const;
@@ -84,9 +84,9 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       vector<asset> get_account_balances( const std::string& account_name_or_id,
                                           const flat_set<asset_id_type>& assets )const;
       vector<asset> get_named_account_balances(const std::string& name, const flat_set<asset_id_type>& assets)const;
-      vector<balance_object> get_balance_objects( const vector<address>& addrs )const;
+      vector<balance_api_object> get_balance_objects( const vector<address>& addrs )const;
       vector<asset> get_vested_balances( const vector<balance_id_type>& objs )const;
-      vector<vesting_balance_object> get_vesting_balances( const std::string account_id_or_name )const;
+      vector<vesting_balance_api_object> get_vesting_balances( const std::string account_id_or_name )const;
 
       // Assets
       uint64_t get_asset_count()const;
@@ -99,22 +99,22 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
                                                                    asset_id_type start, uint32_t limit)const;
 
       // Markets / feeds
-      vector<limit_order_object>         get_limit_orders( const std::string& a, const std::string& b,
+      vector<limit_order_api_object>         get_limit_orders( const std::string& a, const std::string& b,
                                                            uint32_t limit)const;
-      vector<limit_order_object>         get_account_limit_orders( const string& account_name_or_id,
+      vector<limit_order_api_object>         get_account_limit_orders( const string& account_name_or_id,
                                                                    const string &base,
                                                                    const string &quote, uint32_t limit,
                                                                    optional<limit_order_id_type> ostart_id,
                                                                    optional<price> ostart_price );
-      vector<call_order_object>          get_call_orders(const std::string& a, uint32_t limit)const;
-      vector<call_order_object>          get_call_orders_by_account(const std::string& account_name_or_id,
+      vector<call_order_api_object>          get_call_orders(const std::string& a, uint32_t limit)const;
+      vector<call_order_api_object>          get_call_orders_by_account(const std::string& account_name_or_id,
                                                                     asset_id_type start, uint32_t limit)const;
-      vector<force_settlement_object>    get_settle_orders(const std::string& a, uint32_t limit)const;
-      vector<force_settlement_object>    get_settle_orders_by_account(const std::string& account_name_or_id,
+      vector<force_settlement_api_object>    get_settle_orders(const std::string& a, uint32_t limit)const;
+      vector<force_settlement_api_object>    get_settle_orders_by_account(const std::string& account_name_or_id,
                                                                       force_settlement_id_type start,
                                                                       uint32_t limit)const;
-      vector<call_order_object>          get_margin_positions( const std::string account_id_or_name )const;
-      vector<collateral_bid_object>      get_collateral_bids( const std::string& asset,
+      vector<call_order_api_object>          get_margin_positions( const std::string account_id_or_name )const;
+      vector<collateral_bid_api_object>      get_collateral_bids( const std::string& asset,
                                                               uint32_t limit, uint32_t start)const;
 
       void subscribe_to_market( std::function<void(const variant&)> callback,
@@ -187,12 +187,12 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
                                                                                 uint32_t limit )const;
 
       // HTLC
-      optional<htlc_object> get_htlc( htlc_id_type id, optional<bool> subscribe ) const;
-      vector<htlc_object> get_htlc_by_from( const std::string account_id_or_name,
+      optional<htlc_api_object> get_htlc( htlc_id_type id, optional<bool> subscribe ) const;
+      vector<htlc_api_object> get_htlc_by_from( const std::string account_id_or_name,
                                             htlc_id_type start, uint32_t limit ) const;
-      vector<htlc_object> get_htlc_by_to( const std::string account_id_or_name,
+      vector<htlc_api_object> get_htlc_by_to( const std::string account_id_or_name,
                                           htlc_id_type start, uint32_t limit) const;
-      vector<htlc_object> list_htlcs(const htlc_id_type lower_bound_id, uint32_t limit) const;
+      vector<htlc_api_object> list_htlcs(const htlc_id_type lower_bound_id, uint32_t limit) const;
 
    //private:
 
@@ -232,7 +232,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       ////////////////////////////////////////////////
 
       // helper function
-      vector<limit_order_object> get_limit_orders( const asset_id_type a, const asset_id_type b,
+      vector<limit_order_api_object> get_limit_orders( const asset_id_type a, const asset_id_type b,
                                                    const uint32_t limit )const;
 
       ////////////////////////////////////////////////
@@ -300,8 +300,8 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       const std::pair<asset_id_type,asset_id_type> get_order_market( const force_settlement_object& order )
       {
          // TODO cache the result to avoid repeatly fetching from db
-         asset_id_type backing_id = order.balance.asset_id( _db ).bitasset_data( _db ).options.short_backing_asset;
-         auto tmp = std::make_pair( order.balance.asset_id, backing_id );
+         asset_id_type backing_id = order.balance.get_asset()( _db ).bitasset_data( _db ).options.short_backing_asset;
+         auto tmp = std::make_pair( order.balance.get_asset(), backing_id );
          if( tmp.first > tmp.second ) std::swap( tmp.first, tmp.second );
          return tmp;
       }

--- a/libraries/app/include/graphene/app/api_objects.hpp
+++ b/libraries/app/include/graphene/app/api_objects.hpp
@@ -25,6 +25,8 @@
 
 #include <graphene/chain/account_object.hpp>
 #include <graphene/chain/asset_object.hpp>
+#include <graphene/chain/balance_object.hpp>
+#include <graphene/chain/global_property_object.hpp>
 #include <graphene/chain/vesting_balance_object.hpp>
 #include <graphene/chain/market_object.hpp>
 #include <graphene/chain/proposal_object.hpp>
@@ -39,6 +41,132 @@
 namespace graphene { namespace app {
    using namespace graphene::chain;
    using namespace graphene::market_history;
+
+   class account_balance_api_object : public account_balance_master
+   {
+      public:
+         account_balance_api_object() {}
+         account_balance_api_object( const account_balance_object& orig) : account_balance_master(orig)
+         {
+            balance = orig.balance.get_value();
+         }
+         asset balance;
+   };
+
+   class account_statistics_api_object : public account_statistics_master
+   {
+      public:
+         account_statistics_api_object() {}
+         account_statistics_api_object( const account_statistics_object& orig)
+            : account_statistics_master(orig)
+         {
+            pending_fees = orig.pending_fees.get_amount();
+            pending_vested_fees = orig.pending_vested_fees.get_amount();
+         }
+         share_type pending_fees;
+         share_type pending_vested_fees;
+   };
+
+   class balance_api_object : public balance_master
+   {
+      public:
+         balance_api_object() {}
+         balance_api_object( const balance_object& orig) : balance_master(orig)
+         {
+            balance = orig.balance.get_value();
+         }
+         asset balance;
+   };
+
+   class collateral_bid_api_object : public collateral_bid_master
+   {
+      public:
+         collateral_bid_api_object() {}
+         collateral_bid_api_object( const collateral_bid_object& orig) : collateral_bid_master(orig)
+         {
+            inv_swan_price = orig.collateral_offered.get_value() / orig.debt_covered;
+         }
+         price inv_swan_price;
+   };
+
+   class limit_order_api_object : public limit_order_master
+   {
+      public:
+         limit_order_api_object() {}
+         limit_order_api_object( const limit_order_object& orig) : limit_order_master(orig)
+         {
+            for_sale = orig.for_sale.get_amount();
+            deferred_fee = orig.deferred_fee.get_amount();
+            deferred_paid_fee = orig.deferred_paid_fee.get_value();
+         }
+         share_type for_sale;
+         share_type deferred_fee;
+         asset deferred_paid_fee;
+   };
+
+   class call_order_api_object : public call_order_master
+   {
+      public:
+         call_order_api_object() {}
+         call_order_api_object( const call_order_object& orig) : call_order_master(orig)
+         {
+            debt = orig.debt.get_amount();
+            collateral = orig.collateral.get_amount();
+         }
+         share_type debt;
+         share_type collateral;
+   };
+
+   class force_settlement_api_object : public force_settlement_master
+   {
+      public:
+         force_settlement_api_object() {}
+         force_settlement_api_object( const force_settlement_object& orig) : force_settlement_master(orig)
+         {
+            balance = orig.balance.get_value();
+         }
+         asset balance;
+   };
+
+   class htlc_api_object : public htlc_master
+   {
+      public:
+         htlc_api_object() {}
+         htlc_api_object( const htlc_object& orig) : htlc_master(orig)
+         {
+            static_cast<transfer_info_master&>(transfer) = orig.transfer;
+            transfer.amount = orig.transfer.amount.get_amount();
+            transfer.asset_id = orig.transfer.amount.get_asset();
+         }
+
+         struct transfer_info : transfer_info_master {
+            share_type amount;
+            asset_id_type asset_id;
+         } transfer;
+   };
+
+   class vesting_balance_api_object : public vesting_balance_master
+   {
+      public:
+         vesting_balance_api_object() {}
+         vesting_balance_api_object( const vesting_balance_object& orig) : vesting_balance_master(orig)
+         {
+            balance = orig.balance.get_value();
+         }
+         asset balance;
+   };
+
+   class dynamic_global_property_api_object : public dynamic_global_property_master
+   {
+   public:
+      dynamic_global_property_api_object() {}
+      dynamic_global_property_api_object( const dynamic_global_property_object& orig )
+         : dynamic_global_property_master( orig )
+      {
+         witness_budget = orig.witness_budget.get_value();
+      }
+      asset witness_budget;
+   };
 
    struct more_data
    {
@@ -57,25 +185,25 @@ namespace graphene { namespace app {
 
    struct full_account
    {
-      account_object                   account;
-      account_statistics_object        statistics;
-      string                           registrar_name;
-      string                           referrer_name;
-      string                           lifetime_referrer_name;
-      vector<variant>                  votes;
-      optional<vesting_balance_object> cashback_balance;
-      vector<account_balance_object>   balances;
-      vector<vesting_balance_object>   vesting_balances;
-      vector<limit_order_object>       limit_orders;
-      vector<call_order_object>        call_orders;
-      vector<force_settlement_object>  settle_orders;
-      vector<proposal_object>          proposals;
-      vector<asset_id_type>            assets;
-      vector<withdraw_permission_object> withdraws_from;
-      vector<withdraw_permission_object> withdraws_to;
-      vector<htlc_object>              htlcs_from;
-      vector<htlc_object>              htlcs_to;
-      more_data                        more_data_available;
+      account_object                       account;
+      account_statistics_api_object        statistics;
+      string                               registrar_name;
+      string                               referrer_name;
+      string                               lifetime_referrer_name;
+      vector<variant>                      votes;
+      optional<vesting_balance_api_object> cashback_balance;
+      vector<account_balance_api_object>   balances;
+      vector<vesting_balance_api_object>   vesting_balances;
+      vector<limit_order_api_object>       limit_orders;
+      vector<call_order_api_object>        call_orders;
+      vector<force_settlement_api_object>  settle_orders;
+      vector<proposal_object>              proposals;
+      vector<asset_id_type>                assets;
+      vector<withdraw_permission_object>   withdraws_from;
+      vector<withdraw_permission_object>   withdraws_to;
+      vector<htlc_api_object>              htlcs_from;
+      vector<htlc_api_object>              htlcs_to;
+      more_data                            more_data_available;
    };
 
    struct order
@@ -182,5 +310,31 @@ FC_REFLECT( graphene::app::market_ticker,
 FC_REFLECT( graphene::app::market_volume, (time)(base)(quote)(base_volume)(quote_volume) );
 FC_REFLECT( graphene::app::market_trade, (sequence)(date)(price)(amount)(value)(side1_account_id)(side2_account_id) );
 
+FC_REFLECT_DERIVED( graphene::app::vesting_balance_api_object,
+                    (graphene::chain::vesting_balance_master), (balance) );
+
 FC_REFLECT_DERIVED( graphene::app::extended_asset_object, (graphene::chain::asset_object),
                     (total_in_collateral)(total_backing_collateral) );
+
+FC_REFLECT_TYPENAME( graphene::app::account_balance_api_object )
+FC_REFLECT_TYPENAME( graphene::app::account_statistics_api_object )
+FC_REFLECT_TYPENAME( graphene::app::balance_api_object )
+FC_REFLECT_TYPENAME( graphene::app::limit_order_api_object )
+FC_REFLECT_TYPENAME( graphene::app::call_order_api_object )
+FC_REFLECT_TYPENAME( graphene::app::force_settlement_api_object )
+FC_REFLECT_TYPENAME( graphene::app::collateral_bid_api_object )
+FC_REFLECT_TYPENAME( graphene::app::htlc_api_object::transfer_info )
+FC_REFLECT_TYPENAME( graphene::app::htlc_api_object )
+FC_REFLECT_TYPENAME( graphene::app::dynamic_global_property_api_object )
+
+GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::app::account_balance_api_object )
+GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::app::account_statistics_api_object )
+GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::app::balance_api_object )
+GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::app::limit_order_api_object )
+GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::app::call_order_api_object )
+GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::app::force_settlement_api_object )
+GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::app::collateral_bid_api_object )
+GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::app::htlc_api_object::transfer_info )
+GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::app::htlc_api_object )
+GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::app::vesting_balance_api_object )
+GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::app::dynamic_global_property_api_object )

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -215,7 +215,7 @@ class database_api
       /**
        * @brief Retrieve the current @ref graphene::chain::dynamic_global_property_object
        */
-      dynamic_global_property_object get_dynamic_global_properties()const;
+      dynamic_global_property_api_object get_dynamic_global_properties()const;
 
       //////////
       // Keys //
@@ -339,7 +339,7 @@ class database_api
        * @param addrs a list of addresses
        * @return all unclaimed balance objects for the addresses
        */
-      vector<balance_object> get_balance_objects( const vector<address>& addrs )const;
+      vector<balance_api_object> get_balance_objects( const vector<address>& addrs )const;
 
       /**
        * @brief Calculate how much assets in the given balance objects are able to be claimed at current head
@@ -354,7 +354,7 @@ class database_api
        * @param account_name_or_id name or ID of an account
        * @return all vesting balance objects owned by the account
        */
-      vector<vesting_balance_object> get_vesting_balances( const std::string account_name_or_id )const;
+      vector<vesting_balance_api_object> get_vesting_balances( const std::string account_name_or_id )const;
 
       /**
        * @brief Get the total number of accounts registered with the blockchain
@@ -429,7 +429,7 @@ class database_api
        * @param limit Maximum number of orders to retrieve
        * @return The limit orders, ordered from least price to greatest
        */
-      vector<limit_order_object> get_limit_orders(std::string a, std::string b, uint32_t limit)const;
+      vector<limit_order_api_object> get_limit_orders(std::string a, std::string b, uint32_t limit)const;
 
       /**
        * @brief Fetch all orders relevant to the specified account and specified market, result orders
@@ -454,7 +454,7 @@ class database_api
        *    was just canceled accidentally, in such case, the result orders' price may lower or equal to
        *    @p ostart_price, but orders' id greater than @p ostart_id
        */
-      vector<limit_order_object> get_account_limit_orders( const string& account_name_or_id,
+      vector<limit_order_api_object> get_account_limit_orders( const string& account_name_or_id,
                                     const string &base,
                                     const string &quote,
                                     uint32_t limit = 101,
@@ -467,7 +467,7 @@ class database_api
        * @param limit Maximum number of orders to retrieve
        * @return The call orders, ordered from earliest to be called to latest
        */
-      vector<call_order_object> get_call_orders(const std::string& a, uint32_t limit)const;
+      vector<call_order_api_object> get_call_orders(const std::string& a, uint32_t limit)const;
 
       /**
        * @brief Get call orders (aka margin positions) of a given account
@@ -476,7 +476,7 @@ class database_api
        * @param limit Maximum number of objects to retrieve
        * @return The call orders of the account
        */
-      vector<call_order_object> get_call_orders_by_account(const std::string& account_name_or_id,
+      vector<call_order_api_object> get_call_orders_by_account(const std::string& account_name_or_id,
                                                            asset_id_type start, uint32_t limit)const;
 
       /**
@@ -485,7 +485,7 @@ class database_api
        * @param limit Maximum number of orders to retrieve
        * @return The settle orders, ordered from earliest settlement date to latest
        */
-      vector<force_settlement_object> get_settle_orders(const std::string& a, uint32_t limit)const;
+      vector<force_settlement_api_object> get_settle_orders(const std::string& a, uint32_t limit)const;
 
       /**
        * @brief Get forced settlement orders of a given account
@@ -494,7 +494,7 @@ class database_api
        * @param limit Maximum number of orders to retrieve
        * @return The settle orders of the account
        */
-      vector<force_settlement_object> get_settle_orders_by_account( const std::string& account_name_or_id,
+      vector<force_settlement_api_object> get_settle_orders_by_account( const std::string& account_name_or_id,
                                                                     force_settlement_id_type start,
                                                                     uint32_t limit )const;
 
@@ -505,7 +505,7 @@ class database_api
        * @param start skip that many results
        * @return The settle orders, ordered from earliest settlement date to latest
        */
-      vector<collateral_bid_object> get_collateral_bids(const std::string& a, uint32_t limit, uint32_t start)const;
+      vector<collateral_bid_api_object> get_collateral_bids(const std::string& a, uint32_t limit, uint32_t start)const;
 
       /**
        * @brief Get all open margin positions of a given account
@@ -514,7 +514,7 @@ class database_api
        *
        * Similar to @ref get_call_orders_by_account, but without pagination.
        */
-      vector<call_order_object> get_margin_positions( const std::string account_name_or_id )const;
+      vector<call_order_api_object> get_margin_positions( const std::string account_name_or_id )const;
 
       /**
        * @brief Request notification when the active orders in the market between two assets changes
@@ -854,7 +854,7 @@ class database_api
        *                   (see @ref set_auto_subscription)
        *  @return HTLC object for the id
        */
-      optional<htlc_object> get_htlc( htlc_id_type id, optional<bool> subscribe = optional<bool>() ) const;
+      optional<htlc_api_object> get_htlc( htlc_id_type id, optional<bool> subscribe = optional<bool>() ) const;
 
       /**
        *  @brief Get non expired HTLC objects using the sender account
@@ -863,7 +863,7 @@ class database_api
        *  @param limit Maximum number of objects to retrieve
        *  @return HTLC objects for the account
        */
-      vector<htlc_object> get_htlc_by_from( const std::string account_name_or_id,
+      vector<htlc_api_object> get_htlc_by_from( const std::string account_name_or_id,
                                             htlc_id_type start,
                                             uint32_t limit ) const;
 
@@ -874,7 +874,7 @@ class database_api
        *  @param limit Maximum number of objects to retrieve
        *  @return HTLC objects for the account
       */
-      vector<htlc_object> get_htlc_by_to( const std::string account_name_or_id,
+      vector<htlc_api_object> get_htlc_by_to( const std::string account_name_or_id,
                                           htlc_id_type start,
                                           uint32_t limit ) const;
 
@@ -884,7 +884,7 @@ class database_api
        * @param limit Maximum number of htlc objects to fetch
        * @return The htlc object list
       */
-      vector<htlc_object> list_htlcs(const htlc_id_type start, uint32_t limit) const;
+      vector<htlc_api_object> list_htlcs(const htlc_id_type start, uint32_t limit) const;
 
 
 private:

--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library( graphene_chain
              special_authority_evaluation.cpp
              buyback.cpp
 
+	     stored_value.cpp
              account_object.cpp
              asset_object.cpp
              fba_object.cpp

--- a/libraries/chain/account_object.cpp
+++ b/libraries/chain/account_object.cpp
@@ -377,26 +377,9 @@ FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::account_object,
                     (allowed_assets)
                     )
 
-FC_REFLECT_DERIVED( graphene::chain::account_balance_master,
-                    (graphene::db::object),
-                    (owner)(maintenance_flag) )
-
 FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::account_balance_object,
                     (graphene::chain::account_balance_master),
                     (balance) )
-
-FC_REFLECT_DERIVED( graphene::chain::account_statistics_master,
-                    (graphene::db::object),
-                    (owner)(name)
-                    (most_recent_op)
-                    (total_ops)(removed_ops)
-                    (total_core_in_orders)
-                    (core_in_balance)
-                    (has_cashback_vb)
-                    (is_voting)
-                    (last_vote_time)
-                    (lifetime_fees_paid)
-                  )
 
 FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::account_statistics_object,
                     (graphene::chain::account_statistics_master),

--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -98,8 +98,7 @@ void_result asset_create_evaluator::do_evaluate( const asset_create_operation& o
 
 void asset_create_evaluator::pay_fee()
 {
-   fee_is_odd = core_fee_paid.value & 1;
-   core_fee_paid -= core_fee_paid.value/2;
+   for_pool = core_fee_paid.split( core_fee_paid.get_amount().value/2 );
    generic_evaluator::pay_fee();
 }
 
@@ -107,20 +106,15 @@ object_id_type asset_create_evaluator::do_apply( const asset_create_operation& o
 { try {
    database& d = db();
 
-   bool hf_429 = fee_is_odd && d.head_block_time() > HARDFORK_CORE_429_TIME;
+   if( (core_fee_paid.get_amount().value & 1) && d.head_block_time() <= HARDFORK_CORE_429_TIME )
+      d.modify( d.get_core_dynamic_data(), [this]( asset_dynamic_data_object& dd ) {
+         for_pool += dd.current_supply.issue(1);
+      });
 
    const asset_dynamic_data_object& dyn_asset =
-      d.create<asset_dynamic_data_object>( [hf_429,this]( asset_dynamic_data_object& a ) {
-         a.current_supply = 0;
-         a.fee_pool = core_fee_paid - (hf_429 ? 1 : 0);
+      d.create<asset_dynamic_data_object>( [this]( asset_dynamic_data_object& a ) {
+         a.fee_pool = std::move(for_pool);
       });
-
-   if( fee_is_odd && !hf_429 )
-   {
-      d.modify( d.get_core_dynamic_data(), []( asset_dynamic_data_object& dd ) {
-         dd.current_supply++;
-      });
-   }
 
    asset_bitasset_data_id_type bit_asset_id;
 
@@ -164,18 +158,19 @@ void_result asset_issue_evaluator::do_evaluate( const asset_issue_operation& o )
    FC_ASSERT( is_authorized_asset( d, *to_account, a ) );
 
    asset_dyn_data = &a.dynamic_asset_data_id(d);
-   FC_ASSERT( (asset_dyn_data->current_supply + o.asset_to_issue.amount) <= a.options.max_supply );
+   FC_ASSERT( (asset_dyn_data->current_supply.get_amount() + o.asset_to_issue.amount) <= a.options.max_supply );
 
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (o) ) }
 
 void_result asset_issue_evaluator::do_apply( const asset_issue_operation& o )
 { try {
-   db().adjust_balance( o.issue_to_account, o.asset_to_issue );
-
-   db().modify( *asset_dyn_data, [&o]( asset_dynamic_data_object& data ){
-        data.current_supply += o.asset_to_issue.amount;
+   stored_value transport;
+   db().modify( *asset_dyn_data, [&o,&transport]( asset_dynamic_data_object& data ){
+      transport = data.current_supply.issue( o.asset_to_issue.amount );
    });
+
+   db().add_balance( o.issue_to_account, std::move(transport) );
 
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (o) ) }
@@ -196,17 +191,17 @@ void_result asset_reserve_evaluator::do_evaluate( const asset_reserve_operation&
    FC_ASSERT( is_authorized_asset( d, *from_account, a ) );
 
    asset_dyn_data = &a.dynamic_asset_data_id(d);
-   FC_ASSERT( (asset_dyn_data->current_supply - o.amount_to_reserve.amount) >= 0 );
+   FC_ASSERT( (asset_dyn_data->current_supply.get_amount() - o.amount_to_reserve.amount) >= 0 );
 
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (o) ) }
 
 void_result asset_reserve_evaluator::do_apply( const asset_reserve_operation& o )
 { try {
-   db().adjust_balance( o.payer, -o.amount_to_reserve );
+   stored_value transport = db().reduce_balance( o.payer, o.amount_to_reserve );
 
-   db().modify( *asset_dyn_data, [&o]( asset_dynamic_data_object& data ){
-        data.current_supply -= o.amount_to_reserve.amount;
+   db().modify( *asset_dyn_data, [&transport]( asset_dynamic_data_object& data ){
+        data.current_supply.burn( std::move(transport) );
    });
 
    return void_result();
@@ -225,10 +220,10 @@ void_result asset_fund_fee_pool_evaluator::do_evaluate(const asset_fund_fee_pool
 
 void_result asset_fund_fee_pool_evaluator::do_apply(const asset_fund_fee_pool_operation& o)
 { try {
-   db().adjust_balance(o.from_account, -o.amount);
+   stored_value transport = db().reduce_balance( o.from_account, o.amount );
 
-   db().modify( *asset_dyn_data, [&o]( asset_dynamic_data_object& data ) {
-      data.fee_pool += o.amount;
+   db().modify( *asset_dyn_data, [&transport]( asset_dynamic_data_object& data ) {
+      data.fee_pool += std::move(transport);
    });
 
    return void_result();
@@ -267,7 +262,7 @@ void_result asset_update_evaluator::do_evaluate(const asset_update_operation& o)
       validate_new_issuer( d, a, *o.new_issuer );
    }
 
-   if( a.dynamic_asset_data_id(d).current_supply != 0 )
+   if( a.dynamic_asset_data_id(d).current_supply.get_amount() != 0 )
    {
       // new issuer_permissions must be subset of old issuer permissions
       FC_ASSERT(!(o.new_options.issuer_permissions & ~a.options.issuer_permissions),
@@ -417,7 +412,7 @@ void_result asset_update_bitasset_evaluator::do_evaluate(const asset_update_bita
    // Are we changing the backing asset?
    if( op.new_options.short_backing_asset != current_bitasset_data.options.short_backing_asset )
    {
-      FC_ASSERT( asset_obj.dynamic_asset_data_id(d).current_supply == 0,
+      FC_ASSERT( asset_obj.dynamic_asset_data_id(d).current_supply.get_amount() == 0,
                  "Cannot update a bitasset if there is already a current supply." );
 
       const asset_object& new_backing_asset = op.new_options.short_backing_asset(d); // check if the asset exists
@@ -658,7 +653,8 @@ void_result asset_global_settle_evaluator::do_evaluate(const asset_global_settle
    FC_ASSERT( asset_to_settle->is_market_issued(), "Can only globally settle market-issued assets" );
    FC_ASSERT( asset_to_settle->can_global_settle(), "The global_settle permission of this asset is disabled" );
    FC_ASSERT( asset_to_settle->issuer == op.issuer, "Only asset issuer can globally settle an asset" );
-   FC_ASSERT( asset_to_settle->dynamic_data(d).current_supply > 0, "Can not globally settle an asset with zero supply" );
+   FC_ASSERT( asset_to_settle->dynamic_data(d).current_supply.get_amount() > 0,
+              "Can not globally settle an asset with zero supply" );
 
    const asset_bitasset_data_object& _bitasset_data  = asset_to_settle->bitasset_data(d);
    // if there is a settlement for this asset, then no further global settle may be taken
@@ -710,10 +706,10 @@ operation_result asset_settle_evaluator::do_apply(const asset_settle_evaluator::
       const auto& mia_dyn = asset_to_settle->dynamic_asset_data_id(d);
 
       auto settled_amount = op.amount * bitasset.settlement_price; // round down, in favor of global settlement fund
-      if( op.amount.amount == mia_dyn.current_supply )
-         settled_amount.amount = bitasset.settlement_fund; // avoid rounding problems
+      if( op.amount.amount == mia_dyn.current_supply.get_amount() )
+         settled_amount.amount = bitasset.settlement_fund.get_amount(); // avoid rounding problems
       else
-         FC_ASSERT( settled_amount.amount <= bitasset.settlement_fund ); // should be strictly < except for PM with zero outcome
+         FC_ASSERT( settled_amount.amount <= bitasset.settlement_fund.get_amount() ); // should be strictly < except for PM with zero outcome
 
       if( settled_amount.amount == 0 && !bitasset.is_prediction_market )
       {
@@ -724,37 +720,36 @@ operation_result asset_settle_evaluator::do_apply(const asset_settle_evaluator::
       }
 
       asset pays = op.amount;
-      if( op.amount.amount != mia_dyn.current_supply
+      if( op.amount.amount != mia_dyn.current_supply.get_amount()
             && settled_amount.amount != 0
             && d.get_dynamic_global_properties().next_maintenance_time > HARDFORK_CORE_342_TIME )
       {
          pays = settled_amount.multiply_and_round_up( bitasset.settlement_price );
       }
 
-      d.adjust_balance( op.account, -pays );
+      stored_value transport = d.reduce_balance( op.account, pays );
+      d.modify( mia_dyn, [&transport]( asset_dynamic_data_object& obj ){
+         obj.current_supply.burn( std::move(transport) );
+      });
 
       if( settled_amount.amount > 0 )
       {
-         d.modify( bitasset, [&]( asset_bitasset_data_object& obj ){
-            obj.settlement_fund -= settled_amount.amount;
+         d.modify( bitasset, [&transport,&settled_amount]( asset_bitasset_data_object& obj ){
+            transport = obj.settlement_fund.split( settled_amount.amount );
          });
 
-         d.adjust_balance( op.account, settled_amount );
+         d.add_balance( op.account, std::move(transport) );
       }
-
-      d.modify( mia_dyn, [&]( asset_dynamic_data_object& obj ){
-         obj.current_supply -= pays.amount;
-      });
 
       return settled_amount;
    }
    else
    {
-      d.adjust_balance( op.account, -op.amount );
-      return d.create<force_settlement_object>([&](force_settlement_object& s) {
+      stored_value to_settle = d.reduce_balance( op.account, op.amount );
+      return d.create<force_settlement_object>([&op,&to_settle,this](force_settlement_object& s) {
          s.owner = op.account;
-         s.balance = op.amount;
-         s.settlement_date = d.head_block_time() + asset_to_settle->bitasset_data(d).options.force_settlement_delay_sec;
+         s.balance = std::move(to_settle);
+         s.settlement_date = db().head_block_time() + asset_to_settle->bitasset_data(db()).options.force_settlement_delay_sec;
       }).id;
    }
 } FC_CAPTURE_AND_RETHROW( (op) ) }
@@ -842,23 +837,21 @@ void_result asset_publish_feeds_evaluator::do_apply(const asset_publish_feed_ope
       {
          bool should_revive = false;
          const auto& mia_dyn = base.dynamic_asset_data_id(d);
-         if( mia_dyn.current_supply == 0 ) // if current supply is zero, revive the asset
+         if( mia_dyn.current_supply.get_amount() == 0 ) // if current supply is zero, revive the asset
             should_revive = true;
          else // if current supply is not zero, when collateral ratio of settlement fund is greater than MCR, revive the asset
          {
             if( next_maint_time <= HARDFORK_CORE_1270_TIME )
             {
                // before core-1270 hard fork, calculate call_price and compare to median feed
-               if( ~price::call_price( asset(mia_dyn.current_supply, o.asset_id),
-                                       asset(bad.settlement_fund, bad.options.short_backing_asset),
+               if( ~price::call_price( mia_dyn.current_supply.get_value(), bad.settlement_fund.get_value(),
                                        bad.current_feed.maintenance_collateral_ratio ) < bad.current_feed.settlement_price )
                   should_revive = true;
             }
             else
             {
                // after core-1270 hard fork, calculate collateralization and compare to maintenance_collateralization
-               if( price( asset( bad.settlement_fund, bad.options.short_backing_asset ),
-                          asset( mia_dyn.current_supply, o.asset_id ) ) > bad.current_maintenance_collateralization )
+               if( price( bad.settlement_fund.get_value(), mia_dyn.current_supply.get_value() ) > bad.current_maintenance_collateralization )
                   should_revive = true;
             }
          }
@@ -887,13 +880,15 @@ void_result asset_claim_fees_evaluator::do_apply( const asset_claim_fees_operati
 
    const asset_object& a = o.amount_to_claim.asset_id(d);
    const asset_dynamic_data_object& addo = a.dynamic_asset_data_id(d);
-   FC_ASSERT( o.amount_to_claim.amount <= addo.accumulated_fees, "Attempt to claim more fees than have accumulated", ("addo",addo) );
+   FC_ASSERT( o.amount_to_claim.amount <= addo.accumulated_fees.get_amount(),
+              "Attempt to claim more fees than have accumulated", ("addo",addo) );
 
-   d.modify( addo, [&]( asset_dynamic_data_object& _addo  ) {
-     _addo.accumulated_fees -= o.amount_to_claim.amount;
+   stored_value transport;
+   d.modify( addo, [&transport,&o]( asset_dynamic_data_object& _addo  ) {
+      transport = _addo.accumulated_fees.split( o.amount_to_claim.amount );
    });
 
-   d.adjust_balance( o.issuer, o.amount_to_claim );
+   d.add_balance( o.issuer, std::move(transport) );
 
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (o) ) }
@@ -912,13 +907,15 @@ void_result asset_claim_pool_evaluator::do_apply( const asset_claim_pool_operati
 
     const asset_object& a = o.asset_id(d);
     const asset_dynamic_data_object& addo = a.dynamic_asset_data_id(d);
-    FC_ASSERT( o.amount_to_claim.amount <= addo.fee_pool, "Attempt to claim more fees than is available", ("addo",addo) );
+    FC_ASSERT( o.amount_to_claim.amount <= addo.fee_pool.get_amount(),
+               "Attempt to claim more fees than is available", ("addo",addo) );
 
-    d.modify( addo, [&o]( asset_dynamic_data_object& _addo  ) {
-        _addo.fee_pool -= o.amount_to_claim.amount;
+   stored_value transport;
+    d.modify( addo, [&o,&transport]( asset_dynamic_data_object& _addo  ) {
+        transport = _addo.fee_pool.split( o.amount_to_claim.amount );
     });
 
-    d.adjust_balance( o.issuer, o.amount_to_claim );
+    d.add_balance( o.issuer, std::move(transport) );
 
     return void_result();
 } FC_CAPTURE_AND_RETHROW( (o) ) }

--- a/libraries/chain/asset_object.cpp
+++ b/libraries/chain/asset_object.cpp
@@ -32,7 +32,13 @@ namespace graphene { namespace chain {
 
 class asset_dynamic_data_backup : public asset_dynamic_data_master
 {
-   private:
+      asset current_supply;
+      share_type accumulated_fees;
+      share_type fee_pool;
+      share_type confidential_supply;
+      friend class asset_dynamic_data_object;
+
+   public:
       asset_dynamic_data_backup( const asset_dynamic_data_object& original )
          : asset_dynamic_data_master( original )
       {
@@ -41,11 +47,6 @@ class asset_dynamic_data_backup : public asset_dynamic_data_master
          fee_pool = original.fee_pool.get_amount();
          confidential_supply = original.confidential_supply.get_amount();
       }
-      asset current_supply;
-      share_type accumulated_fees;
-      share_type fee_pool;
-      share_type confidential_supply;
-      friend class asset_dynamic_data_object;
 };
 
 unique_ptr<object> asset_dynamic_data_object::backup()const
@@ -56,7 +57,7 @@ unique_ptr<object> asset_dynamic_data_object::backup()const
 void asset_dynamic_data_object::restore( object& obj )
 {
    const auto& backup = static_cast<asset_dynamic_data_backup&>(obj);
-   current_supply.restore( backup.current_supply ) );
+   current_supply.restore( backup.current_supply );
    accumulated_fees.restore( asset( backup.accumulated_fees, backup.current_supply.asset_id ) );
    fee_pool.restore( asset( backup.fee_pool ) );
    confidential_supply.restore( asset( backup.confidential_supply, backup.current_supply.asset_id ) );
@@ -140,16 +141,17 @@ void graphene::chain::asset_bitasset_data_master::update_median_feeds( time_poin
 
 class asset_bitasset_data_backup : public asset_bitasset_data_master
 {
-   private:
+      share_type settlement_fund;
+      share_type total_debt;
+      friend class asset_bitasset_data_object;
+
+   public:
       asset_bitasset_data_backup( const asset_bitasset_data_object& original )
          : asset_bitasset_data_master( original )
       {
          settlement_fund = original.settlement_fund.get_amount();
          total_debt = original.total_debt.get_amount();
       }
-      share_type settlement_fund;
-      share_type total_debt;
-      friend class asset_bitasset_data_object;
 };
 
 unique_ptr<object> asset_bitasset_data_object::backup()const
@@ -238,12 +240,12 @@ string asset_object::amount_to_string(share_type amount) const
 
 } } // graphene::chain
 
-FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::asset_dynamic_data_master, (graphene::db::object), )
+FC_REFLECT_DERIVED( graphene::chain::asset_dynamic_data_master, (graphene::db::object), )
 FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::asset_dynamic_data_object,
                     (graphene::chain::asset_dynamic_data_master),
                     (current_supply)(accumulated_fees)(fee_pool)(confidential_supply) )
 
-FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::asset_bitasset_data_object, (graphene::db::object),
+FC_REFLECT_DERIVED( graphene::chain::asset_bitasset_data_master, (graphene::db::object),
                     (asset_id)
                     (feeds)
                     (current_feed)
@@ -253,11 +255,17 @@ FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::asset_bitasset_data_object, (gr
                     (force_settled_volume)
                     (is_prediction_market)
                     (settlement_price)
-                    (settlement_fund)
                     (asset_cer_updated)
                     (feed_cer_updated)
                   )
+FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::asset_bitasset_data_object,
+                    (graphene::chain::asset_bitasset_data_master),
+                    (settlement_fund)
+                    (total_debt)
+                  )
 
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::chain::asset_object )
+GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::chain::asset_bitasset_data_master )
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::chain::asset_bitasset_data_object )
+GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::chain::asset_dynamic_data_master )
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::chain::asset_dynamic_data_object )

--- a/libraries/chain/asset_object.cpp
+++ b/libraries/chain/asset_object.cpp
@@ -39,10 +39,12 @@ class asset_dynamic_data_backup : public asset_dynamic_data_master
          current_supply = original.current_supply.get_value();
          accumulated_fees = original.accumulated_fees.get_amount();
          fee_pool = original.fee_pool.get_amount();
+         confidential_supply = original.confidential_supply.get_amount();
       }
       asset current_supply;
       share_type accumulated_fees;
       share_type fee_pool;
+      share_type confidential_supply;
       friend class asset_dynamic_data_object;
 };
 
@@ -57,6 +59,7 @@ void asset_dynamic_data_object::restore( object& obj )
    current_supply.restore( backup.current_supply ) );
    accumulated_fees.restore( asset( backup.accumulated_fees, backup.current_supply.asset_id ) );
    fee_pool.restore( asset( backup.fee_pool ) );
+   confidential_supply.restore( asset( backup.confidential_supply, backup.current_supply.asset_id ) );
    static_cast<asset_dynamic_data_master&>(*this) = std::move( backup );
 }
 
@@ -235,11 +238,10 @@ string asset_object::amount_to_string(share_type amount) const
 
 } } // graphene::chain
 
-FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::asset_dynamic_data_master, (graphene::db::object),
-                    (confidential_supply)(accumulated_fees)(fee_pool) )
+FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::asset_dynamic_data_master, (graphene::db::object), )
 FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::asset_dynamic_data_object,
                     (graphene::chain::asset_dynamic_data_master),
-                    (current_supply) )
+                    (current_supply)(accumulated_fees)(fee_pool)(confidential_supply) )
 
 FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::asset_bitasset_data_object, (graphene::db::object),
                     (asset_id)

--- a/libraries/chain/balance_evaluator.cpp
+++ b/libraries/chain/balance_evaluator.cpp
@@ -49,7 +49,7 @@ void_result balance_claim_evaluator::do_evaluate(const balance_claim_operation& 
    {
       GRAPHENE_ASSERT(
          balance->vesting_policy->is_withdraw_allowed(
-            { balance->balance,
+            { balance->balance.get_value(),
               d.head_block_time(),
               op.total_claimed } ),
          balance_claim_invalid_claim_amount,
@@ -64,7 +64,7 @@ void_result balance_claim_evaluator::do_evaluate(const balance_claim_operation& 
       return {};
    }
 
-   FC_ASSERT(op.total_claimed == balance->balance);
+   FC_ASSERT( op.total_claimed.amount == balance->balance.get_amount() );
    return {};
 }
 
@@ -76,16 +76,16 @@ void_result balance_claim_evaluator::do_apply(const balance_claim_operation& op)
 {
    database& d = db();
 
-   if( balance->is_vesting_balance() && op.total_claimed < balance->balance )
-      d.modify(*balance, [&](balance_object& b) {
-         b.vesting_policy->on_withdraw({b.balance, d.head_block_time(), op.total_claimed});
-         b.balance -= op.total_claimed;
-         b.last_claim_date = d.head_block_time();
-      });
-   else
+   stored_value claim;
+   d.modify(*balance, [&claim,&d,&op](balance_object& b) {
+      b.vesting_policy->on_withdraw({b.balance.get_value(), d.head_block_time(), op.total_claimed});
+      claim = b.balance.split( op.total_claimed.amount );
+      b.last_claim_date = d.head_block_time();
+   });
+   if( balance->balance.get_amount() == 0 )
       d.remove(*balance);
 
-   d.adjust_balance(op.deposit_to_account, op.total_claimed);
+   d.add_balance( op.deposit_to_account, std::move(claim) );
    return {};
 }
 } } // namespace graphene::chain

--- a/libraries/chain/confidential_evaluator.cpp
+++ b/libraries/chain/confidential_evaluator.cpp
@@ -116,7 +116,6 @@ void_result transfer_from_blind_evaluator::do_apply( const transfer_from_blind_o
 
 void transfer_from_blind_evaluator::prepare_fee(account_id_type account_id, asset fee)
 {
-   const database& d = db();
    FC_ASSERT( fee.amount >= 0 );
 
    tmp_fee = stored_debt(fee.asset_id);                       // account_id borrows the fee temporarily,
@@ -136,8 +135,8 @@ void transfer_from_blind_evaluator::pay_fee()
 void_result blind_transfer_evaluator::do_evaluate( const blind_transfer_operation& o )
 { try {
    const auto& d = db();
-   o.fee.asset_id(db());  // verify fee is a legit asset 
-   const auto& bbi = db().get_index_type<blinded_balance_index>();
+   o.fee.asset_id(d);  // verify fee is a legit asset 
+   const auto& bbi = d.get_index_type<blinded_balance_index>();
    const auto& cidx = bbi.indices().get<by_commitment>();
    for( const auto& out : o.outputs )
    {
@@ -182,7 +181,6 @@ void_result blind_transfer_evaluator::do_apply( const blind_transfer_operation& 
 
 void blind_transfer_evaluator::prepare_fee(account_id_type account_id, asset fee)
 {
-   const database& d = db();
    FC_ASSERT( fee.amount >= 0 );
 
    tmp_fee = stored_debt(fee.asset_id);                       // account_id borrows the fee temporarily,

--- a/libraries/chain/db_balance.cpp
+++ b/libraries/chain/db_balance.cpp
@@ -60,17 +60,17 @@ void database::add_balance(account_id_type account, stored_value&& what )
    auto& index = get_index_type< primary_index< account_balance_index > >().get_secondary_index<balances_by_account_index>();
    auto abo = index.get_account_balance( account, what.get_asset() );
    if( !abo )
-      create<account_balance_object>([account,delta = std::move(what)](account_balance_object& b) mutable {
+      create<account_balance_object>([account,&what](account_balance_object& b) {
          b.owner = account;
-         b.balance = std::move(delta);
+         b.balance = std::move(what);
          if( b.balance.get_asset() == asset_id_type() ) // CORE asset
             b.maintenance_flag = true;
       });
    else
-      modify(*abo, [delta = std::move(what)] (account_balance_object& b) mutable {
+      modify(*abo, [&what] (account_balance_object& b) {
          if( b.balance.get_asset() == asset_id_type() ) // CORE asset
             b.maintenance_flag = true;
-         b.balance += std::move(delta);
+         b.balance += std::move(what);
       });
 } FC_CAPTURE_AND_RETHROW( (account)(what) ) }
 
@@ -117,7 +117,7 @@ namespace detail {
       bool operator()(const vbo_mfs_key& k, const vesting_balance_object& vbo)const
       {
          return ( vbo.balance_type == vesting_balance_type::market_fee_sharing ) &&
-                  ( k.asset_id == vbo.balance.asset_id ) &&
+                  ( k.asset_id == vbo.balance.get_asset() ) &&
                   ( k.account_id == vbo.owner );
       }
 
@@ -138,18 +138,18 @@ asset database::get_market_fee_vesting_balance(const account_id_type &account_id
    {
       return asset(0, asset_id);
    }
-   return vbo_it->balance;
+   return vbo_it->balance.get_value();
 }
 
-void database::deposit_market_fee_vesting_balance(const account_id_type &account_id, const asset &delta)
+void database::deposit_market_fee_vesting_balance(const account_id_type &account_id, stored_value&& delta)
 { try {
-   FC_ASSERT( delta.amount >= 0, "Invalid negative value for balance");
+   FC_ASSERT( delta.get_amount() >= 0, "Invalid negative value for balance");
 
-   if( delta.amount == 0 )
+   if( delta.get_amount() == 0 )
       return;
 
    auto& vesting_balances = get_index_type<vesting_balance_index>().indices().get<by_vesting_type>();
-   const auto& key = detail::vbo_mfs_key{account_id, delta.asset_id};
+   const auto& key = detail::vbo_mfs_key{account_id, delta.get_asset()};
    auto vbo_it = vesting_balances.find(key, key, key);
 
    auto block_time = head_block_time();
@@ -158,26 +158,26 @@ void database::deposit_market_fee_vesting_balance(const account_id_type &account
    {
       create<vesting_balance_object>([&account_id, &delta](vesting_balance_object &vbo) {
          vbo.owner = account_id;
-         vbo.balance = delta;
+         vbo.balance = std::move(delta);
          vbo.balance_type = vesting_balance_type::market_fee_sharing;
          vbo.policy = instant_vesting_policy{};
       });
    } else {
       modify( *vbo_it, [&block_time, &delta]( vesting_balance_object& vbo )
       {
-         vbo.deposit_vested(block_time, delta);
+         vbo.deposit_vested(block_time, std::move(delta));
       });
    }
 } FC_CAPTURE_AND_RETHROW( (account_id)(delta) ) }
 
 optional< vesting_balance_id_type > database::deposit_lazy_vesting(
    const optional< vesting_balance_id_type >& ovbid,
-   share_type amount, uint32_t req_vesting_seconds,
+   stored_value&& amount, uint32_t req_vesting_seconds,
    vesting_balance_type balance_type,
    account_id_type req_owner,
    bool require_vesting )
 {
-   if( amount == 0 )
+   if( amount.get_amount() == 0 )
       return optional< vesting_balance_id_type >();
 
    fc::time_point_sec now = head_block_time();
@@ -193,25 +193,26 @@ optional< vesting_balance_id_type > database::deposit_lazy_vesting(
          break;
       if( vbo.policy.get< cdd_vesting_policy >().vesting_seconds != req_vesting_seconds )
          break;
-      modify( vbo, [&]( vesting_balance_object& _vbo )
+      modify( vbo, [require_vesting,now,&amount]( vesting_balance_object& _vbo )
       {
          if( require_vesting )
-            _vbo.deposit(now, amount);
+            _vbo.deposit(now, std::move(amount) );
          else
-            _vbo.deposit_vested(now, amount);
+            _vbo.deposit_vested(now, std::move(amount) );
       } );
       return optional< vesting_balance_id_type >();
    }
 
-   const vesting_balance_object& vbo = create< vesting_balance_object >( [&]( vesting_balance_object& _vbo )
+   const vesting_balance_object& vbo = create< vesting_balance_object >(
+      [req_owner,&amount,balance_type,req_vesting_seconds,now,require_vesting]( vesting_balance_object& _vbo )
    {
       _vbo.owner = req_owner;
-      _vbo.balance = amount;
+      _vbo.balance = std::move(amount);
       _vbo.balance_type = balance_type;
 
       cdd_vesting_policy policy;
       policy.vesting_seconds = req_vesting_seconds;
-      policy.coin_seconds_earned = require_vesting ? 0 : amount.value * policy.vesting_seconds;
+      policy.coin_seconds_earned = require_vesting ? 0 : _vbo.balance.get_amount().value * policy.vesting_seconds;
       policy.coin_seconds_earned_last_update = now;
 
       _vbo.policy = policy;
@@ -220,12 +221,12 @@ optional< vesting_balance_id_type > database::deposit_lazy_vesting(
    return vbo.id;
 }
 
-void database::deposit_cashback(const account_object& acct, share_type amount, bool require_vesting)
+void database::deposit_cashback(const account_object& acct, stored_value&& amount, bool require_vesting)
 {
    // If we don't have a VBO, or if it has the wrong maturity
    // due to a policy change, cut it loose.
 
-   if( amount == 0 )
+   if( amount.get_amount() == 0 )
       return;
 
    if( acct.get_id() == GRAPHENE_COMMITTEE_ACCOUNT || acct.get_id() == GRAPHENE_WITNESS_ACCOUNT ||
@@ -233,15 +234,15 @@ void database::deposit_cashback(const account_object& acct, share_type amount, b
        acct.get_id() == GRAPHENE_TEMP_ACCOUNT )
    {
       // The blockchain's accounts do not get cashback; it simply goes to the reserve pool.
-      modify( get_core_dynamic_data(), [amount](asset_dynamic_data_object& d) {
-         d.current_supply -= amount;
+      modify( get_core_dynamic_data(), [&amount](asset_dynamic_data_object& d) {
+         d.current_supply.burn( std::move(amount) );
       });
       return;
    }
 
    optional< vesting_balance_id_type > new_vbid = deposit_lazy_vesting(
       acct.cashback_vb,
-      amount,
+      std::move(amount),
       get_global_properties().parameters.cashback_vesting_period_seconds,
       vesting_balance_type::cashback,
       acct.id,
@@ -262,14 +263,14 @@ void database::deposit_cashback(const account_object& acct, share_type amount, b
    return;
 }
 
-void database::deposit_witness_pay(const witness_object& wit, share_type amount)
+void database::deposit_witness_pay(const witness_object& wit, stored_value&& amount)
 {
-   if( amount == 0 )
+   if( amount.get_amount() == 0 )
       return;
 
    optional< vesting_balance_id_type > new_vbid = deposit_lazy_vesting(
       wit.pay_vb,
-      amount,
+      std::move(amount),
       get_global_properties().parameters.witness_pay_vesting_seconds,
       vesting_balance_type::witness,
       wit.witness_account,
@@ -277,7 +278,7 @@ void database::deposit_witness_pay(const witness_object& wit, share_type amount)
 
    if( new_vbid.valid() )
    {
-      modify( wit, [&]( witness_object& _wit )
+      modify( wit, [&new_vbid]( witness_object& _wit )
       {
          _wit.pay_vb = *new_vbid;
       } );

--- a/libraries/chain/db_debug.cpp
+++ b/libraries/chain/db_debug.cpp
@@ -68,7 +68,7 @@ void database::debug_dump()
       reported_core_in_orders += s.total_core_in_orders;
    }
    for( const collateral_bid_object& b : bids )
-      total_balances[b.inv_swan_price.base.asset_id] += b.inv_swan_price.base.amount;
+      total_balances[b.collateral_offered.get_asset()] += b.collateral_offered.get_amount();
    for( const limit_order_object& o : db.get_index_type<limit_order_index>().indices() )
    {
       auto for_sale = o.amount_for_sale();

--- a/libraries/chain/db_debug.cpp
+++ b/libraries/chain/db_debug.cpp
@@ -57,7 +57,7 @@ void database::debug_dump()
    }
    for( const force_settlement_object& s : settle_index )
    {
-      total_balances[s.balance.asset_id] += s.balance.amount;
+      total_balances[s.balance.get_asset()] += s.balance.get_amount();
    }
    for( const vesting_balance_object& vbo : db.get_index_type< vesting_balance_index >().indices() )
       total_balances[ vbo.balance.get_asset() ] += vbo.balance.get_amount();

--- a/libraries/chain/db_debug.cpp
+++ b/libraries/chain/db_debug.cpp
@@ -60,7 +60,7 @@ void database::debug_dump()
       total_balances[s.balance.asset_id] += s.balance.amount;
    }
    for( const vesting_balance_object& vbo : db.get_index_type< vesting_balance_index >().indices() )
-      total_balances[ vbo.balance.asset_id ] += vbo.balance.amount;
+      total_balances[ vbo.balance.get_asset() ] += vbo.balance.get_amount();
    for( const fba_accumulator_object& fba : db.get_index_type< simple_index< fba_accumulator_object > >() )
       total_balances[ asset_id_type() ] += fba.accumulated_fba_fees.get_amount();
    for( const account_statistics_object& s : statistics_index )
@@ -84,15 +84,15 @@ void database::debug_dump()
    }
    for( const asset_object& asset_obj : db.get_index_type<asset_index>().indices() )
    {
-      total_balances[asset_obj.id] += asset_obj.dynamic_asset_data_id(db).accumulated_fees;
-      total_balances[asset_id_type()] += asset_obj.dynamic_asset_data_id(db).fee_pool;
+      total_balances[asset_obj.id] += asset_obj.dynamic_asset_data_id(db).accumulated_fees.get_amount();
+      total_balances[asset_id_type()] += asset_obj.dynamic_asset_data_id(db).fee_pool.get_amount();
    }
 
-   if( total_balances[asset_id_type()].value != core_asset_data.current_supply.value )
+   if( total_balances[asset_id_type()].value != core_asset_data.current_supply.get_amount() )
    {
       FC_THROW( "computed balance of CORE mismatch",
                 ("computed value",total_balances[asset_id_type()].value)
-                ("current supply",core_asset_data.current_supply.value) );
+                ("current supply",core_asset_data.current_supply.get_amount()) );
    }
 }
 

--- a/libraries/chain/db_debug.cpp
+++ b/libraries/chain/db_debug.cpp
@@ -53,8 +53,7 @@ void database::debug_dump()
 
    for( const account_balance_object& a : balance_index )
    {
-    //  idump(("balance")(a));
-      total_balances[a.asset_type] += a.balance;
+      total_balances[a.get_asset()] += a.get_amount();
    }
    for( const force_settlement_object& s : settle_index )
    {
@@ -63,24 +62,21 @@ void database::debug_dump()
    for( const vesting_balance_object& vbo : db.get_index_type< vesting_balance_index >().indices() )
       total_balances[ vbo.balance.asset_id ] += vbo.balance.amount;
    for( const fba_accumulator_object& fba : db.get_index_type< simple_index< fba_accumulator_object > >() )
-      total_balances[ asset_id_type() ] += fba.accumulated_fba_fees;
+      total_balances[ asset_id_type() ] += fba.accumulated_fba_fees.get_amount();
    for( const account_statistics_object& s : statistics_index )
    {
-    //  idump(("statistics")(s));
       reported_core_in_orders += s.total_core_in_orders;
    }
    for( const collateral_bid_object& b : bids )
       total_balances[b.inv_swan_price.base.asset_id] += b.inv_swan_price.base.amount;
    for( const limit_order_object& o : db.get_index_type<limit_order_index>().indices() )
    {
- //     idump(("limit_order")(o));
       auto for_sale = o.amount_for_sale();
       if( for_sale.asset_id == asset_id_type() ) core_in_orders += for_sale.amount;
       total_balances[for_sale.asset_id] += for_sale.amount;
    }
    for( const call_order_object& o : db.get_index_type<call_order_index>().indices() )
    {
-//      idump(("call_order")(o));
       auto col = o.get_collateral();
       if( col.asset_id == asset_id_type() ) core_in_orders += col.amount;
       total_balances[col.asset_id] += col.amount;
@@ -90,7 +86,6 @@ void database::debug_dump()
    {
       total_balances[asset_obj.id] += asset_obj.dynamic_asset_data_id(db).accumulated_fees;
       total_balances[asset_id_type()] += asset_obj.dynamic_asset_data_id(db).fee_pool;
-//      edump((total_balances[asset_obj.id])(asset_obj.dynamic_asset_data_id(db).current_supply ) );
    }
 
    if( total_balances[asset_id_type()].value != core_asset_data.current_supply.value )
@@ -99,15 +94,6 @@ void database::debug_dump()
                 ("computed value",total_balances[asset_id_type()].value)
                 ("current supply",core_asset_data.current_supply.value) );
    }
-
-
-   /*
-   const auto& vbidx = db.get_index_type<simple_index<vesting_balance_object>>();
-   for( const auto& s : vbidx )
-   {
-//      idump(("vesting_balance")(s));
-   }
-   */
 }
 
 void debug_apply_update( database& db, const fc::variant_object& vo )

--- a/libraries/chain/db_init.cpp
+++ b/libraries/chain/db_init.cpp
@@ -191,7 +191,7 @@ void database::init_genesis(const genesis_state_type& genesis_state)
    // Create blockchain accounts
    fc::ecc::private_key null_private_key = fc::ecc::private_key::regenerate(fc::sha256::hash(string("null_key")));
    create<account_balance_object>([](account_balance_object& b) {
-      b.balance = GRAPHENE_MAX_SHARE_SUPPLY;
+      b.balance = stored_value::issue( asset_id_type(), GRAPHENE_MAX_SHARE_SUPPLY );
    });
    const account_object& committee_account =
       create<account_object>( [&](account_object& n) {
@@ -530,7 +530,7 @@ void database::init_genesis(const genesis_state_type& genesis_state)
 
    if( total_supplies[ asset_id_type(0) ] > 0 )
    {
-       adjust_balance(GRAPHENE_COMMITTEE_ACCOUNT, -get_balance(GRAPHENE_COMMITTEE_ACCOUNT,{}));
+       reduce_balance( GRAPHENE_COMMITTEE_ACCOUNT, -get_balance(GRAPHENE_COMMITTEE_ACCOUNT,{}) ).burn();
    }
    else
    {
@@ -636,28 +636,25 @@ void database::init_genesis(const genesis_state_type& genesis_state)
    });
 
    // Create FBA counters
-   create<fba_accumulator_object>([&]( fba_accumulator_object& acc )
+   create<fba_accumulator_object>([]( fba_accumulator_object& acc )
    {
       FC_ASSERT( acc.id == fba_accumulator_id_type( fba_accumulator_id_transfer_to_blind ) );
-      acc.accumulated_fba_fees = 0;
 #ifdef GRAPHENE_FBA_STEALTH_DESIGNATED_ASSET
       acc.designated_asset = GRAPHENE_FBA_STEALTH_DESIGNATED_ASSET;
 #endif
    });
 
-   create<fba_accumulator_object>([&]( fba_accumulator_object& acc )
+   create<fba_accumulator_object>([]( fba_accumulator_object& acc )
    {
       FC_ASSERT( acc.id == fba_accumulator_id_type( fba_accumulator_id_blind_transfer ) );
-      acc.accumulated_fba_fees = 0;
 #ifdef GRAPHENE_FBA_STEALTH_DESIGNATED_ASSET
       acc.designated_asset = GRAPHENE_FBA_STEALTH_DESIGNATED_ASSET;
 #endif
    });
 
-   create<fba_accumulator_object>([&]( fba_accumulator_object& acc )
+   create<fba_accumulator_object>([]( fba_accumulator_object& acc )
    {
       FC_ASSERT( acc.id == fba_accumulator_id_type( fba_accumulator_id_transfer_from_blind ) );
-      acc.accumulated_fba_fees = 0;
 #ifdef GRAPHENE_FBA_STEALTH_DESIGNATED_ASSET
       acc.designated_asset = GRAPHENE_FBA_STEALTH_DESIGNATED_ASSET;
 #endif

--- a/libraries/chain/db_market.cpp
+++ b/libraries/chain/db_market.cpp
@@ -156,45 +156,54 @@ void database::_cancel_bids_and_revive_mpa( const asset_object& bitasset, const 
 
 void database::cancel_bid(const collateral_bid_object& bid, bool create_virtual_op)
 {
-   adjust_balance(bid.bidder, bid.inv_swan_price.base);
-
+   stored_value collateral;
+   modify( bid, [&collateral] ( collateral_bid_object& _bid ) {
+      collateral = std::move(_bid.collateral_offered);
+   });
    if( create_virtual_op )
    {
       bid_collateral_operation vop;
       vop.bidder = bid.bidder;
-      vop.additional_collateral = bid.inv_swan_price.base;
-      vop.debt_covered = asset( 0, bid.inv_swan_price.quote.asset_id );
+      vop.additional_collateral = collateral.get_value();
+      vop.debt_covered = asset( 0, bid.debt_covered.asset_id() );
       push_applied_operation( vop );
    }
+   add_balance( bid.bidder, std::move(collateral) );
    remove(bid);
 }
 
-void database::execute_bid( const collateral_bid_object& bid, share_type debt_covered, share_type collateral_from_fund,
-                            const price_feed& current_feed )
+void database::execute_bid( const collateral_bid_object& bid, share_type debt_covered,
+                            stored_value&& collateral_from_fund, const price_feed& current_feed )
 {
-   const call_order_object& call_obj = create<call_order_object>( [&](call_order_object& call ){
+   stored_value collateral;
+   modify( bid, [&collateral] ( collateral_bid_object& _bid ) {
+      collateral = std::move(_bid.collateral_offered);
+   });
+   const auto& call_obj = create<call_order_object>(
+      [&bid,&collateral,debt_covered,&current_feed] ( call_order_object& call ) {
          call.borrower = bid.bidder;
-         call.collateral = bid.inv_swan_price.base.amount + collateral_from_fund;
+         call.collateral = std::move(collateral);
+         call.collateral += std::move(collateral_from_fund);
          call.debt = debt_covered;
          // don't calculate call_price after core-1270 hard fork
          if( get_dynamic_global_properties().next_maintenance_time > HARDFORK_CORE_1270_TIME )
             // bid.inv_swan_price is in collateral / debt
-            call.call_price = price( asset( 1, bid.inv_swan_price.base.asset_id ),
-                                     asset( 1, bid.inv_swan_price.quote.asset_id ) );
+            call.call_price = price( asset( 1, bid.collateral_offered.get_asset() ),
+                                     asset( 1, bid.debt_covered.asset_id ) );
          else
-            call.call_price = price::call_price( asset(debt_covered, bid.inv_swan_price.quote.asset_id),
-                                                 asset(call.collateral, bid.inv_swan_price.base.asset_id),
+            call.call_price = price::call_price( asset( debt_covered, bid.debt_covered.asset_id),
+                                                 call.collateral.get_value(),
                                                  current_feed.maintenance_collateral_ratio );
       });
 
    // Note: CORE asset in collateral_bid_object is not counted in account_stats.total_core_in_orders
-   if( bid.inv_swan_price.base.asset_id == asset_id_type() )
-      modify( get_account_stats_by_owner(bid.bidder), [&](account_statistics_object& stats) {
-         stats.total_core_in_orders += call_obj.collateral;
+   if( collateral.get_asset() == asset_id_type() )
+      modify( get_account_stats_by_owner(bid.bidder), [&call_obj] ( account_statistics_object& stats ) {
+         stats.total_core_in_orders += call_obj.collateral.get_amount();
       });
 
-   push_applied_operation( execute_bid_operation( bid.bidder, asset( call_obj.collateral, bid.inv_swan_price.base.asset_id ),
-                                                  asset( debt_covered, bid.inv_swan_price.quote.asset_id ) ) );
+   push_applied_operation( execute_bid_operation( bid.bidder, call_obj.collateral.get_value(),
+                                                  asset( debt_covered, bid.debt_covered.asset_id ) ) );
 
    remove(bid);
 }

--- a/libraries/chain/evaluator.cpp
+++ b/libraries/chain/evaluator.cpp
@@ -83,7 +83,9 @@ database& generic_evaluator::db()const { return trx_state->db(); }
 
    void generic_evaluator::convert_fee()
    {
-      if( !trx_state->skip_fee && fee_asset->get_id() != asset_id_type() )
+      if( fee_asset->get_id() == asset_id_type() )
+         core_fee_paid = std::move(fee_from_account);
+      else if( !trx_state->skip_fee )
          db().modify(*fee_asset_dyn_data, [this](asset_dynamic_data_object& d) {
             d.accumulated_fees += std::move(fee_from_account);
             core_fee_paid = d.fee_pool.split( fee_from_pool );

--- a/libraries/chain/fba_object.cpp
+++ b/libraries/chain/fba_object.cpp
@@ -102,14 +102,15 @@ bool fba_accumulator_master::is_configured( const database& db )const
 
 class fba_accumulator_backup : public fba_accumulator_master
 {
-   private:
+      share_type accumulated_fba_fees;
+      friend class fba_accumulator_object;
+
+   public:
       fba_accumulator_backup( const fba_accumulator_object& original )
          : fba_accumulator_master( original )
       {
          accumulated_fba_fees = original.accumulated_fba_fees.get_amount();
       }
-      share_type accumulated_fba_fees;
-      friend class fba_accumulator_object;
 };
 
 unique_ptr<object> fba_accumulator_object::backup()const
@@ -120,15 +121,16 @@ unique_ptr<object> fba_accumulator_object::backup()const
 void fba_accumulator_object::restore( object& obj )
 {
    const auto& backup = static_cast<fba_accumulator_backup&>(obj);
-   accumulated_fba_fees.restore( asset( asset_id_type(), backup.accumulated_fba_fees ) );
+   accumulated_fba_fees.restore( asset( backup.accumulated_fba_fees ) );
    static_cast<fba_accumulator_master&>(*this) = std::move( backup );
 }
 
 } }
 
-FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::fba_accumulator_master, (graphene::db::object),
+FC_REFLECT_DERIVED( graphene::chain::fba_accumulator_master, (graphene::db::object),
                                 (designated_asset) )
 FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::fba_accumulator_object, (graphene::chain::fba_accumulator_master),
                                 (accumulated_fba_fees) )
 
+GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::chain::fba_accumulator_master )
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::chain::fba_accumulator_object )

--- a/libraries/chain/fba_object.cpp
+++ b/libraries/chain/fba_object.cpp
@@ -28,7 +28,7 @@
 
 namespace graphene { namespace chain {
 
-bool fba_accumulator_object::is_configured( const database& db )const
+bool fba_accumulator_master::is_configured( const database& db )const
 {
    if( !designated_asset.valid() )
    {
@@ -100,4 +100,35 @@ bool fba_accumulator_object::is_configured( const database& db )const
    return true;
 }
 
+class fba_accumulator_backup : public fba_accumulator_master
+{
+   private:
+      fba_accumulator_backup( const fba_accumulator_object& original )
+         : fba_accumulator_master( original )
+      {
+         accumulated_fba_fees = original.accumulated_fba_fees.get_amount();
+      }
+      share_type accumulated_fba_fees;
+      friend class fba_accumulator_object;
+};
+
+unique_ptr<object> fba_accumulator_object::backup()const
+{
+   return std::make_unique<fba_accumulator_backup>( *this );
+}
+
+void fba_accumulator_object::restore( object& obj )
+{
+   const auto& backup = static_cast<fba_accumulator_backup&>(obj);
+   accumulated_fba_fees.restore( asset( asset_id_type(), backup.accumulated_fba_fees ) );
+   static_cast<fba_accumulator_master&>(*this) = std::move( backup );
+}
+
 } }
+
+FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::fba_accumulator_master, (graphene::db::object),
+                                (designated_asset) )
+FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::fba_accumulator_object, (graphene::chain::fba_accumulator_master),
+                                (accumulated_fba_fees) )
+
+GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::chain::fba_accumulator_object )

--- a/libraries/chain/include/graphene/chain/account_object.hpp
+++ b/libraries/chain/include/graphene/chain/account_object.hpp
@@ -452,6 +452,23 @@ MAP_OBJECT_ID_TO_TYPE(graphene::chain::account_object)
 MAP_OBJECT_ID_TO_TYPE(graphene::chain::account_balance_object)
 MAP_OBJECT_ID_TO_TYPE(graphene::chain::account_statistics_object)
 
+FC_REFLECT_DERIVED( graphene::chain::account_balance_master,
+                    (graphene::db::object),
+                    (owner)(maintenance_flag) )
+
+FC_REFLECT_DERIVED( graphene::chain::account_statistics_master,
+                    (graphene::db::object),
+                    (owner)(name)
+                    (most_recent_op)
+                    (total_ops)(removed_ops)
+                    (total_core_in_orders)
+                    (core_in_balance)
+                    (has_cashback_vb)
+                    (is_voting)
+                    (last_vote_time)
+                    (lifetime_fees_paid)
+                  )
+
 FC_REFLECT_TYPENAME( graphene::chain::account_object )
 FC_REFLECT_TYPENAME( graphene::chain::account_balance_object )
 FC_REFLECT_TYPENAME( graphene::chain::account_statistics_object )

--- a/libraries/chain/include/graphene/chain/account_object.hpp
+++ b/libraries/chain/include/graphene/chain/account_object.hpp
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <graphene/chain/types.hpp>
+#include <graphene/chain/stored_value.hpp>
 #include <graphene/db/generic_index.hpp>
 #include <graphene/protocol/account.hpp>
 
@@ -43,7 +44,7 @@ namespace graphene { namespace chain {
     * separating the account data that changes frequently from the account data that is mostly static, which will
     * minimize the amount of data that must be backed up as part of the undo history everytime a transfer is made.
     */
-   class account_statistics_object : public graphene::db::abstract_object<account_statistics_object>
+   class account_statistics_master : public graphene::db::abstract_object<account_statistics_master>
    {
       public:
          static constexpr uint8_t space_id = implementation_ids;
@@ -87,7 +88,11 @@ namespace graphene { namespace chain {
           * Tracks the total fees paid by this account for the purpose of calculating bulk discounts.
           */
          share_type lifetime_fees_paid;
+   };
 
+   class account_statistics_object : public account_statistics_master
+   {
+      public:
          /**
           * Tracks the fees paid by this account which have not been disseminated to the various parties that receive
           * them yet (registrar, referrer, lifetime referrer, network, etc). This is used as an optimization to avoid
@@ -96,15 +101,17 @@ namespace graphene { namespace chain {
           * These fees will be paid out as vesting cash-back, and this counter will reset during the maintenance
           * interval.
           */
-         share_type pending_fees;
+         stored_value pending_fees;
          /**
           * Same as @ref pending_fees, except these fees will be paid out as pre-vested cash-back (immediately
           * available for withdrawal) rather than requiring the normal vesting period.
           */
-         share_type pending_vested_fees;
+         stored_value pending_vested_fees;
 
          /// Whether this account has pending fees, no matter vested or not
-         inline bool has_pending_fees() const { return pending_fees > 0 || pending_vested_fees > 0; }
+         inline bool has_pending_fees() const {
+            return pending_fees.get_amount() > 0 || pending_vested_fees.get_amount() > 0;
+         }
 
          /// Whether need to process this account during the maintenance interval
          inline bool need_maintenance() const { return has_some_core_voting() || has_pending_fees(); }
@@ -115,7 +122,11 @@ namespace graphene { namespace chain {
          /**
           * Core fees are paid into the account_statistics_object by this method
           */
-         void pay_fee( share_type core_fee, share_type cashback_vesting_threshold );
+         void pay_fee( stored_value&& core_fee, share_type cashback_vesting_threshold );
+
+      protected:
+         virtual unique_ptr<graphene::db::object> backup()const;
+         virtual void restore( graphene::db::object& obj );
    };
 
    /**
@@ -125,21 +136,31 @@ namespace graphene { namespace chain {
     * This object is indexed on owner and asset_type so that black swan
     * events in asset_type can be processed quickly.
     */
-   class account_balance_object : public abstract_object<account_balance_object>
+   class account_balance_master : public abstract_object<account_balance_master>
    {
       public:
          static constexpr uint8_t space_id = implementation_ids;
          static constexpr uint8_t type_id  = impl_account_balance_object_type;
 
          account_id_type   owner;
-         asset_id_type     asset_type;
-         share_type        balance;
          bool              maintenance_flag = false; ///< Whether need to process this balance object in maintenance interval
-
-         asset get_balance()const { return asset(balance, asset_type); }
-         void  adjust_balance(const asset& delta);
    };
 
+   class account_balance_object : public account_balance_master
+   {
+      public:
+         stored_value      balance;
+
+         asset get_balance()const { return balance.get_value(); }
+         asset_id_type get_asset()const { return balance.get_asset(); }
+         share_type get_amount()const { return balance.get_amount(); }
+         void add_balance( stored_value&& delta );
+         stored_value reduce_balance( share_type delta );
+
+      protected:
+         virtual unique_ptr<graphene::db::object> backup()const;
+         virtual void restore( graphene::db::object& obj );
+   };
 
    /**
     * @brief This class represents an account on the object graph
@@ -358,13 +379,13 @@ namespace graphene { namespace chain {
       indexed_by<
          ordered_unique< tag<by_id>, member< object, object_id_type, &object::id > >,
          ordered_non_unique< tag<by_maintenance_flag>,
-                             member< account_balance_object, bool, &account_balance_object::maintenance_flag > >,
+                             member< account_balance_master, bool, &account_balance_master::maintenance_flag > >,
          ordered_unique< tag<by_asset_balance>,
             composite_key<
                account_balance_object,
-               member<account_balance_object, asset_id_type, &account_balance_object::asset_type>,
-               member<account_balance_object, share_type, &account_balance_object::balance>,
-               member<account_balance_object, account_id_type, &account_balance_object::owner>
+               const_mem_fun<account_balance_object, asset_id_type, &account_balance_object::get_asset>,
+               const_mem_fun<account_balance_object, share_type, &account_balance_object::get_amount>,
+               member<account_balance_master, account_id_type, &account_balance_master::owner>
             >,
             composite_key_compare<
                std::less< asset_id_type >,
@@ -409,12 +430,12 @@ namespace graphene { namespace chain {
       indexed_by<
          ordered_unique< tag<by_id>, member< object, object_id_type, &object::id > >,
          ordered_unique< tag<by_owner>,
-                         member< account_statistics_object, account_id_type, &account_statistics_object::owner > >,
+                         member< account_statistics_master, account_id_type, &account_statistics_master::owner > >,
          ordered_unique< tag<by_maintenance_seq>,
             composite_key<
                account_statistics_object,
                const_mem_fun<account_statistics_object, bool, &account_statistics_object::need_maintenance>,
-               member<account_statistics_object, string, &account_statistics_object::name>
+               member<account_statistics_master, string, &account_statistics_master::name>
             >
          >
       >
@@ -436,5 +457,7 @@ FC_REFLECT_TYPENAME( graphene::chain::account_balance_object )
 FC_REFLECT_TYPENAME( graphene::chain::account_statistics_object )
 
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::account_object )
+GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::account_balance_master )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::account_balance_object )
+GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::account_statistics_master )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::account_statistics_object )

--- a/libraries/chain/include/graphene/chain/asset_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/asset_evaluator.hpp
@@ -44,7 +44,7 @@ namespace graphene { namespace chain {
           */
          virtual void pay_fee() override;
       private:
-         bool fee_is_odd;
+         stored_value for_pool;
    };
 
    class asset_issue_evaluator : public evaluator<asset_issue_evaluator>

--- a/libraries/chain/include/graphene/chain/asset_object.hpp
+++ b/libraries/chain/include/graphene/chain/asset_object.hpp
@@ -61,8 +61,6 @@ namespace graphene { namespace chain {
       public:
          static constexpr uint8_t space_id = implementation_ids;
          static constexpr uint8_t type_id  = impl_asset_dynamic_data_object_type;
-
-         share_type confidential_supply; ///< total asset held in confidential balances
    };
 
    class asset_dynamic_data_object : public asset_dynamic_data_master
@@ -72,6 +70,7 @@ namespace graphene { namespace chain {
          stored_debt current_supply;
          stored_value accumulated_fees; ///< fees accumulate to be paid out over time
          stored_value fee_pool;         ///< in core asset
+         stored_value confidential_supply; ///< total asset held in confidential balances
 
    protected:
       virtual unique_ptr<graphene::db::object> backup()const;

--- a/libraries/chain/include/graphene/chain/asset_object.hpp
+++ b/libraries/chain/include/graphene/chain/asset_object.hpp
@@ -23,6 +23,7 @@
  */
 #pragma once
 #include <graphene/chain/types.hpp>
+#include <graphene/chain/stored_value.hpp>
 #include <graphene/db/generic_index.hpp>
 #include <graphene/protocol/asset_ops.hpp>
 
@@ -55,17 +56,26 @@ namespace graphene { namespace chain {
     *  This object exists as an implementation detail and its ID should never be referenced by
     *  a blockchain operation.
     */
-   class asset_dynamic_data_object : public abstract_object<asset_dynamic_data_object>
+   class asset_dynamic_data_master : public abstract_object<asset_dynamic_data_master>
    {
       public:
          static constexpr uint8_t space_id = implementation_ids;
          static constexpr uint8_t type_id  = impl_asset_dynamic_data_object_type;
 
-         /// The number of shares currently in existence
-         share_type current_supply;
          share_type confidential_supply; ///< total asset held in confidential balances
-         share_type accumulated_fees; ///< fees accumulate to be paid out over time
-         share_type fee_pool;         ///< in core asset
+   };
+
+   class asset_dynamic_data_object : public asset_dynamic_data_master
+   {
+      public:
+         /// The number of shares currently in existence
+         stored_debt current_supply;
+         stored_value accumulated_fees; ///< fees accumulate to be paid out over time
+         stored_value fee_pool;         ///< in core asset
+
+   protected:
+      virtual unique_ptr<graphene::db::object> backup()const;
+      virtual void restore( graphene::db::object& obj );
    };
 
    /**
@@ -163,7 +173,7 @@ namespace graphene { namespace chain {
           */
          template<class DB>
          share_type reserved( const DB& db )const
-         { return options.max_supply - dynamic_data(db).current_supply; }
+         { return options.max_supply - dynamic_data(db).current_supply.get_amount(); }
    };
 
    /**
@@ -172,7 +182,7 @@ namespace graphene { namespace chain {
     *  @ingroup object
     *  @ingroup implementation
     */
-   class asset_bitasset_data_object : public abstract_object<asset_bitasset_data_object>
+   class asset_bitasset_data_master : public abstract_object<asset_bitasset_data_master>
    {
       public:
          static constexpr uint8_t space_id = implementation_ids;
@@ -217,8 +227,6 @@ namespace graphene { namespace chain {
          ///@{
          /// Price at which force settlements of a black swanned asset will occur
          price settlement_price;
-         /// Amount of collateral which is available for force settlement
-         share_type settlement_fund;
          ///@}
 
          /// Track whether core_exchange_rate in corresponding asset_object has updated
@@ -261,6 +269,21 @@ namespace graphene { namespace chain {
          void update_median_feeds(time_point_sec current_time, time_point_sec next_maintenance_time);
    };
 
+   class asset_bitasset_data_object : public asset_bitasset_data_master
+   {
+      public:
+         ///@{
+         /// Amount of collateral which is available for force settlement
+         stored_value settlement_fund;
+         /// Counterpart for individual debt positions
+         stored_value total_debt;
+         ///@}
+
+   protected:
+      virtual unique_ptr<graphene::db::object> backup()const;
+      virtual void restore( graphene::db::object& obj );
+   };
+
    // key extractor for short backing asset
    struct bitasset_short_backing_asset_extractor
    {
@@ -282,12 +305,12 @@ namespace graphene { namespace chain {
          ordered_non_unique< tag<by_short_backing_asset>, bitasset_short_backing_asset_extractor >,
          ordered_unique< tag<by_feed_expiration>,
             composite_key< asset_bitasset_data_object,
-               const_mem_fun< asset_bitasset_data_object, time_point_sec, &asset_bitasset_data_object::feed_expiration_time >,
-               member< asset_bitasset_data_object, asset_id_type, &asset_bitasset_data_object::asset_id >
+               const_mem_fun< asset_bitasset_data_master, time_point_sec, &asset_bitasset_data_master::feed_expiration_time >,
+               member< asset_bitasset_data_master, asset_id_type, &asset_bitasset_data_master::asset_id >
             >
          >,
          ordered_non_unique< tag<by_cer_update>,
-                             const_mem_fun< asset_bitasset_data_object, bool, &asset_bitasset_data_object::need_to_update_cer >
+                             const_mem_fun< asset_bitasset_data_master, bool, &asset_bitasset_data_master::need_to_update_cer >
          >
       >
    > asset_bitasset_data_object_multi_index_type;
@@ -337,5 +360,7 @@ FC_REFLECT_TYPENAME( graphene::chain::asset_bitasset_data_object )
 FC_REFLECT_TYPENAME( graphene::chain::asset_dynamic_data_object )
 
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::asset_object )
+GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::asset_bitasset_data_master )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::asset_bitasset_data_object )
+GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::asset_dynamic_data_master )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::asset_dynamic_data_object )

--- a/libraries/chain/include/graphene/chain/balance_object.hpp
+++ b/libraries/chain/include/graphene/chain/balance_object.hpp
@@ -53,6 +53,10 @@ namespace graphene { namespace chain {
          stored_value balance;
 
          asset_id_type asset_type()const { return balance.get_asset(); }
+
+   protected:
+      virtual unique_ptr<graphene::db::object> backup()const;
+      virtual void restore( graphene::db::object& obj );
    };
 
    struct by_owner;

--- a/libraries/chain/include/graphene/chain/balance_object.hpp
+++ b/libraries/chain/include/graphene/chain/balance_object.hpp
@@ -36,6 +36,12 @@ namespace graphene { namespace chain {
          bool is_vesting_balance()const
          { return vesting_policy.valid(); }
 
+         asset available( const asset& balance, const fc::time_point_sec now )const
+         {
+            return is_vesting_balance()? vesting_policy->get_allowed_withdraw({balance, now, {}})
+                                       : balance;
+         }
+
          address owner;
          optional<linear_vesting_policy> vesting_policy;
          time_point_sec last_claim_date;
@@ -44,10 +50,9 @@ namespace graphene { namespace chain {
    class balance_object : public balance_master
    {
       public:
-         asset available(fc::time_point_sec now)const
+         asset available(const fc::time_point_sec now)const
          {
-            return is_vesting_balance()? vesting_policy->get_allowed_withdraw({balance.get_value(), now, {}})
-                                       : balance.get_value();
+            return balance_master::available( balance.get_value(), now );
          }
 
          stored_value balance;
@@ -83,6 +88,9 @@ namespace graphene { namespace chain {
 } }
 
 MAP_OBJECT_ID_TO_TYPE(graphene::chain::balance_object)
+
+FC_REFLECT_DERIVED( graphene::chain::balance_master, (graphene::db::object),
+                    (owner)(vesting_policy)(last_claim_date) )
 
 FC_REFLECT_TYPENAME( graphene::chain::balance_object )
 

--- a/libraries/chain/include/graphene/chain/confidential_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/confidential_evaluator.hpp
@@ -47,6 +47,11 @@ class transfer_from_blind_evaluator : public evaluator<transfer_from_blind_evalu
       void_result do_apply( const transfer_from_blind_operation& o ) ;
 
       virtual void pay_fee() override;
+
+   protected:
+      virtual void prepare_fee(account_id_type account_id, asset fee) override;
+
+      stored_debt tmp_fee;
 };
 
 class blind_transfer_evaluator : public evaluator<blind_transfer_evaluator>
@@ -58,6 +63,11 @@ class blind_transfer_evaluator : public evaluator<blind_transfer_evaluator>
       void_result do_apply( const blind_transfer_operation& o ) ;
 
       virtual void pay_fee() override;
+
+   protected:
+      virtual void prepare_fee(account_id_type account_id, asset fee) override;
+
+      stored_debt tmp_fee;
 };
 
 } } // namespace graphene::chain

--- a/libraries/chain/include/graphene/chain/database.hpp
+++ b/libraries/chain/include/graphene/chain/database.hpp
@@ -315,7 +315,7 @@ namespace graphene { namespace chain {
          void add_balance( account_id_type account, stored_value&& what );
          stored_value reduce_balance( account_id_type account, const asset& delta );
 
-         void deposit_market_fee_vesting_balance(const account_id_type &account_id, const asset &delta);
+         void deposit_market_fee_vesting_balance(const account_id_type &account_id, stored_value&& delta);
         /**
           * @brief Retrieve a particular account's market fee vesting balance in a given asset
           * @param owner Account whose balance should be retrieved
@@ -339,16 +339,16 @@ namespace graphene { namespace chain {
           */
          optional< vesting_balance_id_type > deposit_lazy_vesting(
             const optional< vesting_balance_id_type >& ovbid,
-            share_type amount,
+            stored_value&& amount,
             uint32_t req_vesting_seconds,
             vesting_balance_type balance_type,
             account_id_type req_owner,
             bool require_vesting );
 
          // helper to handle cashback rewards
-         void deposit_cashback(const account_object& acct, share_type amount, bool require_vesting = true);
+         void deposit_cashback(const account_object& acct, stored_value&& amount, bool require_vesting = true);
          // helper to handle witness pay
-         void deposit_witness_pay(const witness_object& wit, share_type amount);
+         void deposit_witness_pay(const witness_object& wit, stored_value&& amount);
 
          //////////////////// db_debug.cpp ////////////////////
 
@@ -364,7 +364,8 @@ namespace graphene { namespace chain {
          void cancel_limit_order(const limit_order_object& order, bool create_virtual_op = true, bool skip_cancel_fee = false);
          void revive_bitasset( const asset_object& bitasset );
          void cancel_bid(const collateral_bid_object& bid, bool create_virtual_op = true);
-         void execute_bid( const collateral_bid_object& bid, share_type debt_covered, share_type collateral_from_fund, const price_feed& current_feed );
+         void execute_bid( const collateral_bid_object& bid, share_type debt_covered,
+                           stored_value&& collateral_from_fund, const price_feed& current_feed );
 
          /**
           * @brief Process a new limit order through the markets
@@ -529,7 +530,7 @@ namespace graphene { namespace chain {
 
          void initialize_budget_record( fc::time_point_sec now, budget_record& rec )const;
          void process_budget();
-         void pay_workers( share_type& budget );
+         void pay_workers( stored_value&& budget );
          void perform_chain_maintenance(const signed_block& next_block, const global_property_object& global_props);
          void update_active_witnesses();
          void update_active_committee_members();

--- a/libraries/chain/include/graphene/chain/database.hpp
+++ b/libraries/chain/include/graphene/chain/database.hpp
@@ -408,21 +408,21 @@ namespace graphene { namespace chain {
          /**
           * @return true if the order was completely filled and thus freed.
           */
-         bool fill_limit_order( const limit_order_object& order, const asset& pays, const asset& receives, bool cull_if_small,
-                                const price& fill_price, const bool is_maker );
-         bool fill_call_order( const call_order_object& order, const asset& pays, const asset& receives,
-                               const price& fill_price, const bool is_maker );
-         bool fill_settle_order( const force_settlement_object& settle, const asset& pays, const asset& receives,
-                                 const price& fill_price, const bool is_maker );
+         bool fill_limit_order( const limit_order_object& order, const asset& pays, stored_value&& transport,
+                                bool cull_if_small, const price& fill_price, bool already_paid, const bool is_maker );
+         bool fill_call_order( const call_order_object& order, const asset& pays, stored_value&& transport,
+                               const price& fill_price, bool already_paid, const bool is_maker );
+         void fill_settle_order( const force_settlement_object& settle, const asset& pays,
+                                 stored_value&& receives, const price& fill_price );
 
          bool check_call_orders( const asset_object& mia, bool enable_black_swan = true, bool for_new_limit_order = false,
                                  const asset_bitasset_data_object* bitasset_ptr = nullptr );
 
          // helpers to fill_order
-         void pay_order( const account_object& receiver, const asset& receives, const asset& pays );
+         void pay_order( const account_object& receiver, stored_value&& receives, const asset& pays );
 
-         asset calculate_market_fee(const asset_object& recv_asset, const asset& trade_amount);
-         asset pay_market_fees(const account_object* seller, const asset_object& recv_asset, const asset& receives );
+         share_type calculate_market_fee(const asset_object& recv_asset, const share_type trade_amount);
+         asset pay_market_fees(const account_object* seller, const asset_object& recv_asset, stored_value&& receives );
          ///@}
 
 

--- a/libraries/chain/include/graphene/chain/database.hpp
+++ b/libraries/chain/include/graphene/chain/database.hpp
@@ -45,7 +45,6 @@
 
 namespace graphene { namespace chain {
    using graphene::db::abstract_object;
-   using graphene::db::object;
    class op_evaluator;
    class transaction_evaluation_state;
    class proposal_object;
@@ -57,6 +56,7 @@ namespace graphene { namespace chain {
    class limit_order_object;
    class collateral_bid_object;
    class call_order_object;
+   class stored_value;
 
    struct budget_record;
    enum class vesting_balance_type;
@@ -312,7 +312,8 @@ namespace graphene { namespace chain {
           * @param account ID of account whose balance should be adjusted
           * @param delta Asset ID and amount to adjust balance by
           */
-         void adjust_balance(account_id_type account, asset delta);
+         void add_balance( account_id_type account, stored_value&& what );
+         stored_value reduce_balance( account_id_type account, const asset& delta );
 
          void deposit_market_fee_vesting_balance(const account_id_type &account_id, const asset &delta);
         /**

--- a/libraries/chain/include/graphene/chain/evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/evaluator.hpp
@@ -26,6 +26,8 @@
 #include <graphene/chain/transaction_evaluation_state.hpp>
 #include <graphene/protocol/operations.hpp>
 
+#include "stored_value.hpp"
+
 namespace graphene { namespace chain {
 
    class database;
@@ -70,29 +72,24 @@ namespace graphene { namespace chain {
 
       database& db()const;
 
-      //void check_required_authorities(const operation& op);
    protected:
       /**
        * @brief Fetch objects relevant to fee payer and set pointer members
        * @param account_id Account which is paying the fee
        * @param fee The fee being paid. May be in assets other than core.
        *
-       * This method verifies that the fee is valid and sets the object pointer members and the fee fields. It should
-       * be called during do_evaluate.
+       * This method verifies that the fee is valid and sets the object pointer members and the fee fields.
+       * It should be called during do_evaluate.
        *
-       * In particular, core_fee_paid field is set by prepare_fee().
+       * In particular, fee_from_account and fee_from_pool fields are set by prepare_fee().
        */
       void prepare_fee(account_id_type account_id, asset fee);
 
       /**
        * Convert the fee into BTS through the exchange pool.
        *
-       * Reads core_fee_paid field for how much CORE is deducted from the exchange pool,
+       * Reads fee_from_pool field for how much CORE is deducted from the exchange pool,
        * and fee_from_account for how much USD is added to the pool.
-       *
-       * Since prepare_fee() does the validation checks ensuring the account and fee pool
-       * have sufficient balance and the exchange rate is correct,
-       * those validation checks are not replicated here.
        *
        * Rather than returning a value, this method fills in core_fee_paid field.
        */
@@ -109,10 +106,10 @@ namespace graphene { namespace chain {
       // header to call db() without including database.hpp, which would
       // cause a circular dependency
       share_type calculate_fee_for_operation(const operation& op) const;
-      void db_adjust_balance(const account_id_type& fee_payer, asset fee_from_account);
 
-      asset                            fee_from_account;
-      share_type                       core_fee_paid;
+      stored_value                     fee_from_account;
+      share_type                       fee_from_pool;
+      stored_value                     core_fee_paid;
       const account_object*            fee_paying_account = nullptr;
       const account_statistics_object* fee_paying_account_statistics = nullptr;
       const asset_object*              fee_asset          = nullptr;
@@ -153,10 +150,10 @@ namespace graphene { namespace chain {
          if( !trx_state->skip_fee_schedule_check )
          {
             share_type required_fee = calculate_fee_for_operation(op);
-            GRAPHENE_ASSERT( core_fee_paid >= required_fee,
+            GRAPHENE_ASSERT( core_fee_paid.get_amount() >= required_fee,
                        insufficient_fee,
                        "Insufficient Fee Paid",
-                       ("core_fee_paid",core_fee_paid)("required", required_fee) );
+                       ("core_fee_paid",core_fee_paid.get_amount())("required", required_fee) );
          }
 
          return eval->do_evaluate(op);
@@ -170,11 +167,7 @@ namespace graphene { namespace chain {
          convert_fee();
          pay_fee();
 
-         auto result = eval->do_apply(op);
-
-         db_adjust_balance(op.fee_payer(), -fee_from_account);
-
-         return result;
+         return eval->do_apply(op);
       }
    };
 } }

--- a/libraries/chain/include/graphene/chain/evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/evaluator.hpp
@@ -83,7 +83,7 @@ namespace graphene { namespace chain {
        *
        * In particular, fee_from_account and fee_from_pool fields are set by prepare_fee().
        */
-      void prepare_fee(account_id_type account_id, asset fee);
+      virtual void prepare_fee(account_id_type account_id, asset fee);
 
       /**
        * Convert the fee into BTS through the exchange pool.

--- a/libraries/chain/include/graphene/chain/evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/evaluator.hpp
@@ -23,10 +23,9 @@
  */
 #pragma once
 #include <graphene/chain/exceptions.hpp>
+#include <graphene/chain/stored_value.hpp>
 #include <graphene/chain/transaction_evaluation_state.hpp>
 #include <graphene/protocol/operations.hpp>
-
-#include "stored_value.hpp"
 
 namespace graphene { namespace chain {
 

--- a/libraries/chain/include/graphene/chain/fba_object.hpp
+++ b/libraries/chain/include/graphene/chain/fba_object.hpp
@@ -34,16 +34,28 @@ class database;
  * fba_accumulator_object accumulates fees to be paid out via buyback or other FBA mechanism.
  */
 
-class fba_accumulator_object : public graphene::db::abstract_object< fba_accumulator_object >
+class fba_accumulator_master : public graphene::db::abstract_object< fba_accumulator_master >
 {
    public:
       static constexpr uint8_t space_id = implementation_ids;
       static constexpr uint8_t type_id = impl_fba_accumulator_object_type;
 
-      share_type accumulated_fba_fees;
       optional< asset_id_type > designated_asset;
 
       bool is_configured( const database& db )const;
+};
+
+class fba_accumulator_object : public fba_accumulator_master
+{
+   public:
+      static const uint8_t space_id = implementation_ids;
+      static const uint8_t type_id = impl_fba_accumulator_object_type;
+
+      stored_value accumulated_fba_fees;
+
+      protected:
+         virtual unique_ptr<graphene::db::object> backup()const;
+         virtual void restore( graphene::db::object& obj );
 };
 
 } } // graphene::chain
@@ -52,4 +64,5 @@ MAP_OBJECT_ID_TO_TYPE(graphene::chain::fba_accumulator_object)
 
 FC_REFLECT_TYPENAME( graphene::chain::fba_accumulator_object )
 
+GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::fba_accumulator_master )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::fba_accumulator_object )

--- a/libraries/chain/include/graphene/chain/fba_object.hpp
+++ b/libraries/chain/include/graphene/chain/fba_object.hpp
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <graphene/chain/types.hpp>
+#include <graphene/chain/stored_value.hpp>
 #include <graphene/db/generic_index.hpp>
 
 namespace graphene { namespace chain {

--- a/libraries/chain/include/graphene/chain/global_property_object.hpp
+++ b/libraries/chain/include/graphene/chain/global_property_object.hpp
@@ -25,6 +25,7 @@
 
 #include <graphene/protocol/chain_parameters.hpp>
 #include <graphene/chain/types.hpp>
+#include <graphene/chain/stored_value.hpp>
 #include <graphene/db/object.hpp>
 
 namespace graphene { namespace chain {
@@ -61,7 +62,7 @@ namespace graphene { namespace chain {
     * This is an implementation detail. The values here are calculated during normal chain operations and reflect the
     * current values of global blockchain properties.
     */
-   class dynamic_global_property_object : public abstract_object<dynamic_global_property_object>
+   class dynamic_global_property_master : public abstract_object<dynamic_global_property_master>
    {
       public:
          static constexpr uint8_t space_id = implementation_ids;
@@ -73,7 +74,6 @@ namespace graphene { namespace chain {
          witness_id_type   current_witness;
          time_point_sec    next_maintenance_time;
          time_point_sec    last_budget_time;
-         share_type        witness_budget;
          uint32_t          accounts_registered_this_interval = 0;
          /**
           *  Every time a block is missed this increases by
@@ -118,6 +118,16 @@ namespace graphene { namespace chain {
             maintenance_flag = 0x01
          };
    };
+
+   class dynamic_global_property_object : public dynamic_global_property_master
+   {
+      public:
+         stored_value witness_budget;
+
+   protected:
+      virtual unique_ptr<graphene::db::object> backup()const;
+      virtual void restore( graphene::db::object& obj );
+   };
 }}
 
 MAP_OBJECT_ID_TO_TYPE(graphene::chain::dynamic_global_property_object)
@@ -126,5 +136,6 @@ MAP_OBJECT_ID_TO_TYPE(graphene::chain::global_property_object)
 FC_REFLECT_TYPENAME( graphene::chain::dynamic_global_property_object )
 FC_REFLECT_TYPENAME( graphene::chain::global_property_object )
 
+GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::dynamic_global_property_master )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::dynamic_global_property_object )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::global_property_object )

--- a/libraries/chain/include/graphene/chain/global_property_object.hpp
+++ b/libraries/chain/include/graphene/chain/global_property_object.hpp
@@ -133,6 +133,21 @@ namespace graphene { namespace chain {
 MAP_OBJECT_ID_TO_TYPE(graphene::chain::dynamic_global_property_object)
 MAP_OBJECT_ID_TO_TYPE(graphene::chain::global_property_object)
 
+FC_REFLECT_DERIVED( graphene::chain::dynamic_global_property_master, (graphene::db::object),
+                    (head_block_number)
+                    (head_block_id)
+                    (time)
+                    (current_witness)
+                    (next_maintenance_time)
+                    (last_budget_time)
+                    (accounts_registered_this_interval)
+                    (recently_missed_count)
+                    (current_aslot)
+                    (recent_slots_filled)
+                    (dynamic_flags)
+                    (last_irreversible_block_num)
+                  )
+
 FC_REFLECT_TYPENAME( graphene::chain::dynamic_global_property_object )
 FC_REFLECT_TYPENAME( graphene::chain::global_property_object )
 

--- a/libraries/chain/include/graphene/chain/htlc_object.hpp
+++ b/libraries/chain/include/graphene/chain/htlc_object.hpp
@@ -37,18 +37,16 @@ namespace graphene { namespace chain {
     * This object is stored in the database while an HTLC is active. The HTLC will
     * become inactive at expiration or when unlocked via the preimage.
     */
-   class htlc_object : public graphene::db::abstract_object<htlc_object> {
+   class htlc_master : public graphene::db::abstract_object<htlc_master> {
       public:
          // uniquely identify this object in the database
          static constexpr uint8_t space_id = protocol_ids;
          static constexpr uint8_t type_id  = htlc_object_type;
 
-         struct transfer_info {
+         struct transfer_info_master {
             account_id_type from;
             account_id_type to;
-            share_type amount;
-            asset_id_type asset_id;
-         } transfer;
+         };
          struct condition_info {
             struct hash_lock_info {  
                htlc_hash preimage_hash;
@@ -64,8 +62,16 @@ namespace graphene { namespace chain {
        */
       struct timelock_extractor {
          typedef fc::time_point_sec result_type;
-         const result_type& operator()(const htlc_object& o)const { return o.conditions.time_lock.expiration; }
+         const result_type& operator()(const htlc_master& o)const { return o.conditions.time_lock.expiration; }
       };
+   };
+
+   class htlc_object : public htlc_master
+   {
+      public:
+         struct transfer_info : transfer_info_master {
+            stored_value amount;
+         } transfer;
 
       /*****
        * Index helper for from
@@ -82,6 +88,10 @@ namespace graphene { namespace chain {
          typedef account_id_type result_type;
          const result_type& operator()(const htlc_object& o)const { return o.transfer.to; }
       };
+
+   protected:
+      virtual unique_ptr<graphene::db::object> backup()const;
+      virtual void restore( graphene::db::object& obj );
    };
 
    struct by_from_id;
@@ -94,7 +104,7 @@ namespace graphene { namespace chain {
 
             ordered_unique< tag< by_expiration >, 
                   composite_key< htlc_object,
-                  htlc_object::timelock_extractor,
+                  htlc_master::timelock_extractor,
                   member< object, object_id_type, &object::id > > >,
 
             ordered_unique< tag< by_from_id >,
@@ -121,4 +131,5 @@ FC_REFLECT_TYPENAME( graphene::chain::htlc_object::condition_info::time_lock_inf
 FC_REFLECT_TYPENAME( graphene::chain::htlc_object::condition_info )
 FC_REFLECT_TYPENAME( graphene::chain::htlc_object )
 
+GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::htlc_master )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::htlc_object )

--- a/libraries/chain/include/graphene/chain/htlc_object.hpp
+++ b/libraries/chain/include/graphene/chain/htlc_object.hpp
@@ -126,9 +126,15 @@ namespace graphene { namespace chain {
 
 MAP_OBJECT_ID_TO_TYPE(graphene::chain::htlc_object)
 
-FC_REFLECT_TYPENAME( graphene::chain::htlc_object::condition_info::hash_lock_info )
-FC_REFLECT_TYPENAME( graphene::chain::htlc_object::condition_info::time_lock_info )
-FC_REFLECT_TYPENAME( graphene::chain::htlc_object::condition_info )
+FC_REFLECT( graphene::chain::htlc_master::transfer_info_master, (from)(to) )
+FC_REFLECT( graphene::chain::htlc_master::condition_info::hash_lock_info,
+   (preimage_hash) (preimage_size) )
+FC_REFLECT( graphene::chain::htlc_master::condition_info::time_lock_info,
+   (expiration) )
+FC_REFLECT( graphene::chain::htlc_master::condition_info,
+   (hash_lock)(time_lock) )
+FC_REFLECT_DERIVED( graphene::chain::htlc_master, (graphene::db::object), (conditions) )
+
 FC_REFLECT_TYPENAME( graphene::chain::htlc_object )
 
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::htlc_master )

--- a/libraries/chain/include/graphene/chain/market_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/market_evaluator.hpp
@@ -53,8 +53,8 @@ namespace graphene { namespace chain {
           */
          virtual void pay_fee() override;
 
-         share_type                          _deferred_fee  = 0;
-         asset                               _deferred_paid_fee;
+         stored_value                        _deferred_fee;
+         stored_value                        _deferred_paid_fee;
          const limit_order_create_operation* _op            = nullptr;
          const account_object*               _seller        = nullptr;
          const asset_object*                 _sell_asset    = nullptr;

--- a/libraries/chain/include/graphene/chain/market_object.hpp
+++ b/libraries/chain/include/graphene/chain/market_object.hpp
@@ -313,6 +313,19 @@ MAP_OBJECT_ID_TO_TYPE(graphene::chain::call_order_object)
 MAP_OBJECT_ID_TO_TYPE(graphene::chain::force_settlement_object)
 MAP_OBJECT_ID_TO_TYPE(graphene::chain::collateral_bid_object)
 
+FC_REFLECT_DERIVED( graphene::chain::limit_order_master,
+                    (graphene::db::object),
+                    (expiration)(seller)(sell_price)
+                  )
+FC_REFLECT_DERIVED( graphene::chain::call_order_master, (graphene::db::object),
+                    (borrower)(call_price)(target_collateral_ratio) )
+FC_REFLECT_DERIVED( graphene::chain::force_settlement_master,
+                    (graphene::db::object),
+                    (owner)(settlement_date)
+                  )
+FC_REFLECT_DERIVED( graphene::chain::collateral_bid_master, (graphene::db::object),
+                    (bidder)(debt_covered) )
+
 FC_REFLECT_TYPENAME( graphene::chain::limit_order_object )
 FC_REFLECT_TYPENAME( graphene::chain::call_order_object )
 FC_REFLECT_TYPENAME( graphene::chain::force_settlement_object )

--- a/libraries/chain/include/graphene/chain/market_object.hpp
+++ b/libraries/chain/include/graphene/chain/market_object.hpp
@@ -24,12 +24,11 @@
 #pragma once
 
 #include <graphene/chain/types.hpp>
+#include <graphene/chain/stored_value.hpp>
 #include <graphene/db/generic_index.hpp>
 #include <graphene/protocol/asset.hpp>
 
 #include <boost/multi_index/composite_key.hpp>
-
-#include "stored_value.hpp"
 
 namespace graphene { namespace chain {
 

--- a/libraries/chain/include/graphene/chain/stored_value.hpp
+++ b/libraries/chain/include/graphene/chain/stored_value.hpp
@@ -48,6 +48,59 @@ namespace graphene { namespace chain {
                                  const graphene::protocol::share_type amount );
       void burn();
       graphene::protocol::asset get_value()const;
+      graphene::protocol::asset_id_type get_asset()const { return _asset; }
+      graphene::protocol::share_type get_amount()const { return _amount; }
+   protected:
+      void restore( const graphene::protocol::asset& backup );
+      friend class object;
    };
 } } // graphene::chain
 
+namespace fc {
+/* should be unused
+template<>
+void from_variant( const fc::variant& var, graphene::chain::stored_value& value, uint32_t max_depth )
+{
+}
+*/
+
+template<>
+void to_variant( const graphene::chain::stored_value& value, fc::variant& var, uint32_t max_depth )
+{
+   to_variant( value.get_value(), var, max_depth );
+}
+
+namespace raw {
+
+template< typename Stream >
+void pack( Stream& stream, const graphene::chain::stored_value& value, uint32_t _max_depth=FC_PACK_MAX_DEPTH )
+{
+   FC_ASSERT( _max_depth > 0 );
+   --_max_depth;
+   pack( stream, value.get_value(), _max_depth );
+}
+
+
+template< typename Stream >
+void unpack( Stream& s, graphene::chain::stored_value& value, uint32_t _max_depth=FC_PACK_MAX_DEPTH )
+{
+   FC_ASSERT( _max_depth > 0 );
+   --_max_depth;
+   graphene::protocol::asset amount;
+   unpack( s, amount, _max_depth );
+   value = graphene::chain::stored_value::issue( amount.asset_id, amount.amount );
+}
+
+} // fc::raw
+
+template<>
+struct get_typename< graphene::chain::stored_value >
+{
+   static const char* name()
+   {
+      return "graphene::chain::stored_value";
+   }
+};
+
+
+} // fc

--- a/libraries/chain/include/graphene/chain/stored_value.hpp
+++ b/libraries/chain/include/graphene/chain/stored_value.hpp
@@ -53,7 +53,7 @@ namespace graphene { namespace chain {
       void unpack( Stream s, uint32_t _max_depth )
       {
          graphene::protocol::asset amount;
-         unpack( s, amount, _max_depth );
+         fc::raw::unpack( s, amount, _max_depth );
          _asset = amount.asset_id;
          _amount = amount.amount;
       }
@@ -63,7 +63,20 @@ namespace graphene { namespace chain {
       graphene::protocol::share_type _amount;
 
       void restore( const graphene::protocol::asset& backup );
-      friend class object;
+      friend class account_balance_object;
+      friend class account_statistics_object;
+      friend class asset_dynamic_data_object;
+      friend class asset_bitasset_data_object;
+      friend class balance_object;
+      friend class fba_accumulator_object;
+      friend class dynamic_global_property_object;
+      friend class htlc_object;
+      friend class limit_order_object;
+      friend class call_order_object;
+      friend class force_settlement_object;
+      friend class collateral_bid_object;
+      friend class vesting_balance_object;
+      friend class worker_object;
    };
 
    class stored_value : public stored_debt
@@ -90,12 +103,18 @@ namespace graphene { namespace chain {
 } } // graphene::chain
 
 namespace fc {
-/* should be unused
+
 template<>
 void from_variant( const fc::variant& var, graphene::chain::stored_debt& value, uint32_t max_depth )
 {
+   FC_THROW_EXCEPTION( fc::assert_exception, "Unsupported!" );
 }
-*/
+
+template<>
+void from_variant( const fc::variant& var, graphene::chain::stored_value& value, uint32_t max_depth )
+{
+   FC_THROW_EXCEPTION( fc::assert_exception, "Unsupported!" );
+}
 
 template<>
 void to_variant( const graphene::chain::stored_debt& value, fc::variant& var, uint32_t max_depth )
@@ -120,7 +139,23 @@ void pack( Stream& stream, const graphene::chain::stored_debt& value, uint32_t _
 }
 
 template< typename Stream >
+void pack( Stream& stream, const graphene::chain::stored_value& value, uint32_t _max_depth=FC_PACK_MAX_DEPTH )
+{
+   FC_ASSERT( _max_depth > 0 );
+   --_max_depth;
+   pack( stream, value.get_value(), _max_depth );
+}
+
+template< typename Stream >
 void unpack( Stream& s, graphene::chain::stored_debt& value, uint32_t _max_depth=FC_PACK_MAX_DEPTH )
+{
+   FC_ASSERT( _max_depth > 0 );
+   --_max_depth;
+   value.unpack( s, _max_depth );
+}
+
+template< typename Stream >
+void unpack( Stream& s, graphene::chain::stored_value& value, uint32_t _max_depth=FC_PACK_MAX_DEPTH )
 {
    FC_ASSERT( _max_depth > 0 );
    --_max_depth;

--- a/libraries/chain/include/graphene/chain/stored_value.hpp
+++ b/libraries/chain/include/graphene/chain/stored_value.hpp
@@ -30,8 +30,6 @@ namespace graphene { namespace chain {
 
    class stored_debt
    {
-      graphene::protocol::asset_id_type _asset;
-      graphene::protocol::share_type _amount;
    public:
       explicit stored_debt( const graphene::protocol::asset_id_type asset = graphene::protocol::asset_id_type() );
       ~stored_debt();
@@ -61,6 +59,9 @@ namespace graphene { namespace chain {
       }
 
    protected:
+      graphene::protocol::asset_id_type _asset;
+      graphene::protocol::share_type _amount;
+
       void restore( const graphene::protocol::asset& backup );
       friend class object;
    };

--- a/libraries/chain/include/graphene/chain/stored_value.hpp
+++ b/libraries/chain/include/graphene/chain/stored_value.hpp
@@ -1,0 +1,53 @@
+/*  (C) 2019 Peter Conrad
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <graphene/protocol/asset.hpp>
+
+namespace graphene { namespace chain {
+   class stored_value
+   {
+      graphene::protocol::asset_id_type _asset;
+      graphene::protocol::share_type _amount;
+   public:
+      explicit stored_value( const graphene::protocol::asset_id_type asset = graphene::protocol::asset_id_type() );
+      ~stored_value();
+      stored_value( const stored_value& copy ) = delete;
+      stored_value( stored_value& copy ) = delete;
+      stored_value( stored_value&& move );
+
+      stored_value& operator=( const stored_value& copy ) = delete;
+      stored_value& operator=( stored_value& copy ) = delete;
+      stored_value& operator=( stored_value&& move );
+
+      stored_value split( const graphene::protocol::share_type amount );
+      stored_value& operator+=( stored_value&& other );
+
+      static stored_value issue( const graphene::protocol::asset_id_type asset,
+                                 const graphene::protocol::share_type amount );
+      void burn();
+      graphene::protocol::asset get_value()const;
+   };
+} } // graphene::chain
+

--- a/libraries/chain/include/graphene/chain/stored_value.hpp
+++ b/libraries/chain/include/graphene/chain/stored_value.hpp
@@ -26,43 +26,81 @@
 #include <graphene/protocol/asset.hpp>
 
 namespace graphene { namespace chain {
-   class stored_value
+   class stored_value;
+
+   class stored_debt
    {
       graphene::protocol::asset_id_type _asset;
       graphene::protocol::share_type _amount;
    public:
-      explicit stored_value( const graphene::protocol::asset_id_type asset = graphene::protocol::asset_id_type() );
-      ~stored_value();
-      stored_value( const stored_value& copy ) = delete;
-      stored_value( stored_value& copy ) = delete;
-      stored_value( stored_value&& move );
+      explicit stored_debt( const graphene::protocol::asset_id_type asset = graphene::protocol::asset_id_type() );
+      ~stored_debt();
 
-      stored_value& operator=( const stored_value& copy ) = delete;
-      stored_value& operator=( stored_value& copy ) = delete;
-      stored_value& operator=( stored_value&& move );
+      stored_debt( const stored_debt& copy ) = delete;
+      stored_debt( stored_debt& copy ) = delete;
+      stored_debt( stored_debt&& move );
 
-      stored_value split( const graphene::protocol::share_type amount );
-      stored_value& operator+=( stored_value&& other );
+      stored_debt& operator=( const stored_debt& copy ) = delete;
+      stored_debt& operator=( stored_debt& copy ) = delete;
+      stored_debt& operator=( stored_debt&& move );
 
-      static stored_value issue( const graphene::protocol::asset_id_type asset,
-                                 const graphene::protocol::share_type amount );
-      void burn();
       graphene::protocol::asset get_value()const;
       graphene::protocol::asset_id_type get_asset()const { return _asset; }
       graphene::protocol::share_type get_amount()const { return _amount; }
+
+      stored_value issue( const graphene::protocol::share_type amount );
+      void burn( stored_value&& amount );
+
+      template< typename Stream >
+      void unpack( Stream s, uint32_t _max_depth )
+      {
+         graphene::protocol::asset amount;
+         unpack( s, amount, _max_depth );
+         _asset = amount.asset_id;
+         _amount = amount.amount;
+      }
+
    protected:
       void restore( const graphene::protocol::asset& backup );
       friend class object;
    };
+
+   class stored_value : public stored_debt
+   {
+   public:
+      explicit stored_value( const graphene::protocol::asset_id_type asset = graphene::protocol::asset_id_type() );
+      stored_value( stored_value&& move ) : stored_debt( std::move(move) ) {}
+
+      stored_value& operator=( stored_value&& move ) {
+         this->stored_debt::operator=( std::move(move) );
+         return *this;
+      }
+
+      stored_value split( const graphene::protocol::share_type amount );
+      stored_value& operator+=( stored_value&& other );
+
+   protected:
+      static stored_value issue( const graphene::protocol::asset_id_type asset,
+                                 const graphene::protocol::share_type amount );
+      void burn();
+      friend class stored_debt;
+   };
+
 } } // graphene::chain
 
 namespace fc {
 /* should be unused
 template<>
-void from_variant( const fc::variant& var, graphene::chain::stored_value& value, uint32_t max_depth )
+void from_variant( const fc::variant& var, graphene::chain::stored_debt& value, uint32_t max_depth )
 {
 }
 */
+
+template<>
+void to_variant( const graphene::chain::stored_debt& value, fc::variant& var, uint32_t max_depth )
+{
+   to_variant( value.get_value(), var, max_depth );
+}
 
 template<>
 void to_variant( const graphene::chain::stored_value& value, fc::variant& var, uint32_t max_depth )
@@ -73,25 +111,31 @@ void to_variant( const graphene::chain::stored_value& value, fc::variant& var, u
 namespace raw {
 
 template< typename Stream >
-void pack( Stream& stream, const graphene::chain::stored_value& value, uint32_t _max_depth=FC_PACK_MAX_DEPTH )
+void pack( Stream& stream, const graphene::chain::stored_debt& value, uint32_t _max_depth=FC_PACK_MAX_DEPTH )
 {
    FC_ASSERT( _max_depth > 0 );
    --_max_depth;
    pack( stream, value.get_value(), _max_depth );
 }
 
-
 template< typename Stream >
-void unpack( Stream& s, graphene::chain::stored_value& value, uint32_t _max_depth=FC_PACK_MAX_DEPTH )
+void unpack( Stream& s, graphene::chain::stored_debt& value, uint32_t _max_depth=FC_PACK_MAX_DEPTH )
 {
    FC_ASSERT( _max_depth > 0 );
    --_max_depth;
-   graphene::protocol::asset amount;
-   unpack( s, amount, _max_depth );
-   value = graphene::chain::stored_value::issue( amount.asset_id, amount.amount );
+   value.unpack( s, _max_depth );
 }
 
 } // fc::raw
+
+template<>
+struct get_typename< graphene::chain::stored_debt >
+{
+   static const char* name()
+   {
+      return "graphene::chain::stored_debt";
+   }
+};
 
 template<>
 struct get_typename< graphene::chain::stored_value >
@@ -101,6 +145,5 @@ struct get_typename< graphene::chain::stored_value >
       return "graphene::chain::stored_value";
    }
 };
-
 
 } // fc

--- a/libraries/chain/include/graphene/chain/stored_value.hpp
+++ b/libraries/chain/include/graphene/chain/stored_value.hpp
@@ -104,29 +104,10 @@ namespace graphene { namespace chain {
 
 namespace fc {
 
-template<>
-void from_variant( const fc::variant& var, graphene::chain::stored_debt& value, uint32_t max_depth )
-{
-   FC_THROW_EXCEPTION( fc::assert_exception, "Unsupported!" );
-}
-
-template<>
-void from_variant( const fc::variant& var, graphene::chain::stored_value& value, uint32_t max_depth )
-{
-   FC_THROW_EXCEPTION( fc::assert_exception, "Unsupported!" );
-}
-
-template<>
-void to_variant( const graphene::chain::stored_debt& value, fc::variant& var, uint32_t max_depth )
-{
-   to_variant( value.get_value(), var, max_depth );
-}
-
-template<>
-void to_variant( const graphene::chain::stored_value& value, fc::variant& var, uint32_t max_depth )
-{
-   to_variant( value.get_value(), var, max_depth );
-}
+void from_variant( const fc::variant& var, graphene::chain::stored_debt& value, uint32_t max_depth );
+void from_variant( const fc::variant& var, graphene::chain::stored_value& value, uint32_t max_depth );
+void to_variant( const graphene::chain::stored_debt& value, fc::variant& var, uint32_t max_depth );
+void to_variant( const graphene::chain::stored_value& value, fc::variant& var, uint32_t max_depth );
 
 namespace raw {
 

--- a/libraries/chain/include/graphene/chain/vesting_balance_object.hpp
+++ b/libraries/chain/include/graphene/chain/vesting_balance_object.hpp
@@ -23,6 +23,7 @@
  */
 #pragma once
 
+#include <graphene/chain/stored_value.hpp>
 #include <graphene/db/generic_index.hpp>
 #include <graphene/protocol/asset.hpp>
 
@@ -314,4 +315,5 @@ FC_REFLECT_ENUM( graphene::chain::vesting_balance_type, (unspecified)(cashback)(
 
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::linear_vesting_policy )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::cdd_vesting_policy )
+GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::vesting_balance_master )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::vesting_balance_object )

--- a/libraries/chain/include/graphene/chain/vesting_balance_object.hpp
+++ b/libraries/chain/include/graphene/chain/vesting_balance_object.hpp
@@ -161,6 +161,11 @@ namespace graphene { namespace chain {
          vesting_policy policy;
          /// type of the vesting balance
          vesting_balance_type balance_type = vesting_balance_type::unspecified;
+
+         /**
+          * Get amount of allowed withdrawal.
+          */
+         asset get_allowed_withdraw(const asset& balance, const time_point_sec& now )const;
    };
 
    class vesting_balance_object : public vesting_balance_master

--- a/libraries/chain/include/graphene/chain/worker_object.hpp
+++ b/libraries/chain/include/graphene/chain/worker_object.hpp
@@ -28,6 +28,7 @@
 
 namespace graphene { namespace chain {
 class database;
+class stored_value;
 
 /**
   * @defgroup worker_types Implementations of the various worker types in the system
@@ -63,7 +64,7 @@ struct refund_worker_type
    /// Record of how much this worker has burned in his lifetime
    share_type total_burned;
 
-   void pay_worker(share_type pay, database&);
+   void pay_worker(stored_value&& pay, database&);
 };
 
 /**
@@ -76,7 +77,7 @@ struct vesting_balance_worker_type
    /// The balance this worker pays into
    vesting_balance_id_type balance;
 
-   void pay_worker(share_type pay, database& db);
+   void pay_worker(stored_value&& pay, database& db);
 };
 
 /**
@@ -89,7 +90,7 @@ struct burn_worker_type
    /// Record of how much this worker has burned in his lifetime
    share_type total_burned;
 
-   void pay_worker(share_type pay, database&);
+   void pay_worker(stored_value&& pay, database&);
 };
 ///@}
 

--- a/libraries/chain/market_evaluator.cpp
+++ b/libraries/chain/market_evaluator.cpp
@@ -78,18 +78,13 @@ void_result limit_order_create_evaluator::do_evaluate(const limit_order_create_o
 
 void limit_order_create_evaluator::convert_fee()
 {
-   if( db().head_block_time() <= HARDFORK_CORE_604_TIME )
+   if( db().head_block_time() <= HARDFORK_CORE_604_TIME || fee_asset->get_id() == asset_id_type() )
       generic_evaluator::convert_fee();
    else
       if( !trx_state->skip_fee )
-      {
-         if( fee_asset->get_id() != asset_id_type() )
-         {
-            db().modify(*fee_asset_dyn_data, [this](asset_dynamic_data_object& d) {
-               d.fee_pool -= core_fee_paid;
-            });
-         }
-      }
+         db().modify(*fee_asset_dyn_data, [this](asset_dynamic_data_object& d) {
+            core_fee_paid = d.fee_pool.split( fee_from_pool );
+         });
 }
 
 void limit_order_create_evaluator::pay_fee()
@@ -98,9 +93,9 @@ void limit_order_create_evaluator::pay_fee()
       generic_evaluator::pay_fee();
    else
    {
-      _deferred_fee = core_fee_paid;
+      _deferred_fee = std::move(core_fee_paid);
       if( db().head_block_time() > HARDFORK_CORE_604_TIME && fee_asset->get_id() != asset_id_type() )
-         _deferred_paid_fee = fee_from_account;
+         _deferred_paid_fee = std::move(fee_from_account);
    }
 }
 
@@ -113,15 +108,15 @@ object_id_type limit_order_create_evaluator::do_apply(const limit_order_create_o
       });
    }
 
-   db().adjust_balance(op.seller, -op.amount_to_sell);
+   stored_value transport = db().reduce_balance(op.seller, op.amount_to_sell);
 
-   const auto& new_order_object = db().create<limit_order_object>([&](limit_order_object& obj){
-       obj.seller   = _seller->id;
-       obj.for_sale = op.amount_to_sell.amount;
+   const auto& new_order_object = db().create<limit_order_object>([&op,this,&transport](limit_order_object& obj){
+       obj.seller   = op.seller;
+       obj.for_sale = std::move(transport);
        obj.sell_price = op.get_price();
        obj.expiration = op.expiration;
-       obj.deferred_fee = _deferred_fee;
-       obj.deferred_paid_fee = _deferred_paid_fee;
+       obj.deferred_fee = std::move(_deferred_fee);
+       obj.deferred_paid_fee = std::move(_deferred_paid_fee);
    });
    limit_order_id_type order_id = new_order_object.id; // save this because we may remove the object by filling it
    bool filled;
@@ -196,11 +191,11 @@ void_result call_order_update_evaluator::do_evaluate(const call_order_update_ope
     */
    if (next_maintenance_time > HARDFORK_CORE_1465_TIME)
    {
-      FC_ASSERT( _dynamic_data_obj->current_supply + o.delta_debt.amount <= _debt_asset->options.max_supply,
+      FC_ASSERT( _dynamic_data_obj->current_supply.get_amount() + o.delta_debt.amount <= _debt_asset->options.max_supply,
             "Borrowing this quantity would exceed MAX_SUPPLY" );
    }
    
-   FC_ASSERT( _dynamic_data_obj->current_supply + o.delta_debt.amount >= 0,
+   FC_ASSERT( _dynamic_data_obj->current_supply.get_amount() + o.delta_debt.amount >= 0,
          "This transaction would bring current supply below zero.");
 
    _bitasset_data  = &_debt_asset->bitasset_data(d);
@@ -229,27 +224,33 @@ object_id_type call_order_update_evaluator::do_apply(const call_order_update_ope
 { try {
    database& d = db();
 
-   if( o.delta_debt.amount != 0 )
+   stored_value transport;
+   if( o.delta_debt.amount > 0 )
    {
-      d.adjust_balance( o.funding_account, o.delta_debt );
-
       // Deduct the debt paid from the total supply of the debt asset.
-      d.modify(*_dynamic_data_obj, [&](asset_dynamic_data_object& dynamic_asset) {
-         dynamic_asset.current_supply += o.delta_debt.amount;
+      d.modify(*_dynamic_data_obj, [&o,&transport](asset_dynamic_data_object& dynamic_asset) {
+         transport = dynamic_asset.current_supply.issue( o.delta_debt.amount );
+      });
+      d.add_balance( o.funding_account, std::move(transport) );
+   }
+   else if( o.delta_debt.amount < 0 )
+   {
+      transport = d.reduce_balance( o.funding_account, -o.delta_debt );
+      // Deduct the debt paid from the total supply of the debt asset.
+      d.modify(*_dynamic_data_obj, [&o,&transport](asset_dynamic_data_object& dynamic_asset) {
+         dynamic_asset.current_supply.burn( std::move(transport) );
       });
    }
 
-   if( o.delta_collateral.amount != 0 )
+   if( o.delta_collateral.amount > 0 )
    {
-      d.adjust_balance( o.funding_account, -o.delta_collateral  );
+      transport = d.reduce_balance( o.funding_account, o.delta_collateral  );
 
       // Adjust the total core in orders accodingly
       if( o.delta_collateral.asset_id == asset_id_type() )
-      {
-         d.modify(_paying_account->statistics(d), [&](account_statistics_object& stats) {
-               stats.total_core_in_orders += o.delta_collateral.amount;
+         d.modify(_paying_account->statistics(d), [&o](account_statistics_object& stats) {
+            stats.total_core_in_orders += o.delta_collateral.amount;
          });
-      }
    }
 
    const auto next_maint_time = d.get_dynamic_global_properties().next_maintenance_time;
@@ -268,10 +269,11 @@ object_id_type call_order_update_evaluator::do_apply(const call_order_update_ope
       FC_ASSERT( o.delta_collateral.amount > 0, "Delta collateral amount of new debt position should be positive" );
       FC_ASSERT( o.delta_debt.amount > 0, "Delta debt amount of new debt position should be positive" );
 
-      call_obj = &d.create<call_order_object>( [&o,this,before_core_hardfork_1270]( call_order_object& call ){
+      call_obj = &d.create<call_order_object>( [&o,this,before_core_hardfork_1270,&transport]( call_order_object& call ){
          call.borrower = o.funding_account;
-         call.collateral = o.delta_collateral.amount;
-         call.debt = o.delta_debt.amount;
+         call.collateral = std::move(transport);
+         call.debt = stored_debt(o.delta_debt.asset_id);
+         transport = call.debt.issue( o.delta_debt.amount );
          if( before_core_hardfork_1270 ) // before core-1270 hard fork, calculate call_price here and cache it
             call.call_price = price::call_price( o.delta_debt, o.delta_collateral,
                                                  _bitasset_data->current_feed.maintenance_collateral_ratio );
@@ -280,30 +282,32 @@ object_id_type call_order_update_evaluator::do_apply(const call_order_update_ope
          call.target_collateral_ratio = o.extensions.value.target_collateral_ratio;
       });
       call_order_id = call_obj->id;
+
+      d.modify( *_bitasset_data, [&transport] ( asset_bitasset_data_object& bdo ) {
+         bdo.total_debt += std::move(transport);
+      });
    }
    else // updating existing debt position
    {
       call_obj = &*itr;
-      auto new_collateral = call_obj->collateral + o.delta_collateral.amount;
-      auto new_debt = call_obj->debt + o.delta_debt.amount;
       call_order_id = call_obj->id;
-
-      if( new_debt == 0 )
-      {
-         FC_ASSERT( new_collateral == 0, "Should claim all collateral when closing debt position" );
-         d.remove( *call_obj );
-         return call_order_id;
-      }
-
-      FC_ASSERT( new_collateral > 0 && new_debt > 0,
-                 "Both collateral and debt should be positive after updated a debt position if not to close it" );
-
       old_collateralization = call_obj->collateralization();
-      old_debt = call_obj->debt;
+      old_debt = call_obj->debt.get_amount();
 
-      d.modify( *call_obj, [&o,new_debt,new_collateral,this,before_core_hardfork_1270]( call_order_object& call ){
-         call.collateral = new_collateral;
-         call.debt       = new_debt;
+      stored_value tmp_debt;
+      if( o.delta_debt.amount < 0 )
+         d.modify( *_bitasset_data, [&o,&tmp_debt] ( asset_bitasset_data_object& bdo ) {
+            tmp_debt = bdo.total_debt.split( -o.delta_debt.amount );
+         });
+      d.modify( *call_obj, [&o,&transport,this,before_core_hardfork_1270,&tmp_debt]( call_order_object& call ){
+         if( o.delta_collateral.amount > 0 )
+            call.collateral += std::move(transport);
+         else if( o.delta_collateral.amount < 0 )
+            transport = call.collateral.split( -o.delta_collateral.amount );
+         if( o.delta_debt.amount > 0 )
+            tmp_debt = call.debt.issue( o.delta_debt.amount );
+         else if( o.delta_debt.amount < 0 )
+             call.debt.burn( std::move(tmp_debt) );
          if( before_core_hardfork_1270 ) // don't update call_price after core-1270 hard fork
          {
             call.call_price  =  price::call_price( call.get_debt(), call.get_collateral(),
@@ -311,6 +315,18 @@ object_id_type call_order_update_evaluator::do_apply(const call_order_update_ope
          }
          call.target_collateral_ratio = o.extensions.value.target_collateral_ratio;
       });
+      if( tmp_debt.get_amount() > 0 )
+         d.modify( *_bitasset_data, [&tmp_debt] ( asset_bitasset_data_object& bdo ) {
+            bdo.total_debt += std::move(tmp_debt);
+         });
+
+      if( call_obj->debt.get_amount() == 0 )
+      {
+         FC_ASSERT( call_obj->collateral.get_amount() == 0,
+                    "Should claim all collateral when closing debt position" );
+         d.remove( *call_obj );
+         return call_order_id;
+      }
    }
 
    // then we must check for margin calls and other issues
@@ -365,12 +381,12 @@ object_id_type call_order_update_evaluator::do_apply(const call_order_update_ope
             FC_ASSERT( ( !before_core_hardfork_1270
                             && call_obj->collateralization() > _bitasset_data->current_maintenance_collateralization )
                        || ( before_core_hardfork_1270 && ~call_obj->call_price < _bitasset_data->current_feed.settlement_price )
-                       || ( old_collateralization.valid() && call_obj->debt <= *old_debt
+                       || ( old_collateralization.valid() && call_obj->debt.get_amount() <= *old_debt
                                                           && call_obj->collateralization() > *old_collateralization ),
                "Can only increase collateral ratio without increasing debt if would trigger a margin call that "
                "cannot be fully filled",
                ("old_debt", old_debt)
-               ("new_debt", call_obj->debt)
+               ("new_debt", call_obj->debt.get_amount())
                ("old_collateralization", old_collateralization)
                ("new_collateralization", call_obj->collateralization() )
                );
@@ -428,11 +444,12 @@ void_result bid_collateral_evaluator::do_apply(const bid_collateral_operation& o
 
    if( o.debt_covered.amount == 0 ) return void_result();
 
-   d.adjust_balance( o.bidder, -o.additional_collateral  );
+   stored_value transport = d.reduce_balance( o.bidder, o.additional_collateral  );
 
-   _bid = &d.create<collateral_bid_object>([&]( collateral_bid_object& bid ) {
+   _bid = &d.create<collateral_bid_object>([&o,&transport]( collateral_bid_object& bid ) {
       bid.bidder = o.bidder;
-      bid.inv_swan_price = o.additional_collateral / o.debt_covered;
+      bid.collateral_offered = std::move(transport);
+      bid.debt_covered = o.debt_covered;
    });
 
    // Note: CORE asset in collateral_bid_object is not counted in account_stats.total_core_in_orders

--- a/libraries/chain/market_object.cpp
+++ b/libraries/chain/market_object.cpp
@@ -414,31 +414,19 @@ void collateral_bid_object::restore( object& obj )
 
 } } // graphene::chain
 
-FC_REFLECT_DERIVED( graphene::chain::limit_order_master,
-                    (graphene::db::object),
-                    (expiration)(seller)(sell_price)
-                  )
 FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::limit_order_object,
                     (graphene::chain::limit_order_master),
                     (for_sale)(deferred_fee)(deferred_paid_fee)
                   )
 
-FC_REFLECT_DERIVED( graphene::chain::call_order_master, (graphene::db::object),
-                    (borrower)(call_price)(target_collateral_ratio) )
 FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::call_order_object, (graphene::chain::call_order_master),
                     (debt)(collateral) )
 
-FC_REFLECT_DERIVED( graphene::chain::force_settlement_master,
-                    (graphene::db::object),
-                    (owner)(settlement_date)
-                  )
 FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::force_settlement_object,
                     (graphene::chain::force_settlement_master),
                     (balance)
                   )
 
-FC_REFLECT_DERIVED( graphene::chain::collateral_bid_master, (graphene::db::object),
-                    (bidder)(debt_covered) )
 FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::collateral_bid_object,
                     (graphene::chain::collateral_bid_master),
                     (collateral_offered) )

--- a/libraries/chain/small_objects.cpp
+++ b/libraries/chain/small_objects.cpp
@@ -91,9 +91,6 @@ FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::committee_member_object, (graph
 FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::blinded_balance_object, (graphene::db::object),
                                 (commitment)(asset_id)(owner) )
 
-FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::fba_accumulator_object, (graphene::db::object),
-                                (accumulated_fba_fees)(designated_asset) )
-
 FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::dynamic_global_property_object, (graphene::db::object),
                     (head_block_number)
                     (head_block_id)
@@ -198,7 +195,6 @@ GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::chain::immutable_chain_para
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::chain::chain_property_object )
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::chain::committee_member_object )
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::chain::blinded_balance_object )
-GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::chain::fba_accumulator_object )
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::chain::dynamic_global_property_object )
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::chain::global_property_object )
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::chain::htlc_object )

--- a/libraries/chain/small_objects.cpp
+++ b/libraries/chain/small_objects.cpp
@@ -48,14 +48,15 @@ namespace graphene { namespace chain {
 
 class balance_backup : public balance_master
 {
-   private:
+      asset balance;
+      friend class balance_object;
+
+   public:
       balance_backup( const balance_object& original )
          : balance_master( original )
       {
          balance = original.balance.get_value();
       }
-      asset balance;
-      friend class balance_object;
 };
 
 unique_ptr<object> balance_object::backup()const
@@ -72,14 +73,15 @@ void balance_object::restore( object& obj )
 
 class dynamic_global_property_backup : public dynamic_global_property_master
 {
-   private:
+      asset witness_budget;
+      friend class dynamic_global_property_object;
+
+   public:
       dynamic_global_property_backup( const dynamic_global_property_object& original )
          : dynamic_global_property_master( original )
       {
          witness_budget = original.witness_budget.get_value();
       }
-      asset witness_budget;
-      friend class dynamic_global_property_object;
 };
 
 unique_ptr<object> dynamic_global_property_object::backup()const
@@ -90,22 +92,23 @@ unique_ptr<object> dynamic_global_property_object::backup()const
 void dynamic_global_property_object::restore( object& obj )
 {
    const auto& backup = static_cast<dynamic_global_property_backup&>(obj);
-   balance.restore( backup.witness_budget ) );
+   witness_budget.restore( backup.witness_budget );
    static_cast<dynamic_global_property_master&>(*this) = std::move( backup );
 }
 
 class htlc_backup : public htlc_master
 {
-   private:
+      asset amount;
+      transfer_info_master transfer;
+      friend class htlc_object;
+
+   public:
       htlc_backup( const htlc_object& original )
          : htlc_master( original )
       {
          transfer = original.transfer;
          amount = original.transfer.amount.get_value();
       }
-      asset amount;
-      transfer_info_master transfer;
-      friend class htlc_object;
 };
 
 unique_ptr<object> htlc_object::backup()const
@@ -123,7 +126,7 @@ void htlc_object::restore( object& obj )
 
 } } // graphene::chain
 
-FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::balance_master, (graphene::db::object),
+FC_REFLECT_DERIVED( graphene::chain::balance_master, (graphene::db::object),
                     (owner)(vesting_policy)(last_claim_date) )
 FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::balance_object, (graphene::chain::balance_master),
                     (balance) )
@@ -172,7 +175,7 @@ FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::committee_member_object, (graph
 FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::blinded_balance_object, (graphene::db::object),
                                 (commitment)(asset_id)(owner) )
 
-FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::dynamic_global_property_master, (graphene::db::object),
+FC_REFLECT_DERIVED( graphene::chain::dynamic_global_property_master, (graphene::db::object),
                     (head_block_number)
                     (head_block_id)
                     (time)
@@ -198,18 +201,18 @@ FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::global_property_object, (graphe
                     (active_witnesses)
                   )
 
-FC_REFLECT( graphene::chain::htlc_master::transfer_info_master, (from) (to) )
+FC_REFLECT( graphene::chain::htlc_master::transfer_info_master, (from)(to) )
 FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::htlc_object::condition_info::hash_lock_info, BOOST_PP_SEQ_NIL,
    (preimage_hash) (preimage_size) )
 FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::htlc_object::condition_info::time_lock_info, BOOST_PP_SEQ_NIL,
    (expiration) )
 FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::htlc_object::condition_info, BOOST_PP_SEQ_NIL,
    (hash_lock)(time_lock) )
-FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::htlc_master, (graphene::db::object),
+FC_REFLECT_DERIVED( graphene::chain::htlc_master, (graphene::db::object),
                (conditions) )
-FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::htlc_object::transfer_info,
-                                (graphene::chain::htlc_master::transfer_info_master),
-                                (from) (to) )
+FC_REFLECT_DERIVED( graphene::chain::htlc_object::transfer_info,
+                    (graphene::chain::htlc_master::transfer_info_master),
+                    (amount) )
 FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::htlc_object, (graphene::chain::htlc_master),
                (transfer) )
 

--- a/libraries/chain/small_objects.cpp
+++ b/libraries/chain/small_objects.cpp
@@ -126,8 +126,6 @@ void htlc_object::restore( object& obj )
 
 } } // graphene::chain
 
-FC_REFLECT_DERIVED( graphene::chain::balance_master, (graphene::db::object),
-                    (owner)(vesting_policy)(last_claim_date) )
 FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::balance_object, (graphene::chain::balance_master),
                     (balance) )
 
@@ -175,20 +173,6 @@ FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::committee_member_object, (graph
 FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::blinded_balance_object, (graphene::db::object),
                                 (commitment)(asset_id)(owner) )
 
-FC_REFLECT_DERIVED( graphene::chain::dynamic_global_property_master, (graphene::db::object),
-                    (head_block_number)
-                    (head_block_id)
-                    (time)
-                    (current_witness)
-                    (next_maintenance_time)
-                    (last_budget_time)
-                    (accounts_registered_this_interval)
-                    (recently_missed_count)
-                    (current_aslot)
-                    (recent_slots_filled)
-                    (dynamic_flags)
-                    (last_irreversible_block_num)
-                  )
 FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::dynamic_global_property_object, (graphene::chain::dynamic_global_property_master),
                     (witness_budget)
                   )
@@ -201,15 +185,6 @@ FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::global_property_object, (graphe
                     (active_witnesses)
                   )
 
-FC_REFLECT( graphene::chain::htlc_master::transfer_info_master, (from)(to) )
-FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::htlc_object::condition_info::hash_lock_info, BOOST_PP_SEQ_NIL,
-   (preimage_hash) (preimage_size) )
-FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::htlc_object::condition_info::time_lock_info, BOOST_PP_SEQ_NIL,
-   (expiration) )
-FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::htlc_object::condition_info, BOOST_PP_SEQ_NIL,
-   (hash_lock)(time_lock) )
-FC_REFLECT_DERIVED( graphene::chain::htlc_master, (graphene::db::object),
-               (conditions) )
 FC_REFLECT_DERIVED( graphene::chain::htlc_object::transfer_info,
                     (graphene::chain::htlc_master::transfer_info_master),
                     (amount) )

--- a/libraries/chain/stored_value.cpp
+++ b/libraries/chain/stored_value.cpp
@@ -40,10 +40,10 @@ namespace graphene { namespace chain {
       move._amount = 0;
    }
 
-   stored_debt& stored_debt::operator=( stored_value&& other )
+   stored_debt& stored_debt::operator=( stored_debt&& other )
    {
       if( &other == this ) return *this;
-      FC_ASSERT( _amount.value == 0 && (_asset == asset_id_type() || _asset == other._asset),
+      FC_ASSERT( _amount.value == 0 && (_asset == graphene::protocol::asset_id_type() || _asset == other._asset),
                  "Can't overwrite (${n},${a}) with (${on},${oa})!",
                  ("on",other._amount.value)("oa",other._asset)("n",_amount.value)("a",_asset) );
       _asset = other._asset;
@@ -78,13 +78,6 @@ namespace graphene { namespace chain {
    graphene::protocol::asset stored_debt::get_value()const
    {
       return graphene::protocol::asset( _amount, _asset );
-   }
-
-   void stored_debt::restore( const graphene::protocol::asset& backup )
-   {
-      FC_ASSERT( _asset == backup.asset_id, "Corrupted backup: ${a} != ${b}",
-                 ("a",_asset)("b",backup.asset_id) );
-      _amount = backup.amount;
    }
 
 

--- a/libraries/chain/stored_value.cpp
+++ b/libraries/chain/stored_value.cpp
@@ -26,30 +26,69 @@
 #include <fc/exception/exception.hpp>
 
 namespace graphene { namespace chain {
-   stored_value::stored_value( const graphene::protocol::asset_id_type asset )
+   stored_debt::stored_debt( const graphene::protocol::asset_id_type asset )
       : _asset(asset), _amount(0) {}
 
-   stored_value::~stored_value()
+   stored_debt::~stored_debt()
    {
       FC_ASSERT( _amount == 0, "Value leak detected: (${n],${a])!", ("n",_amount.value)("a",_asset) );
    }
 
-   stored_value::stored_value( stored_value&& move )
+   stored_debt::stored_debt( stored_debt&& move )
       : _asset(move._asset), _amount(move._amount)
    {
       move._amount = 0;
    }
 
-   stored_value& stored_value::operator=( stored_value&& other )
+   stored_debt& stored_debt::operator=( stored_value&& other )
    {
       if( &other == this ) return *this;
-      FC_ASSERT( _amount.value == 0, "Can't overwrite (${n},${a}) with (${on},${oa})!",
+      FC_ASSERT( _amount.value == 0 && (_asset == asset_id_type() || _asset == other._asset),
+                 "Can't overwrite (${n},${a}) with (${on},${oa})!",
                  ("on",other._amount.value)("oa",other._asset)("n",_amount.value)("a",_asset) );
       _asset = other._asset;
       _amount = other._amount;
       other._amount = 0;
       return *this;
    }
+
+   stored_value stored_debt::issue( const graphene::protocol::share_type amount )
+   {
+      FC_ASSERT( amount >= 0, "Cannot issue a negative amount of ${a}", ("a",_asset) );
+      _amount += amount;
+      return stored_value::issue( _asset, amount );
+   }
+
+   void stored_debt::burn( stored_value&& amount )
+   {
+      FC_ASSERT( amount.get_amount() >= 0, "Cannot burn a negative amount of ${a}", ("a",_asset) );
+      FC_ASSERT( _asset == amount.get_asset(), "Debt ${a} cannot burn ${n} of ${b}",
+                 ("a",_asset)("n",amount.get_amount())("b",amount.get_asset()) );
+      _amount -= amount.get_amount();
+      amount.burn();
+   }
+
+   void stored_debt::restore( const graphene::protocol::asset& backup )
+   {
+      FC_ASSERT( _asset == backup.asset_id, "Corrupted backup: ${a} != ${b}",
+                 ("a",_asset)("b",backup.asset_id) );
+      _amount = backup.amount;
+   }
+
+   graphene::protocol::asset stored_debt::get_value()const
+   {
+      return graphene::protocol::asset( _amount, _asset );
+   }
+
+   void stored_debt::restore( const graphene::protocol::asset& backup )
+   {
+      FC_ASSERT( _asset == backup.asset_id, "Corrupted backup: ${a} != ${b}",
+                 ("a",_asset)("b",backup.asset_id) );
+      _amount = backup.amount;
+   }
+
+
+   stored_value::stored_value( const graphene::protocol::asset_id_type asset ) : stored_debt( asset ) {}
 
    stored_value stored_value::split( const graphene::protocol::share_type amount )
    {
@@ -85,9 +124,5 @@ namespace graphene { namespace chain {
       _amount = 0;
    }
 
-   graphene::protocol::asset stored_value::get_value()const
-   {
-      return graphene::protocol::asset( _amount, _asset );
-   }
 } } // graphene::chain
 

--- a/libraries/chain/stored_value.cpp
+++ b/libraries/chain/stored_value.cpp
@@ -119,3 +119,26 @@ namespace graphene { namespace chain {
 
 } } // graphene::chain
 
+namespace fc {
+
+void from_variant( const fc::variant& var, graphene::chain::stored_debt& value, uint32_t max_depth )
+{
+   FC_THROW_EXCEPTION( fc::assert_exception, "Unsupported!" );
+}
+
+void from_variant( const fc::variant& var, graphene::chain::stored_value& value, uint32_t max_depth )
+{
+   FC_THROW_EXCEPTION( fc::assert_exception, "Unsupported!" );
+}
+
+void to_variant( const graphene::chain::stored_debt& value, fc::variant& var, uint32_t max_depth )
+{
+   to_variant( value.get_value(), var, max_depth );
+}
+
+void to_variant( const graphene::chain::stored_value& value, fc::variant& var, uint32_t max_depth )
+{
+   to_variant( value.get_value(), var, max_depth );
+}
+
+} // fc

--- a/libraries/chain/stored_value.cpp
+++ b/libraries/chain/stored_value.cpp
@@ -1,0 +1,93 @@
+/*  (C) 2019 Peter Conrad
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <graphene/chain/stored_value.hpp>
+
+#include <fc/exception/exception.hpp>
+
+namespace graphene { namespace chain {
+   stored_value::stored_value( const graphene::protocol::asset_id_type asset )
+      : _asset(asset), _amount(0) {}
+
+   stored_value::~stored_value()
+   {
+      FC_ASSERT( _amount == 0, "Value leak detected: (${n],${a])!", ("n",_amount.value)("a",_asset) );
+   }
+
+   stored_value::stored_value( stored_value&& move )
+      : _asset(move._asset), _amount(move._amount)
+   {
+      move._amount = 0;
+   }
+
+   stored_value& stored_value::operator=( stored_value&& other )
+   {
+      if( &other == this ) return *this;
+      FC_ASSERT( _amount.value == 0, "Can't overwrite (${n},${a}) with (${on},${oa})!",
+                 ("on",other._amount.value)("oa",other._asset)("n",_amount.value)("a",_asset) );
+      _asset = other._asset;
+      _amount = other._amount;
+      other._amount = 0;
+      return *this;
+   }
+
+   stored_value stored_value::split( const graphene::protocol::share_type amount )
+   {
+      FC_ASSERT( amount <= _amount, "Invalid split: want ${w} but have only ${n} of ${a}",
+                 ("w",amount)("n",_amount)("a",_asset) );
+      stored_value result( _asset );
+      result._amount = amount;
+      _amount -= amount;
+      return result;
+   }
+
+   stored_value& stored_value::operator+=( stored_value&& other )
+   {
+      FC_ASSERT( other._asset == _asset, "Can't merge (${on},${oa}) with (${n},${a})!",
+                 ("on",other._amount.value)("oa",other._asset)("n",_amount.value)("a",_asset) );
+      FC_ASSERT( &other != this, "Can't merge (${n},${a}) with itself!",
+		 ("n",_amount.value)("a",_asset) );
+      _amount += other._amount;
+      other._amount = 0;
+      return *this;
+   }
+
+   stored_value stored_value::issue( const graphene::protocol::asset_id_type asset,
+                                     const graphene::protocol::share_type amount )
+   {
+      stored_value result( asset );
+      result._amount = amount;
+      return result;
+   }
+
+   void stored_value::burn()
+   {
+      _amount = 0;
+   }
+
+   graphene::protocol::asset stored_value::get_value()const
+   {
+      return graphene::protocol::asset( _amount, _asset );
+   }
+} } // graphene::chain
+

--- a/libraries/chain/transfer_evaluator.cpp
+++ b/libraries/chain/transfer_evaluator.cpp
@@ -76,8 +76,7 @@ void_result transfer_evaluator::do_evaluate( const transfer_operation& op )
 
 void_result transfer_evaluator::do_apply( const transfer_operation& o )
 { try {
-   db().adjust_balance( o.from, -o.amount );
-   db().adjust_balance( o.to, o.amount );
+   db().add_balance( o.to, db().reduce_balance( o.from, o.amount ) );
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (o) ) }
 
@@ -110,8 +109,7 @@ void_result override_transfer_evaluator::do_evaluate( const override_transfer_op
 
 void_result override_transfer_evaluator::do_apply( const override_transfer_operation& o )
 { try {
-   db().adjust_balance( o.from, -o.amount );
-   db().adjust_balance( o.to, o.amount );
+   db().add_balance( o.to, db().reduce_balance( o.from, o.amount ) );
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (o) ) }
 

--- a/libraries/chain/vesting_balance_evaluator.cpp
+++ b/libraries/chain/vesting_balance_evaluator.cpp
@@ -91,14 +91,15 @@ object_id_type vesting_balance_create_evaluator::do_apply( const vesting_balance
    const time_point_sec now = d.head_block_time();
 
    FC_ASSERT( d.get_balance( op.creator, op.amount.asset_id ) >= op.amount );
-   d.adjust_balance( op.creator, -op.amount );
 
-   const vesting_balance_object& vbo = d.create< vesting_balance_object >( [&]( vesting_balance_object& obj )
+   stored_value transport = d.reduce_balance( op.creator, op.amount );
+
+   const vesting_balance_object& vbo = d.create< vesting_balance_object >( [&op,now,&transport]( vesting_balance_object& obj )
    {
       //WARNING: The logic to create a vesting balance object is replicated in vesting_balance_worker_type::initializer::init.
       // If making changes to this logic, check if those changes should also be made there as well.
       obj.owner = op.owner;
-      obj.balance = op.amount;
+      obj.balance = std::move(transport);
       op.policy.visit( init_policy_visitor( obj.policy, op.amount.amount, now ) );
    } );
 
@@ -131,13 +132,13 @@ void_result vesting_balance_withdraw_evaluator::do_apply( const vesting_balance_
    // Allow zero balance objects to stick around, (1) to comply
    // with the chain's "objects live forever" design principle, (2)
    // if it's cashback or worker, it'll be filled up again.
-
-   d.modify( vbo, [&]( vesting_balance_object& vbo )
+   stored_value transport;
+   d.modify( vbo, [&transport,now,&op]( vesting_balance_object& vbo )
    {
-      vbo.withdraw( now, op.amount );
+      transport = vbo.withdraw( now, op.amount );
    } );
 
-   d.adjust_balance( op.owner, op.amount );
+   d.add_balance( op.owner, std::move(transport) );
 
    // TODO: Check asset authorizations and withdrawals
    return void_result();

--- a/libraries/chain/vesting_balance_object.cpp
+++ b/libraries/chain/vesting_balance_object.cpp
@@ -264,9 +264,14 @@ stored_value vesting_balance_object::withdraw(const time_point_sec& now, const a
    return balance.split( amount.amount );
 }
 
+asset vesting_balance_master::get_allowed_withdraw( const asset& balance, const time_point_sec& now )const
+{
+   return policy.visit(get_allowed_withdraw_visitor(balance, now, asset()));
+}
+
 asset vesting_balance_object::get_allowed_withdraw(const time_point_sec& now)const
 {
-   return policy.visit(get_allowed_withdraw_visitor(balance.get_value(), now, asset()));
+   return vesting_balance_master::get_allowed_withdraw( balance.get_value(), now );
 }
 
 class vesting_balance_backup : public vesting_balance_master

--- a/libraries/chain/vesting_balance_object.cpp
+++ b/libraries/chain/vesting_balance_object.cpp
@@ -199,7 +199,7 @@ struct NAME ## _visitor                                       \
      ) result_type;                                           \
                                                               \
    NAME ## _visitor(                                          \
-      const asset& balance,                                   \
+      const asset balance,                                    \
       const time_point_sec& now,                              \
       const asset& amount                                     \
      )                                                        \
@@ -225,61 +225,61 @@ VESTING_VISITOR(get_allowed_withdraw, const);
 
 bool vesting_balance_object::is_deposit_allowed(const time_point_sec& now, const asset& amount)const
 {
-   return policy.visit(is_deposit_allowed_visitor(balance, now, amount));
+   return policy.visit(is_deposit_allowed_visitor(balance.get_value(), now, amount));
 }
 
 bool vesting_balance_object::is_withdraw_allowed(const time_point_sec& now, const asset& amount)const
 {
-   bool result = policy.visit(is_withdraw_allowed_visitor(balance, now, amount));
+   bool result = policy.visit(is_withdraw_allowed_visitor(balance.get_value(), now, amount));
    // if some policy allows you to withdraw more than your balance,
    //    there's a programming bug in the policy algorithm
-   assert((amount <= balance) || (!result));
+   assert((amount <= balance.get_value()) || (!result));
    return result;
 }
 
 void vesting_balance_object::deposit(const time_point_sec& now, stored_value&& amount)
 {
-   on_deposit_visitor vtor(balance, now, amount);
+   on_deposit_visitor vtor(balance.get_value(), now, amount.get_value());
    policy.visit(vtor);
-   balance += amount;
+   balance += std::move(amount);
 }
 
 void vesting_balance_object::deposit_vested(const time_point_sec& now, stored_value&& amount)
 {
-   on_deposit_vested_visitor vtor(balance, now, amount);
+   on_deposit_vested_visitor vtor(balance.get_value(), now, amount.get_value());
    policy.visit(vtor);
-   balance += amount;
+   balance += std::move(amount);
 }
 
 bool vesting_balance_object::is_deposit_vested_allowed(const time_point_sec& now, const asset& amount) const
 {
-   return policy.visit(is_deposit_vested_allowed_visitor(balance, now, amount));
+   return policy.visit(is_deposit_vested_allowed_visitor(balance.get_value(), now, amount));
 }
 
 stored_value vesting_balance_object::withdraw(const time_point_sec& now, const asset& amount)
 {
-   assert(amount <= balance);
-   on_withdraw_visitor vtor(balance, now, amount);
+   assert(amount <= balance.get_value());
+   on_withdraw_visitor vtor(balance.get_value(), now, amount);
    policy.visit(vtor);
-   balance -= amount;
+   return balance.split( amount.amount );
 }
 
 asset vesting_balance_object::get_allowed_withdraw(const time_point_sec& now)const
 {
-   asset amount = asset();
-   return policy.visit(get_allowed_withdraw_visitor(balance, now, amount));
+   return policy.visit(get_allowed_withdraw_visitor(balance.get_value(), now, asset()));
 }
 
 class vesting_balance_backup : public vesting_balance_master
 {
-   private:
+      asset balance;
+      friend class vesting_balance_object;
+
+   public:
       vesting_balance_backup( const vesting_balance_object& original )
          : vesting_balance_master( original )
       {
          balance = original.balance.get_value();
       }
-      asset balance;
-      friend class vesting_balance_object;
 };
 
 unique_ptr<object> vesting_balance_object::backup()const
@@ -290,7 +290,7 @@ unique_ptr<object> vesting_balance_object::backup()const
 void vesting_balance_object::restore( object& obj )
 {
    const auto& backup = static_cast<vesting_balance_backup&>(obj);
-   balance.restore( backup.balance ) );
+   balance.restore( backup.balance );
    static_cast<vesting_balance_master&>(*this) = std::move( backup );
 }
 
@@ -298,4 +298,5 @@ void vesting_balance_object::restore( object& obj )
 
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::chain::linear_vesting_policy )
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::chain::cdd_vesting_policy )
+GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::chain::vesting_balance_master )
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::chain::vesting_balance_object )

--- a/libraries/chain/withdraw_permission_evaluator.cpp
+++ b/libraries/chain/withdraw_permission_evaluator.cpp
@@ -105,8 +105,7 @@ void_result withdraw_permission_claim_evaluator::do_apply(const withdraw_permiss
          p.claimed_this_period = op.amount_to_withdraw.amount;
    });
 
-   d.adjust_balance(op.withdraw_from_account, -op.amount_to_withdraw);
-   d.adjust_balance(op.withdraw_to_account, op.amount_to_withdraw);
+   d.add_balance( op.withdraw_to_account, d.reduce_balance(op.withdraw_from_account, op.amount_to_withdraw) );
 
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (op) ) }

--- a/libraries/chain/worker_evaluator.cpp
+++ b/libraries/chain/worker_evaluator.cpp
@@ -104,26 +104,26 @@ object_id_type worker_create_evaluator::do_apply(const worker_create_evaluator::
    }).id;
 } FC_CAPTURE_AND_RETHROW( (o) ) }
 
-void refund_worker_type::pay_worker(share_type pay, database& db)
+void refund_worker_type::pay_worker(stored_value&& pay, database& db)
 {
-   total_burned += pay;
-   db.modify( db.get_core_dynamic_data(), [pay](asset_dynamic_data_object& d) {
-      d.current_supply -= pay;
+   total_burned += pay.get_amount();
+   db.modify( db.get_core_dynamic_data(), [&pay](asset_dynamic_data_object& d) {
+      d.current_supply.burn( std::move(pay) );
    });
 }
 
-void vesting_balance_worker_type::pay_worker(share_type pay, database& db)
+void vesting_balance_worker_type::pay_worker(stored_value&& pay, database& db)
 {
-   db.modify(balance(db), [&](vesting_balance_object& b) {
-      b.deposit(db.head_block_time(), asset(pay));
+   db.modify(balance(db), [&pay,&db](vesting_balance_object& b) {
+      b.deposit(db.head_block_time(), std::move(pay));
    });
 }
 
 
-void burn_worker_type::pay_worker(share_type pay, database& db)
+void burn_worker_type::pay_worker(stored_value&& pay, database& db)
 {
    total_burned += pay;
-   db.adjust_balance( GRAPHENE_NULL_ACCOUNT, pay );
+   db.add_balance( GRAPHENE_NULL_ACCOUNT, std::move(pay) );
 }
 
 } } // graphene::chain

--- a/libraries/chain/worker_evaluator.cpp
+++ b/libraries/chain/worker_evaluator.cpp
@@ -57,7 +57,6 @@ struct worker_init_visitor
       vesting_balance_worker_type w;
        w.balance = db.create<vesting_balance_object>([&](vesting_balance_object& b) {
          b.owner = worker.worker_account;
-         b.balance = asset(0);
          b.balance_type = vesting_balance_type::worker;
 
          cdd_vesting_policy policy;
@@ -122,7 +121,7 @@ void vesting_balance_worker_type::pay_worker(stored_value&& pay, database& db)
 
 void burn_worker_type::pay_worker(stored_value&& pay, database& db)
 {
-   total_burned += pay;
+   total_burned += pay.get_amount();
    db.add_balance( GRAPHENE_NULL_ACCOUNT, std::move(pay) );
 }
 

--- a/libraries/db/include/graphene/db/index.hpp
+++ b/libraries/db/include/graphene/db/index.hpp
@@ -120,13 +120,14 @@ namespace graphene { namespace db {
 
          /**
           *   When forming your lambda to modify obj, it is natural to have Object& be the signature, but
-          *   that is not compatible with the type erasue required by the virtual method.  This method
+          *   that is not compatible with the type erasure required by the virtual method.  This method
           *   provides a helper to wrap the lambda in a form compatible with the virtual modify call.
           *   @note Lambda should have the signature:  void(Object&)
           */
          template<typename Object, typename Lambda>
-         void modify( const Object& obj, const Lambda& l ) {
-            modify( static_cast<const object&>(obj), std::function<void(object&)>( [&]( object& o ){ l( static_cast<Object&>(o) ); } ) );
+         void modify( const Object& obj, Lambda&& l ) {
+            modify( static_cast<const object&>(obj),
+                    std::function<void(object&)>( [&l]( object& o ){ l( static_cast<Object&>(o) ); } ) );
          }
 
          virtual void               inspect_all_objects(std::function<void(const object&)> inspector)const = 0;

--- a/libraries/db/include/graphene/db/object.hpp
+++ b/libraries/db/include/graphene/db/object.hpp
@@ -66,8 +66,8 @@ namespace graphene { namespace db {
          object(){}
          virtual ~object(){}
 
-         static const uint8_t space_id = 0;
-         static const uint8_t type_id  = 0;
+         static constexpr uint8_t space_id = 0;
+         static constexpr uint8_t type_id  = 0;
 
          // serialized
          object_id_type          id;

--- a/libraries/db/include/graphene/db/object_database.hpp
+++ b/libraries/db/include/graphene/db/object_database.hpp
@@ -87,7 +87,7 @@ namespace graphene { namespace db {
          const object& insert( object&& obj ) { return get_mutable_index(obj.id).insert( std::move(obj) ); }
          void          remove( const object& obj ) { get_mutable_index(obj.id).remove( obj ); }
          template<typename T, typename Lambda>
-         void modify( const T& obj, const Lambda& m ) {
+         void modify( const T& obj, Lambda&& m ) {
             get_mutable_index(obj.id).modify(obj,m);
          }
 

--- a/libraries/plugins/api_helper_indexes/api_helper_indexes.cpp
+++ b/libraries/plugins/api_helper_indexes/api_helper_indexes.cpp
@@ -35,17 +35,17 @@ void amount_in_collateral_index::object_inserted( const object& objct )
    {
       auto itr = in_collateral.find( o.collateral_type() );
       if( itr == in_collateral.end() )
-         in_collateral[o.collateral_type()] = o.collateral;
+         in_collateral[o.collateral_type()] = o.collateral.get_amount();
       else
-         itr->second += o.collateral;
+         itr->second += o.collateral.get_amount();
    }
 
    {
       auto itr = backing_collateral.find( o.debt_type() );
       if( itr == backing_collateral.end() )
-         backing_collateral[o.debt_type()] = o.collateral;
+         backing_collateral[o.debt_type()] = o.collateral.get_amount();
       else
-         itr->second += o.collateral;
+         itr->second += o.collateral.get_amount();
    }
 
 } FC_CAPTURE_AND_RETHROW( (objct) ); }
@@ -57,13 +57,13 @@ void amount_in_collateral_index::object_removed( const object& objct )
    {
       auto itr = in_collateral.find( o.collateral_type() );
       if( itr != in_collateral.end() ) // should always be true
-         itr->second -= o.collateral;
+         itr->second -= o.collateral.get_amount();
    }
 
    {
       auto itr = backing_collateral.find( o.debt_type() );
       if( itr != backing_collateral.end() ) // should always be true
-         itr->second -= o.collateral;
+         itr->second -= o.collateral.get_amount();
    }
 
 } FC_CAPTURE_AND_RETHROW( (objct) ); }

--- a/libraries/plugins/custom_operations/custom_operations_plugin.cpp
+++ b/libraries/plugins/custom_operations/custom_operations_plugin.cpp
@@ -23,10 +23,10 @@
  */
 
 #include <graphene/custom_operations/custom_operations_plugin.hpp>
+#include <graphene/chain/operation_history_object.hpp>
 
 #include <fc/crypto/hex.hpp>
 #include <iostream>
-#include <graphene/app/database_api.hpp>
 
 namespace graphene { namespace custom_operations {
 

--- a/libraries/plugins/delayed_node/delayed_node_plugin.cpp
+++ b/libraries/plugins/delayed_node/delayed_node_plugin.cpp
@@ -86,7 +86,7 @@ void delayed_node_plugin::sync_with_trusted_node()
    uint32_t pass_count = 0;
    while( true )
    {
-      graphene::chain::dynamic_global_property_object remote_dpo = my->database_api->get_dynamic_global_properties();
+      auto remote_dpo = my->database_api->get_dynamic_global_properties();
       if( remote_dpo.last_irreversible_block_num <= db.head_block_num() )
       {
          if( remote_dpo.last_irreversible_block_num < db.head_block_num() )

--- a/libraries/plugins/es_objects/es_objects.cpp
+++ b/libraries/plugins/es_objects/es_objects.cpp
@@ -74,7 +74,7 @@ class es_objects_plugin_impl
 
    private:
       template<typename T>
-      void prepareTemplate(T blockchain_object, string index_name);
+      void prepareTemplate(const T& blockchain_object, string index_name);
 };
 
 bool es_objects_plugin_impl::genesis()
@@ -234,7 +234,7 @@ void es_objects_plugin_impl::remove_from_database( object_id_type id, std::strin
 }
 
 template<typename T>
-void es_objects_plugin_impl::prepareTemplate(T blockchain_object, string index_name)
+void es_objects_plugin_impl::prepareTemplate(const T& blockchain_object, string index_name)
 {
    fc::mutable_variant_object bulk_header;
    bulk_header["_index"] = _es_objects_index_prefix + index_name;

--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -24,7 +24,6 @@
 #pragma once
 
 #include <fc/optional.hpp>
-#include <graphene/chain/htlc_object.hpp>
 #include <graphene/app/api.hpp>
 #include <graphene/utilities/key_conversion.hpp>
 #include "wallet_structs.hpp"
@@ -180,7 +179,7 @@ class wallet_api
        *    if \c ostart_id is specified and valid, its price will be used to do page query preferentially,
        *    otherwise the \c ostart_price will be used
        */
-      vector<limit_order_object>        get_account_limit_orders( const string& name_or_id,
+      vector<graphene::app::limit_order_api_object> get_account_limit_orders( const string& name_or_id,
                                             const string &base,
                                             const string &quote,
                                             uint32_t limit = 101,
@@ -194,7 +193,7 @@ class wallet_api
        * @param limit Maximum number of orders to retrieve
        * @return The limit orders, ordered from least price to greatest
        */
-      vector<limit_order_object>        get_limit_orders(string a, string b, uint32_t limit)const;
+      vector<graphene::app::limit_order_api_object> get_limit_orders(string a, string b, uint32_t limit)const;
 
       /**
        * @brief Get call orders (aka margin positions) for a given asset
@@ -202,7 +201,7 @@ class wallet_api
        * @param limit Maximum number of orders to retrieve
        * @return The call orders, ordered from earliest to be called to latest
        */
-      vector<call_order_object>         get_call_orders(string a, uint32_t limit)const;
+      vector<graphene::app::call_order_api_object> get_call_orders(string a, uint32_t limit)const;
 
       /**
        * @brief Get forced settlement orders in a given asset
@@ -210,7 +209,7 @@ class wallet_api
        * @param limit Maximum number of orders to retrieve
        * @return The settle orders, ordered from earliest settlement date to latest
        */
-      vector<force_settlement_object>   get_settle_orders(string a, uint32_t limit)const;
+      vector<graphene::app::force_settlement_api_object> get_settle_orders(string a, uint32_t limit)const;
 
       /** Returns the collateral_bid object for the given MPA
        *
@@ -219,7 +218,7 @@ class wallet_api
        * @param start the sequence number where to start looping back throw the history
        * @returns a list of \c collateral_bid_objects
        */
-      vector<collateral_bid_object> get_collateral_bids(string asset, uint32_t limit = 100, uint32_t start = 0)const;
+      vector<graphene::app::collateral_bid_api_object> get_collateral_bids(string asset, uint32_t limit = 100, uint32_t start = 0)const;
 
       /** Returns the block chain's slowly-changing settings.
        * This object contains all of the properties of the blockchain that are fixed
@@ -250,7 +249,7 @@ class wallet_api
        * @see \c get_global_properties() for less-frequently changing properties
        * @returns the dynamic global properties
        */
-      dynamic_global_property_object    get_dynamic_global_properties() const;
+      graphene::app::dynamic_global_property_api_object get_dynamic_global_properties() const;
 
       /** Returns information about the given account.
        *
@@ -271,7 +270,7 @@ class wallet_api
        * @param asset_name_or_id the symbol or id of the BitAsset in question
        * @returns the BitAsset-specific data for this asset
        */
-      asset_bitasset_data_object        get_bitasset_data(string asset_name_or_id)const;
+      variant        get_bitasset_data(string asset_name_or_id)const;
 
       /**
        * Returns information about the given HTLC object.

--- a/libraries/wallet/include/graphene/wallet/wallet_structs.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet_structs.hpp
@@ -236,9 +236,9 @@ struct signed_block_with_info : public signed_block
    vector< transaction_id_type > transaction_ids;
 };
 
-struct vesting_balance_object_with_info : public vesting_balance_object
+struct vesting_balance_object_with_info : public graphene::app::vesting_balance_api_object
 {
-   vesting_balance_object_with_info( const vesting_balance_object& vbo, fc::time_point_sec now );
+   vesting_balance_object_with_info( const graphene::app::vesting_balance_api_object& vbo, fc::time_point_sec now );
    vesting_balance_object_with_info( const vesting_balance_object_with_info& vbo ) = default;
 
    /**
@@ -375,7 +375,8 @@ FC_REFLECT( graphene::wallet::worker_vote_delta,
 FC_REFLECT_DERIVED( graphene::wallet::signed_block_with_info, (graphene::chain::signed_block),
    (block_id)(signing_key)(transaction_ids) )
 
-FC_REFLECT_DERIVED( graphene::wallet::vesting_balance_object_with_info, (graphene::chain::vesting_balance_object),
+FC_REFLECT_DERIVED( graphene::wallet::vesting_balance_object_with_info,
+   (graphene::app::vesting_balance_api_object),
    (allowed_withdraw)(allowed_withdraw_time) )
 
 FC_REFLECT( graphene::wallet::operation_detail,

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -210,10 +210,10 @@ signed_transaction wallet_api::htlc_create( string source, string destination, s
 
 fc::optional<fc::variant> wallet_api::get_htlc(std::string htlc_id) const
 {
-   fc::optional<htlc_object> optional_obj = my->get_htlc(htlc_id);
+   fc::optional<graphene::app::htlc_api_object> optional_obj = my->get_htlc(htlc_id);
    if ( optional_obj.valid() )
    {
-      const htlc_object& obj = *optional_obj;
+      const auto& obj = *optional_obj;
       // convert to formatted variant
       fc::mutable_variant_object transfer;
       const auto& from = my->get_account( obj.transfer.from );
@@ -426,7 +426,7 @@ vector<bucket_object> wallet_api::get_market_history(
    return my->_remote_hist->get_market_history( symbol1, symbol2, bucket, start, end );
 }
 
-vector<limit_order_object> wallet_api::get_account_limit_orders(
+vector<graphene::app::limit_order_api_object> wallet_api::get_account_limit_orders(
       const string& name_or_id,
       const string &base,
       const string &quote,
@@ -437,22 +437,22 @@ vector<limit_order_object> wallet_api::get_account_limit_orders(
    return my->_remote_db->get_account_limit_orders(name_or_id, base, quote, limit, ostart_id, ostart_price);
 }
 
-vector<limit_order_object> wallet_api::get_limit_orders(std::string a, std::string b, uint32_t limit)const
+vector<graphene::app::limit_order_api_object> wallet_api::get_limit_orders(std::string a, std::string b, uint32_t limit)const
 {
    return my->_remote_db->get_limit_orders(a, b, limit);
 }
 
-vector<call_order_object> wallet_api::get_call_orders(std::string a, uint32_t limit)const
+vector<graphene::app::call_order_api_object> wallet_api::get_call_orders(std::string a, uint32_t limit)const
 {
    return my->_remote_db->get_call_orders(a, limit);
 }
 
-vector<force_settlement_object> wallet_api::get_settle_orders(std::string a, uint32_t limit)const
+vector<graphene::app::force_settlement_api_object> wallet_api::get_settle_orders(std::string a, uint32_t limit)const
 {
    return my->_remote_db->get_settle_orders(a, limit);
 }
 
-vector<collateral_bid_object> wallet_api::get_collateral_bids(std::string asset, uint32_t limit, uint32_t start)const
+vector<graphene::app::collateral_bid_api_object> wallet_api::get_collateral_bids(std::string asset, uint32_t limit, uint32_t start)const
 {
    return my->_remote_db->get_collateral_bids(asset, limit, start);
 }
@@ -567,11 +567,11 @@ extended_asset_object wallet_api::get_asset(string asset_name_or_id) const
    return *a;
 }
 
-asset_bitasset_data_object wallet_api::get_bitasset_data(string asset_name_or_id) const
+variant wallet_api::get_bitasset_data(string asset_name_or_id) const
 {
    auto asset = get_asset(asset_name_or_id);
    FC_ASSERT(asset.is_market_issued() && asset.bitasset_data_id);
-   return my->get_object(*asset.bitasset_data_id);
+   return my->_remote_db->get_objects({*asset.bitasset_data_id}, {}).front();;
 }
 
 account_id_type wallet_api::get_account_id(string account_name_or_id) const
@@ -1097,7 +1097,7 @@ global_property_object wallet_api::get_global_properties() const
    return my->get_global_properties();
 }
 
-dynamic_global_property_object wallet_api::get_dynamic_global_properties() const
+dynamic_global_property_api_object wallet_api::get_dynamic_global_properties() const
 {
    return my->get_dynamic_global_properties();
 }
@@ -1920,11 +1920,11 @@ signed_block_with_info::signed_block_with_info( const signed_block& block )
 }
 
 vesting_balance_object_with_info::vesting_balance_object_with_info(
-      const vesting_balance_object& vbo,
+      const vesting_balance_api_object& vbo,
       fc::time_point_sec now )
-   : vesting_balance_object( vbo )
+   : vesting_balance_api_object( vbo )
 {
-   allowed_withdraw = get_allowed_withdraw( now );
+   allowed_withdraw = get_allowed_withdraw( balance, now );
    allowed_withdraw_time = now;
 }
 

--- a/libraries/wallet/wallet_account.cpp
+++ b/libraries/wallet/wallet_account.cpp
@@ -300,11 +300,11 @@ namespace graphene { namespace wallet { namespace detail {
          return result;
       }
 
-      vector< vesting_balance_object > vbos = _remote_db->get_vesting_balances( account_name );
+      vector< vesting_balance_api_object > vbos = _remote_db->get_vesting_balances( account_name );
       if( vbos.size() == 0 )
          return result;
 
-      for( const vesting_balance_object& vbo : vbos )
+      for( const auto& vbo : vbos )
          result.emplace_back( vbo, now );
 
       return result;
@@ -315,7 +315,7 @@ namespace graphene { namespace wallet { namespace detail {
          const vector<string>& wif_keys, bool broadcast )
    { try {
       FC_ASSERT(!is_locked());
-      const dynamic_global_property_object& dpo = _remote_db->get_dynamic_global_properties();
+      const auto dpo = _remote_db->get_dynamic_global_properties();
       account_object claimer = get_account( name_or_id );
       uint32_t max_ops_per_tx = 30;
 
@@ -365,11 +365,11 @@ namespace graphene { namespace wallet { namespace detail {
          }
       }
 
-      vector< balance_object > balances = _remote_db->get_balance_objects( addrs );
+      vector< balance_api_object > balances = _remote_db->get_balance_objects( addrs );
       addrs.clear();
 
       set<asset_id_type> bal_types;
-      for( auto b : balances ) bal_types.insert( b.balance.asset_id );
+      for( const auto& b : balances ) bal_types.insert( b.balance.asset_id );
 
       struct claim_tx
       {
@@ -382,11 +382,11 @@ namespace graphene { namespace wallet { namespace detail {
       {
          balance_claim_operation op;
          op.deposit_to_account = claimer.id;
-         for( const balance_object& b : balances )
+         for( const auto& b : balances )
          {
             if( b.balance.asset_id == a )
             {
-               op.total_claimed = b.available( dpo.time );
+               op.total_claimed = b.available( b.balance, dpo.time );
                if( op.total_claimed.amount == 0 )
                   continue;
                op.balance_to_claim = b.id;

--- a/libraries/wallet/wallet_api_impl.cpp
+++ b/libraries/wallet/wallet_api_impl.cpp
@@ -172,7 +172,7 @@ namespace graphene { namespace wallet { namespace detail {
    {
       return _remote_db->get_global_properties();
    }
-   dynamic_global_property_object wallet_api_impl::get_dynamic_global_properties() const
+   graphene::app::dynamic_global_property_api_object wallet_api_impl::get_dynamic_global_properties() const
    {
       return _remote_db->get_dynamic_global_properties();
    }

--- a/libraries/wallet/wallet_api_impl.hpp
+++ b/libraries/wallet/wallet_api_impl.hpp
@@ -151,7 +151,7 @@ public:
 
    chain_property_object get_chain_properties() const;
    global_property_object get_global_properties() const;
-   dynamic_global_property_object get_dynamic_global_properties() const;
+   graphene::app::dynamic_global_property_api_object get_dynamic_global_properties() const;
 
    account_object get_account(account_id_type id) const;
    account_object get_account(string account_name_or_id) const;
@@ -167,7 +167,7 @@ public:
 
    extended_asset_object get_asset(string asset_symbol_or_id)const;
 
-   fc::optional<htlc_object> get_htlc(string htlc_id) const;
+   fc::optional<htlc_api_object> get_htlc(string htlc_id) const;
 
    asset_id_type get_asset_id(string asset_symbol_or_id) const;
 

--- a/libraries/wallet/wallet_builder.cpp
+++ b/libraries/wallet/wallet_builder.cpp
@@ -62,7 +62,7 @@ namespace graphene { namespace wallet { namespace detail {
             total_fee += gprops.get_current_fees().set_fee( op, fee_asset_obj.options.core_exchange_rate );
 
          FC_ASSERT((total_fee * fee_asset_obj.options.core_exchange_rate).amount <=
-                   get_object(fee_asset_obj.dynamic_asset_data_id).fee_pool,
+                   get_object(fee_asset_obj.dynamic_asset_data_id).fee_pool.get_amount(), // FIXME
                    "Cannot pay fees in ${asset}, as this asset's fee pool is insufficiently funded.",
                    ("asset", fee_asset_obj.symbol));
       } else {

--- a/libraries/wallet/wallet_transfer.cpp
+++ b/libraries/wallet/wallet_transfer.cpp
@@ -115,7 +115,7 @@ namespace graphene { namespace wallet { namespace detail {
       try
       {
          FC_ASSERT( !self.is_locked() );
-         fc::optional<htlc_object> htlc_obj = get_htlc(htlc_id);
+         fc::optional<htlc_api_object> htlc_obj = get_htlc(htlc_id);
          FC_ASSERT(htlc_obj, "Could not find HTLC matching ${htlc}", ("htlc", htlc_id));
 
          account_object issuer_obj = get_account(issuer);
@@ -140,7 +140,7 @@ namespace graphene { namespace wallet { namespace detail {
       try
       {
          FC_ASSERT( !self.is_locked() );
-         fc::optional<htlc_object> htlc_obj = get_htlc(htlc_id);
+         fc::optional<htlc_api_object> htlc_obj = get_htlc(htlc_id);
          FC_ASSERT(htlc_obj, "Could not find HTLC matching ${htlc}", ("htlc", htlc_id));
 
          account_object issuer_obj = get_account(issuer);
@@ -159,7 +159,7 @@ namespace graphene { namespace wallet { namespace detail {
       } FC_CAPTURE_AND_RETHROW( (htlc_id)(issuer)(seconds_to_add)(broadcast) )
    }
 
-   fc::optional<htlc_object> wallet_api_impl::get_htlc(string htlc_id) const
+   fc::optional<graphene::app::htlc_api_object> wallet_api_impl::get_htlc(string htlc_id) const
    {
       htlc_id_type id;
       fc::from_variant(htlc_id, id);

--- a/tests/app/main.cpp
+++ b/tests/app/main.cpp
@@ -278,7 +278,7 @@ BOOST_AUTO_TEST_CASE( two_node_network )
          claim_op.deposit_to_account = nathan_id;
          claim_op.balance_to_claim = bid;
          claim_op.balance_owner_key = nathan_key.get_public_key();
-         claim_op.total_claimed = bid(*db1).balance;
+         claim_op.total_claimed = bid(*db1).balance.get_value();
          trx.operations.push_back( claim_op );
          db1->current_fee_schedule().set_fee( trx.operations.back() );
 

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -689,7 +689,7 @@ BOOST_FIXTURE_TEST_CASE( cli_confidential_tx_test, cli_fixture )
 
       // ** Check head block:
       BOOST_TEST_MESSAGE("Check that all expected blocks have processed");
-      dynamic_global_property_object dgp = W.get_dynamic_global_properties();
+      graphene::app::dynamic_global_property_api_object dgp = W.get_dynamic_global_properties();
       BOOST_CHECK(dgp.head_block_number == head_block);
    } catch( fc::exception& e ) {
       edump((e.to_detail_string()));
@@ -809,7 +809,6 @@ BOOST_AUTO_TEST_CASE( cli_multisig_transaction )
 
       // transfer bts from cifer.test to nathan
       BOOST_TEST_MESSAGE("Transferring bitshares from cifer.test to nathan");
-      auto dyn_props = app1->chain_database()->get_dynamic_global_properties();
       account_object cifer_test = con.wallet_api_ptr->get_account("cifer.test");
 
       // construct a transfer transaction

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -475,7 +475,7 @@ void database_fixture::verify_asset_supplies( const database& db )
 {
    //wlog("*** Begin asset supply verification ***");
    const asset_dynamic_data_object& core_asset_data = db.get_core_asset().dynamic_asset_data_id(db);
-   BOOST_CHECK(core_asset_data.fee_pool == 0);
+   BOOST_CHECK(core_asset_data.fee_pool.get_amount() == 0);
 
    const auto& statistics_index = db.get_index_type<account_stats_index>().indices();
    const auto& acct_balance_index = db.get_index_type<account_balance_index>().indices();
@@ -487,23 +487,23 @@ void database_fixture::verify_asset_supplies( const database& db )
    share_type reported_core_in_orders;
 
    for( const account_balance_object& b : acct_balance_index )
-      total_balances[b.asset_type] += b.balance;
+      total_balances[b.get_asset()] += b.balance.get_amount();
    for( const force_settlement_object& s : settle_index )
-      total_balances[s.balance.asset_id] += s.balance.amount;
+      total_balances[s.balance.get_asset()] += s.balance.get_amount();
    for( const collateral_bid_object& b : bids )
-      total_balances[b.inv_swan_price.base.asset_id] += b.inv_swan_price.base.amount;
+      total_balances[b.collateral_offered.get_asset()] += b.collateral_offered.get_amount();
    for( const account_statistics_object& a : statistics_index )
    {
       reported_core_in_orders += a.total_core_in_orders;
-      total_balances[asset_id_type()] += a.pending_fees + a.pending_vested_fees;
+      total_balances[asset_id_type()] += a.pending_fees.get_amount() + a.pending_vested_fees.get_amount();
    }
    for( const limit_order_object& o : db.get_index_type<limit_order_index>().indices() )
    {
       asset for_sale = o.amount_for_sale();
       if( for_sale.asset_id == asset_id_type() ) core_in_orders += for_sale.amount;
       total_balances[for_sale.asset_id] += for_sale.amount;
-      total_balances[asset_id_type()] += o.deferred_fee;
-      total_balances[o.deferred_paid_fee.asset_id] += o.deferred_paid_fee.amount;
+      total_balances[asset_id_type()] += o.deferred_fee.get_amount();
+      total_balances[o.deferred_paid_fee.get_asset()] += o.deferred_paid_fee.get_amount();
    }
    for( const call_order_object& o : db.get_index_type<call_order_index>().indices() )
    {
@@ -515,39 +515,39 @@ void database_fixture::verify_asset_supplies( const database& db )
    for( const asset_object& asset_obj : db.get_index_type<asset_index>().indices() )
    {
       const auto& dasset_obj = asset_obj.dynamic_asset_data_id(db);
-      total_balances[asset_obj.id] += dasset_obj.accumulated_fees;
-      total_balances[asset_id_type()] += dasset_obj.fee_pool;
+      total_balances[asset_obj.id] += dasset_obj.accumulated_fees.get_amount();
+      total_balances[asset_id_type()] += dasset_obj.fee_pool.get_amount();
       if( asset_obj.is_market_issued() )
       {
          const auto& bad = asset_obj.bitasset_data(db);
-         total_balances[bad.options.short_backing_asset] += bad.settlement_fund;
+         total_balances[bad.options.short_backing_asset] += bad.settlement_fund.get_amount();
       }
-      total_balances[asset_obj.id] += dasset_obj.confidential_supply.value;
+      total_balances[asset_obj.id] += dasset_obj.confidential_supply.get_amount();
    }
    for( const vesting_balance_object& vbo : db.get_index_type< vesting_balance_index >().indices() )
-      total_balances[ vbo.balance.asset_id ] += vbo.balance.amount;
+      total_balances[ vbo.balance.get_asset() ] += vbo.balance.get_amount();
    for( const fba_accumulator_object& fba : db.get_index_type< simple_index< fba_accumulator_object > >() )
-      total_balances[ asset_id_type() ] += fba.accumulated_fba_fees;
+      total_balances[ asset_id_type() ] += fba.accumulated_fba_fees.get_amount();
    for( const balance_object& bo : db.get_index_type< balance_index >().indices() )
-      total_balances[ bo.balance.asset_id ] += bo.balance.amount;
+      total_balances[ bo.balance.get_asset() ] += bo.balance.get_amount();
 
-   total_balances[asset_id_type()] += db.get_dynamic_global_properties().witness_budget;
+   total_balances[asset_id_type()] += db.get_dynamic_global_properties().witness_budget.get_amount();
 
    for( const auto& item : total_debts )
    {
-      BOOST_CHECK_EQUAL(item.first(db).dynamic_asset_data_id(db).current_supply.value, item.second.value);
+      BOOST_CHECK_EQUAL(item.first(db).dynamic_asset_data_id(db).current_supply.get_amount().value, item.second.value);
    }
 
    // htlc
    const auto& htlc_idx = db.get_index_type< htlc_index >().indices().get< by_id >();
    for( auto itr = htlc_idx.begin(); itr != htlc_idx.end(); ++itr )
    {
-      total_balances[itr->transfer.asset_id] += itr->transfer.amount;
+      total_balances[itr->transfer.amount.get_asset()] += itr->transfer.amount.get_amount();
    }
 
    for( const asset_object& asset_obj : db.get_index_type<asset_index>().indices() )
    {
-      BOOST_CHECK_EQUAL(total_balances[asset_obj.id].value, asset_obj.dynamic_asset_data_id(db).current_supply.value);
+      BOOST_CHECK_EQUAL(total_balances[asset_obj.id].value, asset_obj.dynamic_asset_data_id(db).current_supply.get_amount().value);
    }
 
    BOOST_CHECK_EQUAL( core_in_orders.value , reported_core_in_orders.value );
@@ -1300,7 +1300,7 @@ void database_fixture::print_market( const string& syma, const string& symb )con
    while( cur != price_idx.end() )
    {
       cerr << std::setw( 10 ) << std::left   << cur->seller(db).name << " ";
-      cerr << std::setw( 10 ) << std::right  << cur->for_sale.value << " ";
+      cerr << std::setw( 10 ) << std::right  << cur->amount_for_sale().amount.value << " ";
       cerr << std::setw( 5 )  << std::left   << cur->amount_for_sale().asset_id(db).symbol << " ";
       cerr << std::setw( 10 ) << std::right  << cur->amount_to_receive().amount.value << " ";
       cerr << std::setw( 5 )  << std::left   << cur->amount_to_receive().asset_id(db).symbol << " ";

--- a/tests/tests/block_tests.cpp
+++ b/tests/tests/block_tests.cpp
@@ -928,7 +928,7 @@ BOOST_FIXTURE_TEST_CASE( limit_order_expiration, database_fixture )
    BOOST_CHECK_EQUAL( get_balance(*nathan, *core), 49500 );
 
    auto ptrx_id = ptrx.operation_results.back().get<object_id_type>();
-   auto limit_index = db.get_index_type<limit_order_index>().indices();
+   auto& limit_index = db.get_index_type<limit_order_index>().indices();
    auto limit_itr = limit_index.begin();
    BOOST_REQUIRE( limit_itr != limit_index.end() );
    BOOST_REQUIRE( limit_itr->id == ptrx_id );

--- a/tests/tests/database_api_tests.cpp
+++ b/tests/tests/database_api_tests.cpp
@@ -1134,8 +1134,8 @@ BOOST_AUTO_TEST_CASE(get_account_limit_orders)
       BOOST_CHECK(create_sell_order(seller, core.amount(100), bitcny.amount(250 - i)));
    }
 
-   std::vector<limit_order_object> results;
-   limit_order_object o;
+   std::vector<graphene::app::limit_order_api_object> results;
+   graphene::app::limit_order_api_object o;
 
    // query with no constraint, expected:
    // 1. up to 101 orders returned
@@ -1186,7 +1186,7 @@ BOOST_AUTO_TEST_CASE(get_account_limit_orders)
    //    id should greater than specified
    // 2. returned orders sorted by price desendingly
    // 3. the first order's sell price equal to specified
-   cancel_limit_order(o); // NOTE 1: this canceled order was in scope of the
+   cancel_limit_order( db.get<limit_order_object>(o.id) ); // NOTE 1: this canceled order was in scope of the
                           // first created 50 orders, so with price 2.5 BTS/CNY
    results = db_api.get_account_limit_orders(seller.name, GRAPHENE_SYMBOL, "CNY", 50,
        limit_order_id_type(o.id), o.sell_price);
@@ -1204,7 +1204,7 @@ BOOST_AUTO_TEST_CASE(get_account_limit_orders)
    o = results.back();
    results.clear();
 
-   cancel_limit_order(o); // NOTE 3: this time the canceled order was in scope
+   cancel_limit_order( db.get<limit_order_object>(o.id) ); // NOTE 3: this time the canceled order was in scope
                           // of the lowest price 150 orders
    results = db_api.get_account_limit_orders(seller.name, GRAPHENE_SYMBOL, "CNY", 101,
        limit_order_id_type(o.id), o.sell_price);
@@ -1568,7 +1568,7 @@ BOOST_AUTO_TEST_CASE( api_limit_get_limit_orders ){
    fc::usleep(fc::milliseconds(100));
    GRAPHENE_CHECK_THROW(db_api.get_limit_orders(std::string(static_cast<object_id_type>(asset_id_type())),
       std::string(static_cast<object_id_type>(bit_jmj_id)), 370), fc::exception);
-   vector<limit_order_object>  limit_orders =db_api.get_limit_orders(std::string(
+   vector<graphene::app::limit_order_api_object>  limit_orders =db_api.get_limit_orders(std::string(
       static_cast<object_id_type>(asset_id_type())),
       std::string(static_cast<object_id_type>(bit_jmj_id)), 340);
    BOOST_REQUIRE_EQUAL( limit_orders.size(), 0u);
@@ -1592,7 +1592,7 @@ BOOST_AUTO_TEST_CASE( api_limit_get_call_orders ){
    BOOST_CHECK( bitusd_id(db).is_market_issued() );
    GRAPHENE_CHECK_THROW(db_api.get_call_orders(std::string(static_cast<object_id_type>(bitusd_id)),
 	   370), fc::exception);
-   vector< call_order_object>  call_order =db_api.get_call_orders(std::string(
+   vector< graphene::app::call_order_api_object>  call_order =db_api.get_call_orders(std::string(
 	   static_cast<object_id_type>(bitusd_id)), 340);
    BOOST_REQUIRE_EQUAL( call_order.size(), 0u);
    }catch (fc::exception& e) {
@@ -1613,7 +1613,7 @@ BOOST_AUTO_TEST_CASE( api_limit_get_settle_orders ){
    fc::usleep(fc::milliseconds(100));
    GRAPHENE_CHECK_THROW(db_api.get_settle_orders(
    	std::string(static_cast<object_id_type>(bitusd_id)), 370), fc::exception);
-   vector<force_settlement_object> result =db_api.get_settle_orders(
+   vector<graphene::app::force_settlement_api_object> result =db_api.get_settle_orders(
    	std::string(static_cast<object_id_type>(bitusd_id)), 340);
    BOOST_REQUIRE_EQUAL( result.size(), 0u);
    }catch (fc::exception& e) {
@@ -1972,7 +1972,7 @@ BOOST_AUTO_TEST_CASE(api_limit_get_collateral_bids) {
 
 
       //validating normal case; total_bids =3 ; result_bids=3
-      vector<collateral_bid_object> result_bids = db_api.get_collateral_bids(swan_symbol, 250, 0);
+      vector<graphene::app::collateral_bid_api_object> result_bids = db_api.get_collateral_bids(swan_symbol, 250, 0);
       BOOST_CHECK_EQUAL( 3u, result_bids.size() );
 
       //verify skip /// inefficient code test
@@ -2021,7 +2021,7 @@ BOOST_AUTO_TEST_CASE(api_limit_get_account_limit_orders) {
       }
 
 
-      std::vector<limit_order_object> results=db_api.get_account_limit_orders(seller.name, GRAPHENE_SYMBOL, "CNY",250);
+      std::vector<graphene::app::limit_order_api_object> results=db_api.get_account_limit_orders(seller.name, GRAPHENE_SYMBOL, "CNY",250);
       BOOST_REQUIRE_EQUAL( results.size(), 250u);
       GRAPHENE_CHECK_THROW( db_api.get_account_limit_orders(seller.name, GRAPHENE_SYMBOL, "CNY",251), fc::exception);
 

--- a/tests/tests/fee_tests.cpp
+++ b/tests/tests/fee_tests.cpp
@@ -168,8 +168,8 @@ BOOST_AUTO_TEST_CASE(asset_claim_fees_test)
          //wdump( (jillcoin)(jillcoin.dynamic_asset_data_id(db))((*jillcoin.bitasset_data_id)(db)) );
 
          // check the correct amount of fees has been awarded
-         BOOST_CHECK( izzycoin.dynamic_asset_data_id(db).accumulated_fees == _izzy(1).amount );
-         BOOST_CHECK( jillcoin.dynamic_asset_data_id(db).accumulated_fees == _jill(6).amount );
+         BOOST_CHECK( izzycoin.dynamic_asset_data_id(db).accumulated_fees.get_amount() == _izzy(1).amount );
+         BOOST_CHECK( jillcoin.dynamic_asset_data_id(db).accumulated_fees.get_amount() == _jill(6).amount );
 
       }
 
@@ -188,14 +188,14 @@ BOOST_AUTO_TEST_CASE(asset_claim_fees_test)
          // can claim asset in one go
          claim_fees( izzy_id, _izzy(1) );
          GRAPHENE_REQUIRE_THROW( claim_fees( izzy_id, izzy_satoshi ), fc::exception );
-         BOOST_CHECK( izzycoin.dynamic_asset_data_id(db).accumulated_fees == _izzy(0).amount );
+         BOOST_CHECK( izzycoin.dynamic_asset_data_id(db).accumulated_fees.get_amount() == _izzy(0).amount );
 
          // can claim in multiple goes
          claim_fees( jill_id, _jill(4) );
-         BOOST_CHECK( jillcoin.dynamic_asset_data_id(db).accumulated_fees == _jill(2).amount );
+         BOOST_CHECK( jillcoin.dynamic_asset_data_id(db).accumulated_fees.get_amount() == _jill(2).amount );
          GRAPHENE_REQUIRE_THROW( claim_fees( jill_id, _jill(2) + jill_satoshi ), fc::exception );
          claim_fees( jill_id, _jill(2) );
-         BOOST_CHECK( jillcoin.dynamic_asset_data_id(db).accumulated_fees == _jill(0).amount );
+         BOOST_CHECK( jillcoin.dynamic_asset_data_id(db).accumulated_fees.get_amount() == _jill(0).amount );
       }
    }
    FC_LOG_AND_RETHROW()
@@ -287,8 +287,8 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
         fund_fee_pool( alice_id(db), alicecoin_id(db), _core(300).amount );
 
         // Test amount of CORE in fee pools
-        BOOST_CHECK( alicecoin_id(db).dynamic_asset_data_id(db).fee_pool == _core(300).amount );
-        BOOST_CHECK( aliceusd_id(db).dynamic_asset_data_id(db).fee_pool == _core(100).amount );
+        BOOST_CHECK( alicecoin_id(db).dynamic_asset_data_id(db).fee_pool.get_amount() == _core(300).amount );
+        BOOST_CHECK( aliceusd_id(db).dynamic_asset_data_id(db).fee_pool.get_amount() == _core(100).amount );
 
         // can't claim pool of an asset that doesn't belong to you
         GRAPHENE_REQUIRE_THROW( claim_pool( alice_id, bobcoin_id, _core(200), core_asset_hf), fc::exception );
@@ -301,12 +301,12 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
 
         // can claim BTS back from the fee pool
         claim_pool( alice_id, alicecoin_id, _core(200), core_asset_hf );
-        BOOST_CHECK( alicecoin_id(db).dynamic_asset_data_id(db).fee_pool == _core(100).amount );
+        BOOST_CHECK( alicecoin_id(db).dynamic_asset_data_id(db).fee_pool.get_amount() == _core(100).amount );
 
         // can pay fee in the asset other than the one whose pool is being drained
         share_type balance_before_claim = get_balance( alice_id, asset_id_type() );
         claim_pool( alice_id, alicecoin_id, _core(100), aliceusd_id(db) );
-        BOOST_CHECK( alicecoin_id(db).dynamic_asset_data_id(db).fee_pool == _core(0).amount );
+        BOOST_CHECK( alicecoin_id(db).dynamic_asset_data_id(db).fee_pool.get_amount() == _core(0).amount );
 
         //check balance after claiming pool
         share_type current_balance = get_balance( alice_id, asset_id_type() );
@@ -326,14 +326,14 @@ BOOST_AUTO_TEST_CASE(asset_claim_pool_test)
    BOOST_CHECK_EQUAL( get_balance( actor_name ## _id, asset_id_type() ), amount )
 
 #define CHECK_VESTED_CASHBACK( actor_name, amount ) \
-   BOOST_CHECK_EQUAL( actor_name ## _id(db).statistics(db).pending_vested_fees.value, amount )
+   BOOST_CHECK_EQUAL( actor_name ## _id(db).statistics(db).pending_vested_fees.get_amount().value, amount )
 
 #define CHECK_UNVESTED_CASHBACK( actor_name, amount ) \
-   BOOST_CHECK_EQUAL( actor_name ## _id(db).statistics(db).pending_fees.value, amount )
+   BOOST_CHECK_EQUAL( actor_name ## _id(db).statistics(db).pending_fees.get_amount().value, amount )
 
 #define GET_CASHBACK_BALANCE( account ) \
    ( (account.cashback_vb.valid()) \
-   ? account.cashback_balance(db).balance.amount.value \
+   ? account.cashback_balance(db).balance.get_amount().value \
    : 0 )
 
 #define CHECK_CASHBACK_VBO( actor_name, _amount ) \
@@ -965,8 +965,8 @@ BOOST_AUTO_TEST_CASE( non_core_fee_refund_test )
          BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
          BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
          BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-         BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+         BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
          // Bob cancels order
          if( !expire_order )
@@ -1004,8 +1004,8 @@ BOOST_AUTO_TEST_CASE( non_core_fee_refund_test )
          BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
          BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
          BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-         BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+         BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
 
          // Alice cancels order
@@ -1020,8 +1020,8 @@ BOOST_AUTO_TEST_CASE( non_core_fee_refund_test )
          BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
          BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
          BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-         BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+         BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
          // Check partial fill
          const limit_order_object* ao2 = create_sell_order( alice_id, asset(1000), asset(200, usd_id), exp, cer );
@@ -1047,8 +1047,8 @@ BOOST_AUTO_TEST_CASE( non_core_fee_refund_test )
          BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
          BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
          BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-         BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+         BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
          // cancel Alice order, show that entire deferred_fee was consumed by partial match
          if( !expire_order )
@@ -1087,8 +1087,8 @@ BOOST_AUTO_TEST_CASE( non_core_fee_refund_test )
          BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
          BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
          BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-         BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+         BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
          // Check multiple fill
          // Alice creating multiple orders
@@ -1113,8 +1113,8 @@ BOOST_AUTO_TEST_CASE( non_core_fee_refund_test )
          BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
          BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
          BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-         BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+         BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
          // Bob creating an order matching multiple Alice's orders
          const limit_order_object* bo31 = create_sell_order(   bob_id, asset(500, usd_id), asset(2500), exp );
@@ -1138,8 +1138,8 @@ BOOST_AUTO_TEST_CASE( non_core_fee_refund_test )
          BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
          BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
          BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-         BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+         BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
          // Bob creating an order matching multiple Alice's orders
          const limit_order_object* bo32 = create_sell_order(   bob_id, asset(500, usd_id), asset(2500), exp );
@@ -1163,8 +1163,8 @@ BOOST_AUTO_TEST_CASE( non_core_fee_refund_test )
          BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
          BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
          BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-         BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+         BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
          // cancel Bob order, show that entire deferred_fee was consumed by partial match
          if( !expire_order )
@@ -1202,8 +1202,8 @@ BOOST_AUTO_TEST_CASE( non_core_fee_refund_test )
          BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
          BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
          BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-         BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+         BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
          // cancel Alice order, will refund after hard fork 445
          cancel_limit_order( ao32id( db ) );
@@ -1217,8 +1217,8 @@ BOOST_AUTO_TEST_CASE( non_core_fee_refund_test )
          BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
          BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
          BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-         BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+         BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
          // undo above tx's and reset
          generate_block( skip );
@@ -1337,8 +1337,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // ao3: won't expire, partially match before hard fork 445, fee in core
       BOOST_TEST_MESSAGE( "Creating order ao3 .." );
@@ -1358,8 +1358,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // ao4: will expire, will partially match before hard fork 445, fee in core
       BOOST_TEST_MESSAGE( "Creating order ao4 .." );
@@ -1379,8 +1379,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // bo3: won't expire, will partially match before hard fork 445, fee in usd
       BOOST_TEST_MESSAGE( "Creating order bo3 .." );
@@ -1402,8 +1402,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // bo4: will expire, will partially match before hard fork 445, fee in usd
       BOOST_TEST_MESSAGE( "Creating order bo4 .." );
@@ -1425,8 +1425,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // ao5: won't expire, partially match after hard fork 445, fee in core
       BOOST_TEST_MESSAGE( "Creating order ao5 .." );
@@ -1441,8 +1441,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // ao6: will expire, partially match after hard fork 445, fee in core
       BOOST_TEST_MESSAGE( "Creating order ao6 .." );
@@ -1457,8 +1457,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // bo5: won't expire, partially match after hard fork 445, fee in usd
       BOOST_TEST_MESSAGE( "Creating order bo5 .." );
@@ -1475,8 +1475,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // bo6: will expire, partially match after hard fork 445, fee in usd
       BOOST_TEST_MESSAGE( "Creating order bo6 .." );
@@ -1493,8 +1493,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // generate block so the orders will be in db before hard fork
       BOOST_TEST_MESSAGE( "Generating blocks ..." );
@@ -1509,8 +1509,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // generate more blocks, so some orders will expire
       generate_blocks( exp, true, skip );
@@ -1526,8 +1526,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // prepare for new transactions
       enable_fees();
@@ -1546,8 +1546,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // cancel ao3
       BOOST_TEST_MESSAGE( "Cancel order ao3 .." );
@@ -1560,8 +1560,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // cancel bo1
       BOOST_TEST_MESSAGE( "Cancel order bo1 .." );
@@ -1574,8 +1574,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // cancel bo3
       BOOST_TEST_MESSAGE( "Cancel order bo3 .." );
@@ -1588,8 +1588,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // partially fill ao6
       BOOST_TEST_MESSAGE( "Partially fill ao6 .." );
@@ -1605,8 +1605,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // partially fill bo6
       BOOST_TEST_MESSAGE( "Partially fill bo6 .." );
@@ -1622,8 +1622,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // generate block to save the changes
       BOOST_TEST_MESSAGE( "Generating blocks ..." );
@@ -1633,8 +1633,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // generate blocks util exp2, so some orders will expire
       generate_blocks( exp2, true, skip );
@@ -1648,8 +1648,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // prepare for new transactions
       enable_fees();
@@ -1671,8 +1671,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // partially fill bo5
       BOOST_TEST_MESSAGE( "Partially fill bo5 .." );
@@ -1688,8 +1688,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // cancel ao5
       BOOST_TEST_MESSAGE( "Cancel order ao5 .." );
@@ -1702,8 +1702,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // cancel bo5
       BOOST_TEST_MESSAGE( "Cancel order bo5 .." );
@@ -1716,8 +1716,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // generate block to save the changes
       BOOST_TEST_MESSAGE( "Generating blocks ..." );
@@ -1727,8 +1727,8 @@ BOOST_AUTO_TEST_CASE( hf445_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
    }
    FC_LOG_AND_RETHROW()
@@ -1913,8 +1913,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_test )
          BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
          BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
          BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-         BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+         BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
          // Alice cancels order
          if( !expire_order )
@@ -1969,8 +1969,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_test )
          BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
          BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
          BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-         BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+         BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
          BOOST_TEST_MESSAGE( "Creating bo1" );
          limit_order_id_type bo1_id = create_sell_order(   bob_id, asset(500, usd_id), asset(1000), exp, cer )->id;
@@ -1984,8 +1984,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_test )
          BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
          BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
          BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-         BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+         BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
          // Bob cancels order
          if( !expire_order )
@@ -2054,8 +2054,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_test )
          BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
          BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
          BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-         BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+         BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
 
          // Check partial fill
@@ -2084,8 +2084,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_test )
          BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
          BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
          BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-         BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+         BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
          // cancel Alice order, show that entire deferred_fee was consumed by partial match
          if( !expire_order )
@@ -2128,8 +2128,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_test )
          BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
          BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
          BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-         BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+         BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
          // Check multiple fill
          // Alice creating multiple orders
@@ -2155,8 +2155,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_test )
          BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
          BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
          BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-         BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+         BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
          // Bob creating an order matching multiple Alice's orders
          BOOST_TEST_MESSAGE( "Creating bo31, completely fill ao31 and ao33, partially fill ao34" );
@@ -2182,8 +2182,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_test )
          BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
          BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
          BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-         BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+         BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
          // Bob creating an order matching multiple Alice's orders
          BOOST_TEST_MESSAGE( "Creating bo32, completely fill partially filled ao34 and new ao35, leave on market" );
@@ -2209,8 +2209,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_test )
          BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
          BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
          BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-         BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+         BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
          // cancel Bob order, show that entire deferred_fee was consumed by partial match
          if( !expire_order )
@@ -2252,8 +2252,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_test )
          BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
          BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
          BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-         BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+         BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
          // cancel Alice order, will refund after hard fork 445
          BOOST_TEST_MESSAGE( "Cancel order ao32" );
@@ -2269,8 +2269,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_test )
          BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
          BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
          BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-         BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+         BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+         BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
          // undo above tx's and reset
          BOOST_TEST_MESSAGE( "Clean up" );
@@ -2401,8 +2401,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // ao3: won't expire, partially match before hard fork 445, fee in core
       BOOST_TEST_MESSAGE( "Creating order ao3 .." ); // 1:30
@@ -2422,8 +2422,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // ao4: will expire, will partially match before hard fork 445, fee in core
       BOOST_TEST_MESSAGE( "Creating order ao4 .." ); // 1:20
@@ -2443,8 +2443,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // bo3: won't expire, will partially match before hard fork 445, fee in usd
       BOOST_TEST_MESSAGE( "Creating order bo3 .." ); // 1:30
@@ -2466,8 +2466,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // bo4: will expire, will partially match before hard fork 445, fee in usd
       BOOST_TEST_MESSAGE( "Creating order bo4 .." ); // 1:20
@@ -2489,8 +2489,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
 
       // ao11: won't expire, partially match after hard fork core-604, fee in core
@@ -2506,8 +2506,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // ao12: will expire, partially match after hard fork core-604, fee in core
       BOOST_TEST_MESSAGE( "Creating order ao12 .." ); // 1:16
@@ -2522,8 +2522,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // bo11: won't expire, partially match after hard fork core-604, fee in usd
       BOOST_TEST_MESSAGE( "Creating order bo11 .." ); // 1:18
@@ -2540,8 +2540,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // bo12: will expire, partially match after hard fork core-604, fee in usd
       BOOST_TEST_MESSAGE( "Creating order bo12 .." ); // 1:17
@@ -2558,8 +2558,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // ao5: won't expire, partially match after hard fork 445, fee in core
       BOOST_TEST_MESSAGE( "Creating order ao5 .." ); // 1:15
@@ -2574,8 +2574,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // ao6: will expire, partially match after hard fork 445, fee in core
       if( false ) { // only can have either ao5 or ao6, can't have both
@@ -2591,8 +2591,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
       }
 
       // bo5: won't expire, partially match after hard fork 445, fee in usd
@@ -2611,8 +2611,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
       }
 
       // bo6: will expire, partially match after hard fork 445, fee in usd
@@ -2631,8 +2631,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // generate block so the orders will be in db before hard fork 445
       BOOST_TEST_MESSAGE( "Generating blocks, passing hard fork 445 ..." );
@@ -2647,8 +2647,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // prepare for new transactions
       enable_fees();
@@ -2671,8 +2671,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
       }
 
       // partially fill bo6
@@ -2689,8 +2689,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // partially fill ao5
       BOOST_TEST_MESSAGE( "Partially fill ao5 .." ); // 1:15
@@ -2706,8 +2706,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // partially fill bo5
       if( false ) { // only can have either bo5 or bo6, can't have both
@@ -2724,8 +2724,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
       }
 
       // prepare more orders
@@ -2760,8 +2760,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // ao9: won't expire, partially match before hard fork core-604, fee in core
       BOOST_TEST_MESSAGE( "Creating order ao9 .." ); // 1:3
@@ -2781,8 +2781,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // ao10: will expire, will partially match before hard fork core-604, fee in core
       BOOST_TEST_MESSAGE( "Creating order ao10 .." ); // 1:2
@@ -2802,8 +2802,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // bo9: won't expire, will partially match before hard fork core-604, fee in usd
       BOOST_TEST_MESSAGE( "Creating order bo9 .." ); // 1:3
@@ -2825,8 +2825,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // bo10: will expire, will partially match before hard fork core-604, fee in usd
       BOOST_TEST_MESSAGE( "Creating order bo10 .." ); // 1:2
@@ -2848,8 +2848,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // ao13: won't expire, partially match after hard fork core-604, fee in core
       BOOST_TEST_MESSAGE( "Creating order ao13 .." ); // 1:1.5
@@ -2864,8 +2864,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // ao14: will expire, partially match after hard fork core-604, fee in core
       BOOST_TEST_MESSAGE( "Creating order ao14 .." ); // 1:1.2
@@ -2880,8 +2880,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // bo13: won't expire, partially match after hard fork core-604, fee in usd
       BOOST_TEST_MESSAGE( "Creating order bo13 .." ); // 1:1.5
@@ -2898,8 +2898,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // bo14: will expire, partially match after hard fork core-604, fee in usd
       BOOST_TEST_MESSAGE( "Creating order bo14 .." ); // 1:1.2
@@ -2916,8 +2916,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // generate block so the orders will be in db before hard fork core-604
       BOOST_TEST_MESSAGE( "Generating blocks, passing hard fork core-604 ..." );
@@ -2932,8 +2932,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // prepare for new transactions
       enable_fees();
@@ -2955,8 +2955,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // partially fill bo14
       BOOST_TEST_MESSAGE( "Partially fill bo14 .." ); // 1:1.2
@@ -2972,8 +2972,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // generate block to save the changes
       BOOST_TEST_MESSAGE( "Generating blocks ..." );
@@ -2983,8 +2983,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // generate more blocks, so some orders will expire
       generate_blocks( exp, true, skip );
@@ -3008,8 +3008,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // prepare for new transactions
       enable_fees();
@@ -3031,8 +3031,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // partially fill bo13
       BOOST_TEST_MESSAGE( "Partially fill bo13 .." ); // 1:1.5
@@ -3048,8 +3048,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // don't refund fee, only refund remaining funds, for manually cancellations with an explicit fee:
       // * orders created before hard fork 445 : ao1, ao3, ao5, bo1, bo3, bo5
@@ -3066,8 +3066,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // cancel bo1
       BOOST_TEST_MESSAGE( "Cancel order bo1 .." );
@@ -3080,8 +3080,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // cancel ao3
       BOOST_TEST_MESSAGE( "Cancel order ao3 .." );
@@ -3094,8 +3094,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // cancel bo3
       BOOST_TEST_MESSAGE( "Cancel order bo3 .." );
@@ -3108,8 +3108,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // cancel ao5
       BOOST_TEST_MESSAGE( "Cancel order ao5 .." );
@@ -3122,8 +3122,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // cancel bo5
       if( false ) { // can only have bo5 or bo6 but not both
@@ -3137,8 +3137,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
       }
 
       // cancel ao9
@@ -3152,8 +3152,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // cancel bo9
       BOOST_TEST_MESSAGE( "Cancel order bo9 .." );
@@ -3166,8 +3166,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // cancel ao13
       BOOST_TEST_MESSAGE( "Cancel order ao13 .." );
@@ -3180,8 +3180,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // cancel bo13
       BOOST_TEST_MESSAGE( "Cancel order bo13 .." );
@@ -3194,8 +3194,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
 
       // generate block to save the changes
@@ -3206,8 +3206,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // generate blocks util exp1, so some orders will expire
       BOOST_TEST_MESSAGE( "Generating blocks ..." );
@@ -3226,8 +3226,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // prepare for new transactions
       enable_fees();
@@ -3251,8 +3251,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // cancel bo7
       BOOST_TEST_MESSAGE( "Cancel order bo7 .." );
@@ -3266,8 +3266,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // partially fill ao12
       BOOST_TEST_MESSAGE( "Partially fill ao12 .." ); // 1:16
@@ -3283,8 +3283,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // partially fill bo12
       BOOST_TEST_MESSAGE( "Partially fill bo12 .." ); // 1:17
@@ -3300,8 +3300,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // generate block to save the changes
       BOOST_TEST_MESSAGE( "Generating blocks ..." );
@@ -3311,8 +3311,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // generate blocks util exp2, so some orders will expire
       generate_blocks( exp2, true, skip );
@@ -3327,8 +3327,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // prepare for new transactions
       enable_fees();
@@ -3350,8 +3350,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // partially fill bo11
       BOOST_TEST_MESSAGE( "Partially fill bo11 .." ); // 1:18
@@ -3367,8 +3367,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // no fee refund for orders created before hard fork 445, if manually cancelled with an explicit fee.
       // remaining funds will be refunded
@@ -3384,8 +3384,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // cancel bo11
       BOOST_TEST_MESSAGE( "Cancel order bo11 .." );
@@ -3398,8 +3398,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
       // generate block to save the changes
       BOOST_TEST_MESSAGE( "Generating blocks ..." );
@@ -3409,8 +3409,8 @@ BOOST_AUTO_TEST_CASE( bsip26_fee_refund_cross_test )
       BOOST_CHECK_EQUAL( get_balance( alice_id,  usd_id ), alice_bu );
       BOOST_CHECK_EQUAL( get_balance(   bob_id, core_id ), bob_bc );
       BOOST_CHECK_EQUAL( get_balance(   bob_id,  usd_id ), bob_bu );
-      BOOST_CHECK_EQUAL( usd_stat->fee_pool.value,          pool_b );
-      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.value,  accum_b );
+      BOOST_CHECK_EQUAL( usd_stat->fee_pool.get_amount().value,          pool_b );
+      BOOST_CHECK_EQUAL( usd_stat->accumulated_fees.get_amount().value,  accum_b );
 
    }
    FC_LOG_AND_RETHROW()

--- a/tests/tests/market_fee_sharing_tests.cpp
+++ b/tests/tests/market_fee_sharing_tests.cpp
@@ -650,8 +650,8 @@ BOOST_AUTO_TEST_CASE(accumulated_fees_before_hf_test)
 
       // 100 Izzys and 300 Jills are matched, so the fees should be
       // 10 Izzy (10%) and 60 Jill (20%).
-      BOOST_CHECK( izzycoin.dynamic_asset_data_id(db).accumulated_fees == izzycoin.amount(10).amount );
-      BOOST_CHECK( jillcoin.dynamic_asset_data_id(db).accumulated_fees == jillcoin.amount(60).amount );
+      BOOST_CHECK( izzycoin.dynamic_asset_data_id(db).accumulated_fees.get_amount() == izzycoin.amount(10).amount );
+      BOOST_CHECK( jillcoin.dynamic_asset_data_id(db).accumulated_fees.get_amount() == jillcoin.amount(60).amount );
    }
    FC_LOG_AND_RETHROW()
 }
@@ -674,8 +674,8 @@ BOOST_AUTO_TEST_CASE(accumulated_fees_after_hf_test)
 
       // 100 Izzys and 300 Jills are matched, so the fees should be
       // 10 Izzy (10%) and 60 Jill (20%).
-      BOOST_CHECK( izzycoin.dynamic_asset_data_id(db).accumulated_fees == izzycoin.amount(10).amount );
-      BOOST_CHECK( jillcoin.dynamic_asset_data_id(db).accumulated_fees == jillcoin.amount(60).amount );
+      BOOST_CHECK( izzycoin.dynamic_asset_data_id(db).accumulated_fees.get_amount() == izzycoin.amount(10).amount );
+      BOOST_CHECK( jillcoin.dynamic_asset_data_id(db).accumulated_fees.get_amount() == jillcoin.amount(60).amount );
    }
    FC_LOG_AND_RETHROW()
 }
@@ -705,8 +705,8 @@ BOOST_AUTO_TEST_CASE(accumulated_fees_with_additional_options_after_hf_test)
 
       // 100 Izzys and 300 Jills are matched, so the fees should be
       // 10 Izzy (10%) and 60 Jill (20%).
-      BOOST_CHECK( izzycoin.dynamic_asset_data_id(db).accumulated_fees == izzycoin.amount(10).amount );
-      BOOST_CHECK( jillcoin.dynamic_asset_data_id(db).accumulated_fees == jillcoin.amount(60).amount );
+      BOOST_CHECK( izzycoin.dynamic_asset_data_id(db).accumulated_fees.get_amount() == izzycoin.amount(10).amount );
+      BOOST_CHECK( jillcoin.dynamic_asset_data_id(db).accumulated_fees.get_amount() == jillcoin.amount(60).amount );
    }
    FC_LOG_AND_RETHROW()
 }

--- a/tests/tests/market_rounding_tests.cpp
+++ b/tests/tests/market_rounding_tests.cpp
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE( limit_limit_rounding_test1 )
       // the order is filled immediately
       BOOST_CHECK( !create_sell_order( buyer, test.amount(25), core.amount(2) ) );
 
-      BOOST_CHECK_EQUAL( sell_id(db).for_sale.value, 1 ); // 2 core sold, 1 remaining
+      BOOST_CHECK_EQUAL( sell_id(db).for_sale.get_amount().value, 1 ); // 2 core sold, 1 remaining
 
       BOOST_CHECK_EQUAL(get_balance(seller, core), 99999997);
       BOOST_CHECK_EQUAL(get_balance(seller, test), 25); // seller got 25 test
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE( limit_limit_rounding_test1 )
       generate_block();
 
       BOOST_CHECK( !db.find_object( sell_id ) ); // sell order is filled
-      BOOST_CHECK_EQUAL( buy_id(db).for_sale.value, 15 ); // 10 test sold, 15 remaining
+      BOOST_CHECK_EQUAL( buy_id(db).for_sale.get_amount().value, 15 ); // 10 test sold, 15 remaining
 
       BOOST_CHECK_EQUAL(get_balance(seller_id, core_id), 99999997);
       BOOST_CHECK_EQUAL(get_balance(seller_id, test_id), 35); // seller got 10 more test
@@ -244,7 +244,7 @@ BOOST_AUTO_TEST_CASE( limit_limit_rounding_test1_after_hf_342 )
       // the order is filled immediately
       BOOST_CHECK( !create_sell_order( buyer, test.amount(25), core.amount(2) ) );
 
-      BOOST_CHECK_EQUAL( sell_id(db).for_sale.value, 1 ); // 2 core sold, 1 remaining
+      BOOST_CHECK_EQUAL( sell_id(db).for_sale.get_amount().value, 1 ); // 2 core sold, 1 remaining
 
       BOOST_CHECK_EQUAL(get_balance(buyer, core), 2); // buyer got 2 core
       BOOST_CHECK_EQUAL(get_balance(buyer, test), 9999979); // buyer actually paid 21 test according to price 10.33
@@ -260,7 +260,7 @@ BOOST_AUTO_TEST_CASE( limit_limit_rounding_test1_after_hf_342 )
       generate_block();
 
       BOOST_CHECK( !db.find_object( sell_id ) ); // sell order is filled
-      BOOST_CHECK_EQUAL( buy_id(db).for_sale.value, 15 ); // 10 test sold according to price 10.33, and 15 remaining
+      BOOST_CHECK_EQUAL( buy_id(db).for_sale.get_amount().value, 15 ); // 10 test sold according to price 10.33, and 15 remaining
 
       BOOST_CHECK_EQUAL(get_balance(buyer_id, core_id), 3); // buyer got 1 more core
       BOOST_CHECK_EQUAL(get_balance(buyer_id, test_id), 9999954);
@@ -306,7 +306,7 @@ BOOST_AUTO_TEST_CASE( limit_limit_rounding_test2 )
       limit_order_id_type sell_id = create_sell_order( seller, core.amount(33), test.amount(5) )->id;
 
       BOOST_CHECK( !db.find_object( tmp_buy_id ) ); // buy order is filled
-      BOOST_CHECK_EQUAL( sell_id(db).for_sale.value, 16 ); // 17 core sold, 16 remaining
+      BOOST_CHECK_EQUAL( sell_id(db).for_sale.get_amount().value, 16 ); // 17 core sold, 16 remaining
 
       BOOST_CHECK_EQUAL(get_balance(seller, core), 99999967);
       BOOST_CHECK_EQUAL(get_balance(seller, test), 3); // seller got 3 test
@@ -323,7 +323,7 @@ BOOST_AUTO_TEST_CASE( limit_limit_rounding_test2 )
       generate_block();
 
       BOOST_CHECK( !db.find_object( sell_id ) ); // sell order is filled
-      BOOST_CHECK_EQUAL( buy_id(db).for_sale.value, 1 ); // 2 test sold, 1 remaining
+      BOOST_CHECK_EQUAL( buy_id(db).for_sale.get_amount().value, 1 ); // 2 test sold, 1 remaining
 
       BOOST_CHECK_EQUAL(get_balance(seller_id, core_id), 99999967); // seller paid the 16 core which was remaining in the order
       BOOST_CHECK_EQUAL(get_balance(seller_id, test_id), 5); // seller got 2 more test
@@ -373,7 +373,7 @@ BOOST_AUTO_TEST_CASE( limit_limit_rounding_test2_after_hf_342 )
       limit_order_id_type sell_id = create_sell_order( seller, core.amount(33), test.amount(5) )->id;
 
       BOOST_CHECK( !db.find_object( tmp_buy_id ) ); // buy order is filled
-      BOOST_CHECK_EQUAL( sell_id(db).for_sale.value, 16 ); // 17 core sold, 16 remaining
+      BOOST_CHECK_EQUAL( sell_id(db).for_sale.get_amount().value, 16 ); // 17 core sold, 16 remaining
 
       BOOST_CHECK_EQUAL(get_balance(seller, core), 99999967);
       BOOST_CHECK_EQUAL(get_balance(seller, test), 3); // seller got 3 test
@@ -390,7 +390,7 @@ BOOST_AUTO_TEST_CASE( limit_limit_rounding_test2_after_hf_342 )
       generate_block();
 
       BOOST_CHECK( !db.find_object( sell_id ) ); // sell order is filled
-      BOOST_CHECK_EQUAL( buy_id(db).for_sale.value, 1 ); // 2 test sold, 1 remaining
+      BOOST_CHECK_EQUAL( buy_id(db).for_sale.get_amount().value, 1 ); // 2 test sold, 1 remaining
 
       BOOST_CHECK_EQUAL(get_balance(buyer_id, core_id), 31); // buyer got 14 more core according to price 0.1515
       BOOST_CHECK_EQUAL(get_balance(buyer_id, test_id), 9999994);
@@ -444,12 +444,12 @@ BOOST_AUTO_TEST_CASE( issue_132_limit_and_call_test1 )
    transfer(borrower2, seller, bitusd.amount(100000));
    transfer(borrower3, seller, bitusd.amount(100000));
 
-   BOOST_CHECK_EQUAL( 10, call.debt.value );
-   BOOST_CHECK_EQUAL( 1, call.collateral.value );
-   BOOST_CHECK_EQUAL( 100000, call2.debt.value );
-   BOOST_CHECK_EQUAL( 15500, call2.collateral.value );
-   BOOST_CHECK_EQUAL( 100000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 17500, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 10, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 1, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 100000, call2.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15500, call2.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 100000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 17500, call3.collateral.get_amount().value );
 
    BOOST_CHECK_EQUAL( 200010, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
@@ -516,10 +516,10 @@ BOOST_AUTO_TEST_CASE( issue_132_limit_and_call_test2 )
    transfer(borrower, seller, bitusd.amount(10));
    transfer(borrower3, seller, bitusd.amount(100000));
 
-   BOOST_CHECK_EQUAL( 10, call.debt.value );
-   BOOST_CHECK_EQUAL( 1, call.collateral.value );
-   BOOST_CHECK_EQUAL( 100000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 17500, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 10, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 1, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 100000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 17500, call3.collateral.get_amount().value );
 
    BOOST_CHECK_EQUAL( 100010, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
@@ -538,7 +538,7 @@ BOOST_AUTO_TEST_CASE( issue_132_limit_and_call_test2 )
    BOOST_CHECK( !db.find<call_order_object>( call_id ) ); // the first call order get filled
    BOOST_CHECK_EQUAL( 100010-33, get_balance(seller, bitusd) ); // the seller paid 33 USD
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) ); // the seller got nothing
-   BOOST_CHECK_EQUAL( 33-10, sell_id(db).for_sale.value ); // the sell order has some USD left
+   BOOST_CHECK_EQUAL( 33-10, sell_id(db).for_sale.get_amount().value ); // the sell order has some USD left
    BOOST_CHECK_EQUAL( 0, get_balance(borrower, bitusd) );
    BOOST_CHECK_EQUAL( init_balance, get_balance(borrower, core) );
 
@@ -589,10 +589,10 @@ BOOST_AUTO_TEST_CASE( issue_132_limit_and_call_test3 )
    transfer(borrower, seller, bitusd.amount(10));
    transfer(borrower3, seller, bitusd.amount(100000));
 
-   BOOST_CHECK_EQUAL( 10, call.debt.value );
-   BOOST_CHECK_EQUAL( 1, call.collateral.value );
-   BOOST_CHECK_EQUAL( 100000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 17500, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 10, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 1, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 100000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 17500, call3.collateral.get_amount().value );
 
    BOOST_CHECK_EQUAL( 100010, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
@@ -601,7 +601,7 @@ BOOST_AUTO_TEST_CASE( issue_132_limit_and_call_test3 )
 
    // create a limit order which will be matched later
    limit_order_id_type sell_id = create_sell_order(seller, bitusd.amount(33), core.amount(3))->id;
-   BOOST_CHECK_EQUAL( 33, sell_id(db).for_sale.value );
+   BOOST_CHECK_EQUAL( 33, sell_id(db).for_sale.get_amount().value );
    BOOST_CHECK_EQUAL( 100010-33, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
 
@@ -618,7 +618,7 @@ BOOST_AUTO_TEST_CASE( issue_132_limit_and_call_test3 )
    BOOST_CHECK( !db.find<call_order_object>( call_id ) ); // the first call order get filled
    BOOST_CHECK_EQUAL( 100010-33, get_balance(seller_id, bitusd_id) ); // the seller paid 33 USD
    BOOST_CHECK_EQUAL( 0, get_balance(seller_id, core_id) ); // the seller got nothing
-   BOOST_CHECK_EQUAL( 33-10, sell_id(db).for_sale.value ); // the sell order has some USD left
+   BOOST_CHECK_EQUAL( 33-10, sell_id(db).for_sale.get_amount().value ); // the sell order has some USD left
    BOOST_CHECK_EQUAL( 0, get_balance(borrower_id, bitusd_id) );
    BOOST_CHECK_EQUAL( init_balance, get_balance(borrower_id, core_id) );
 
@@ -667,12 +667,12 @@ BOOST_AUTO_TEST_CASE( issue_132_limit_and_call_test1_after_hardfork )
    transfer(borrower2, seller, bitusd.amount(100000));
    transfer(borrower3, seller, bitusd.amount(100000));
 
-   BOOST_CHECK_EQUAL( 10, call.debt.value );
-   BOOST_CHECK_EQUAL( 1, call.collateral.value );
-   BOOST_CHECK_EQUAL( 100000, call2.debt.value );
-   BOOST_CHECK_EQUAL( 15500, call2.collateral.value );
-   BOOST_CHECK_EQUAL( 100000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 17500, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 10, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 1, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 100000, call2.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15500, call2.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 100000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 17500, call3.collateral.get_amount().value );
 
    BOOST_CHECK_EQUAL( 200010, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
@@ -740,10 +740,10 @@ BOOST_AUTO_TEST_CASE( issue_132_limit_and_call_test2_after_hardfork )
    transfer(borrower, seller, bitusd.amount(10));
    transfer(borrower3, seller, bitusd.amount(100000));
 
-   BOOST_CHECK_EQUAL( 10, call.debt.value );
-   BOOST_CHECK_EQUAL( 1, call.collateral.value );
-   BOOST_CHECK_EQUAL( 100000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 17500, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 10, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 1, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 100000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 17500, call3.collateral.get_amount().value );
 
    BOOST_CHECK_EQUAL( 100010, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
@@ -763,7 +763,7 @@ BOOST_AUTO_TEST_CASE( issue_132_limit_and_call_test2_after_hardfork )
    BOOST_CHECK( !db.find<call_order_object>( call_id ) ); // the first call order get filled
    BOOST_CHECK_EQUAL( 100010-33, get_balance(seller, bitusd) ); // the seller paid 33 USD
    BOOST_CHECK_EQUAL( 1, get_balance(seller, core) ); // the seller got 1 CORE
-   BOOST_CHECK_EQUAL( 33-10, sell_id(db).for_sale.value ); // the sell order has some USD left
+   BOOST_CHECK_EQUAL( 33-10, sell_id(db).for_sale.get_amount().value ); // the sell order has some USD left
    BOOST_CHECK_EQUAL( 0, get_balance(borrower, bitusd) );
    BOOST_CHECK_EQUAL( init_balance-1, get_balance(borrower, core) );
 
@@ -815,10 +815,10 @@ BOOST_AUTO_TEST_CASE( issue_132_limit_and_call_test3_after_hardfork )
    transfer(borrower, seller, bitusd.amount(10));
    transfer(borrower3, seller, bitusd.amount(100000));
 
-   BOOST_CHECK_EQUAL( 10, call.debt.value );
-   BOOST_CHECK_EQUAL( 1, call.collateral.value );
-   BOOST_CHECK_EQUAL( 100000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 17500, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 10, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 1, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 100000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 17500, call3.collateral.get_amount().value );
 
    BOOST_CHECK_EQUAL( 100010, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
@@ -827,7 +827,7 @@ BOOST_AUTO_TEST_CASE( issue_132_limit_and_call_test3_after_hardfork )
 
    // create a limit order which will be matched later
    limit_order_id_type sell_id = create_sell_order(seller, bitusd.amount(33), core.amount(3))->id;
-   BOOST_CHECK_EQUAL( 33, sell_id(db).for_sale.value );
+   BOOST_CHECK_EQUAL( 33, sell_id(db).for_sale.get_amount().value );
    BOOST_CHECK_EQUAL( 100010-33, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
 
@@ -844,7 +844,7 @@ BOOST_AUTO_TEST_CASE( issue_132_limit_and_call_test3_after_hardfork )
    BOOST_CHECK( !db.find<call_order_object>( call_id ) ); // the first call order get filled
    BOOST_CHECK_EQUAL( 100010-33, get_balance(seller_id, bitusd_id) ); // the seller paid 33 USD
    BOOST_CHECK_EQUAL( 1, get_balance(seller_id, core_id) ); // the seller got 1 CORE
-   BOOST_CHECK_EQUAL( 33-10, sell_id(db).for_sale.value ); // the sell order has some USD left
+   BOOST_CHECK_EQUAL( 33-10, sell_id(db).for_sale.get_amount().value ); // the sell order has some USD left
    BOOST_CHECK_EQUAL( 0, get_balance(borrower_id, bitusd_id) );
    BOOST_CHECK_EQUAL( init_balance-1, get_balance(borrower_id, core_id) );
 
@@ -891,10 +891,10 @@ BOOST_AUTO_TEST_CASE( limit_call_rounding_test1 )
    transfer(borrower, seller, bitusd.amount(20));
    transfer(borrower3, seller, bitusd.amount(100000));
 
-   BOOST_CHECK_EQUAL( 20, call.debt.value );
-   BOOST_CHECK_EQUAL( 2, call.collateral.value );
-   BOOST_CHECK_EQUAL( 100000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 17500, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 20, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 2, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 100000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 17500, call3.collateral.get_amount().value );
 
    BOOST_CHECK_EQUAL( 100020, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
@@ -914,7 +914,7 @@ BOOST_AUTO_TEST_CASE( limit_call_rounding_test1 )
    BOOST_CHECK( !db.find<call_order_object>( call_id ) ); // the first call order get filled
    BOOST_CHECK_EQUAL( 100020-33, get_balance(seller, bitusd) ); // the seller paid 33 USD
    BOOST_CHECK_EQUAL( 1, get_balance(seller, core) ); // the seller got 1 CORE
-   BOOST_CHECK_EQUAL( 33-20, sell_id(db).for_sale.value ); // the sell order has some USD left
+   BOOST_CHECK_EQUAL( 33-20, sell_id(db).for_sale.get_amount().value ); // the sell order has some USD left
    BOOST_CHECK_EQUAL( 0, get_balance(borrower, bitusd) );
    BOOST_CHECK_EQUAL( init_balance-1, get_balance(borrower, core) );
 
@@ -962,10 +962,10 @@ BOOST_AUTO_TEST_CASE( limit_call_rounding_test1_after_hf_342 )
    transfer(borrower, seller, bitusd.amount(20));
    transfer(borrower3, seller, bitusd.amount(100000));
 
-   BOOST_CHECK_EQUAL( 20, call.debt.value );
-   BOOST_CHECK_EQUAL( 2, call.collateral.value );
-   BOOST_CHECK_EQUAL( 100000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 17500, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 20, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 2, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 100000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 17500, call3.collateral.get_amount().value );
 
    BOOST_CHECK_EQUAL( 100020, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
@@ -986,7 +986,7 @@ BOOST_AUTO_TEST_CASE( limit_call_rounding_test1_after_hf_342 )
    BOOST_CHECK( !db.find<call_order_object>( call_id ) ); // the first call order get filled
    BOOST_CHECK_EQUAL( 100020-33, get_balance(seller, bitusd) ); // the seller paid 33 USD
    BOOST_CHECK_EQUAL( 2, get_balance(seller, core) ); // the seller got 2 CORE
-   BOOST_CHECK_EQUAL( 33-20, sell_id(db).for_sale.value ); // the sell order has some USD left
+   BOOST_CHECK_EQUAL( 33-20, sell_id(db).for_sale.get_amount().value ); // the sell order has some USD left
    BOOST_CHECK_EQUAL( 0, get_balance(borrower, bitusd) );
    BOOST_CHECK_EQUAL( init_balance-2, get_balance(borrower, core) );
 
@@ -1036,10 +1036,10 @@ BOOST_AUTO_TEST_CASE( limit_call_rounding_test2 )
    transfer(borrower, seller, bitusd.amount(20));
    transfer(borrower3, seller, bitusd.amount(100000));
 
-   BOOST_CHECK_EQUAL( 20, call.debt.value );
-   BOOST_CHECK_EQUAL( 2, call.collateral.value );
-   BOOST_CHECK_EQUAL( 100000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 17500, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 20, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 2, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 100000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 17500, call3.collateral.get_amount().value );
 
    BOOST_CHECK_EQUAL( 100020, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
@@ -1056,8 +1056,8 @@ BOOST_AUTO_TEST_CASE( limit_call_rounding_test2 )
    //   effective price is 15/1.
    BOOST_CHECK( !create_sell_order(seller, bitusd.amount(15), core.amount(1)) ); // the sell order is filled
    BOOST_CHECK( db.find<call_order_object>( call_id ) != nullptr ); // the first call order did not get filled
-   BOOST_CHECK_EQUAL( 20-15, call.debt.value ); // call paid 15 USD
-   BOOST_CHECK_EQUAL( 2-1, call.collateral.value ); // call got 1 CORE
+   BOOST_CHECK_EQUAL( 20-15, call.debt.get_amount().value ); // call paid 15 USD
+   BOOST_CHECK_EQUAL( 2-1, call.collateral.get_amount().value ); // call got 1 CORE
    BOOST_CHECK_EQUAL( 100020-15, get_balance(seller, bitusd) ); // the seller paid 15 USD
    BOOST_CHECK_EQUAL( 1, get_balance(seller, core) ); // the seller got 1 CORE
    BOOST_CHECK_EQUAL( 0, get_balance(borrower, bitusd) );
@@ -1108,10 +1108,10 @@ BOOST_AUTO_TEST_CASE( limit_call_rounding_test2_after_hf_342 )
    transfer(borrower, seller, bitusd.amount(20));
    transfer(borrower3, seller, bitusd.amount(100000));
 
-   BOOST_CHECK_EQUAL( 20, call.debt.value );
-   BOOST_CHECK_EQUAL( 2, call.collateral.value );
-   BOOST_CHECK_EQUAL( 100000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 17500, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 20, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 2, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 100000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 17500, call3.collateral.get_amount().value );
 
    BOOST_CHECK_EQUAL( 100020, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
@@ -1129,8 +1129,8 @@ BOOST_AUTO_TEST_CASE( limit_call_rounding_test2_after_hf_342 )
    //     effective price is 11/1 which is close to 120/11.
    BOOST_CHECK( !create_sell_order(seller, bitusd.amount(15), core.amount(1)) ); // the sell order is filled
    BOOST_CHECK( db.find<call_order_object>( call_id ) != nullptr ); // the first call order did not get filled
-   BOOST_CHECK_EQUAL( 20-11, call.debt.value ); // call paid 11 USD
-   BOOST_CHECK_EQUAL( 2-1, call.collateral.value ); // call got 1 CORE
+   BOOST_CHECK_EQUAL( 20-11, call.debt.get_amount().value ); // call paid 11 USD
+   BOOST_CHECK_EQUAL( 2-1, call.collateral.get_amount().value ); // call got 1 CORE
    BOOST_CHECK_EQUAL( 100020-11, get_balance(seller, bitusd) ); // the seller paid 11 USD
    BOOST_CHECK_EQUAL( 1, get_balance(seller, core) ); // the seller got 1 CORE
    BOOST_CHECK_EQUAL( 0, get_balance(borrower, bitusd) );
@@ -1181,10 +1181,10 @@ BOOST_AUTO_TEST_CASE( call_limit_rounding_test1 )
    transfer(borrower, seller, bitusd.amount(20));
    transfer(borrower3, seller, bitusd.amount(100000));
 
-   BOOST_CHECK_EQUAL( 20, call.debt.value );
-   BOOST_CHECK_EQUAL( 2, call.collateral.value );
-   BOOST_CHECK_EQUAL( 100000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 17500, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 20, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 2, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 100000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 17500, call3.collateral.get_amount().value );
 
    BOOST_CHECK_EQUAL( 100020, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
@@ -1193,7 +1193,7 @@ BOOST_AUTO_TEST_CASE( call_limit_rounding_test1 )
 
    // create a limit order which will be matched later
    limit_order_id_type sell_id = create_sell_order(seller, bitusd.amount(33), core.amount(3))->id;
-   BOOST_CHECK_EQUAL( 33, sell_id(db).for_sale.value );
+   BOOST_CHECK_EQUAL( 33, sell_id(db).for_sale.get_amount().value );
    BOOST_CHECK_EQUAL( 100020-33, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
 
@@ -1211,7 +1211,7 @@ BOOST_AUTO_TEST_CASE( call_limit_rounding_test1 )
    BOOST_CHECK( !db.find<call_order_object>( call_id ) ); // the first call order get filled
    BOOST_CHECK_EQUAL( 100020-33, get_balance(seller_id, bitusd_id) ); // the seller paid 33 USD
    BOOST_CHECK_EQUAL( 1, get_balance(seller_id, core_id) ); // the seller got 1 CORE
-   BOOST_CHECK_EQUAL( 33-20, sell_id(db).for_sale.value ); // the sell order has some USD left
+   BOOST_CHECK_EQUAL( 33-20, sell_id(db).for_sale.get_amount().value ); // the sell order has some USD left
    BOOST_CHECK_EQUAL( 0, get_balance(borrower_id, bitusd_id) );
    BOOST_CHECK_EQUAL( init_balance-1, get_balance(borrower_id, core_id) );
 
@@ -1261,10 +1261,10 @@ BOOST_AUTO_TEST_CASE( call_limit_rounding_test1_after_hf_342 )
    transfer(borrower, seller, bitusd.amount(20));
    transfer(borrower3, seller, bitusd.amount(100000));
 
-   BOOST_CHECK_EQUAL( 20, call.debt.value );
-   BOOST_CHECK_EQUAL( 2, call.collateral.value );
-   BOOST_CHECK_EQUAL( 100000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 17500, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 20, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 2, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 100000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 17500, call3.collateral.get_amount().value );
 
    BOOST_CHECK_EQUAL( 100020, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
@@ -1273,7 +1273,7 @@ BOOST_AUTO_TEST_CASE( call_limit_rounding_test1_after_hf_342 )
 
    // create a limit order which will be matched later
    limit_order_id_type sell_id = create_sell_order(seller, bitusd.amount(33), core.amount(3))->id;
-   BOOST_CHECK_EQUAL( 33, sell_id(db).for_sale.value );
+   BOOST_CHECK_EQUAL( 33, sell_id(db).for_sale.get_amount().value );
    BOOST_CHECK_EQUAL( 100020-33, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
 
@@ -1291,7 +1291,7 @@ BOOST_AUTO_TEST_CASE( call_limit_rounding_test1_after_hf_342 )
    BOOST_CHECK( !db.find<call_order_object>( call_id ) ); // the first call order get filled
    BOOST_CHECK_EQUAL( 100020-33, get_balance(seller_id, bitusd_id) ); // the seller paid 33 USD
    BOOST_CHECK_EQUAL( 2, get_balance(seller_id, core_id) ); // the seller got 2 CORE
-   BOOST_CHECK_EQUAL( 33-20, sell_id(db).for_sale.value ); // the sell order has some USD left
+   BOOST_CHECK_EQUAL( 33-20, sell_id(db).for_sale.get_amount().value ); // the sell order has some USD left
    BOOST_CHECK_EQUAL( 0, get_balance(borrower_id, bitusd_id) );
    BOOST_CHECK_EQUAL( init_balance-2, get_balance(borrower_id, core_id) );
 
@@ -1340,10 +1340,10 @@ BOOST_AUTO_TEST_CASE( call_limit_rounding_test2 )
    transfer(borrower, seller, bitusd.amount(50));
    transfer(borrower3, seller2, bitusd.amount(100000));
 
-   BOOST_CHECK_EQUAL( 50, call.debt.value );
-   BOOST_CHECK_EQUAL( 5, call.collateral.value );
-   BOOST_CHECK_EQUAL( 100000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 17500, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 50, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 5, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 100000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 17500, call3.collateral.get_amount().value );
 
    BOOST_CHECK_EQUAL( 50, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 100000, get_balance(seller2, bitusd) );
@@ -1353,7 +1353,7 @@ BOOST_AUTO_TEST_CASE( call_limit_rounding_test2 )
 
    // create a buy order which will be matched
    limit_order_id_type buy_id = create_sell_order(buyer, core.amount(1), bitusd.amount(10))->id;
-   BOOST_CHECK_EQUAL( 1, buy_id(db).for_sale.value );
+   BOOST_CHECK_EQUAL( 1, buy_id(db).for_sale.get_amount().value );
    BOOST_CHECK_EQUAL( 1000000-1, get_balance(buyer, core) );
    BOOST_CHECK_EQUAL( 0, get_balance(buyer, bitusd) );
 
@@ -1362,13 +1362,13 @@ BOOST_AUTO_TEST_CASE( call_limit_rounding_test2 )
    BOOST_CHECK( !db.find<limit_order_object>( buy_id ) ); // the buy order is filled
    BOOST_CHECK_EQUAL( 1000000-1, get_balance(buyer, core) );
    BOOST_CHECK_EQUAL( 10, get_balance(buyer, bitusd) ); // buyer got 10 usd
-   BOOST_CHECK_EQUAL( 21, sell_id(db).for_sale.value ); // remaining amount of sell order is 21
+   BOOST_CHECK_EQUAL( 21, sell_id(db).for_sale.get_amount().value ); // remaining amount of sell order is 21
    BOOST_CHECK_EQUAL( 50-31, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 1, get_balance(seller, core) ); // seller got 1 core
 
    // create another limit order which will be matched later
    limit_order_id_type sell_id2 = create_sell_order(seller2, bitusd.amount(14), core.amount(1))->id;
-   BOOST_CHECK_EQUAL( 14, sell_id2(db).for_sale.value );
+   BOOST_CHECK_EQUAL( 14, sell_id2(db).for_sale.get_amount().value );
    BOOST_CHECK_EQUAL( 100000-14, get_balance(seller2, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller2, core) );
 
@@ -1388,8 +1388,8 @@ BOOST_AUTO_TEST_CASE( call_limit_rounding_test2 )
    BOOST_CHECK( !db.find<limit_order_object>( sell_id ) ); // the sell order is filled
    BOOST_CHECK( !db.find<limit_order_object>( sell_id2 ) ); // the other sell order is filled
    BOOST_CHECK( db.find<call_order_object>( call_id ) != nullptr ); // the first call order did not get filled
-   BOOST_CHECK_EQUAL( 50-14-21, call_id(db).debt.value ); // call paid 14 USD and 21 USD
-   BOOST_CHECK_EQUAL( 5-1-1, call_id(db).collateral.value ); // call got 1 CORE and 1 CORE
+   BOOST_CHECK_EQUAL( 50-14-21, call_id(db).debt.get_amount().value ); // call paid 14 USD and 21 USD
+   BOOST_CHECK_EQUAL( 5-1-1, call_id(db).collateral.get_amount().value ); // call got 1 CORE and 1 CORE
    BOOST_CHECK_EQUAL( 50-31, get_balance(seller_id, bitusd_id) ); // seller paid 31 USD in total
    BOOST_CHECK_EQUAL( 1+1, get_balance(seller_id, core_id) ); // seller got 1 more CORE
    BOOST_CHECK_EQUAL( 100000-14, get_balance(seller2_id, bitusd_id) ); // seller2 paid 14 USD
@@ -1443,10 +1443,10 @@ BOOST_AUTO_TEST_CASE( call_limit_rounding_test2_after_hf_342 )
    transfer(borrower, seller, bitusd.amount(50));
    transfer(borrower3, seller2, bitusd.amount(100000));
 
-   BOOST_CHECK_EQUAL( 50, call.debt.value );
-   BOOST_CHECK_EQUAL( 5, call.collateral.value );
-   BOOST_CHECK_EQUAL( 100000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 17500, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 50, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 5, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 100000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 17500, call3.collateral.get_amount().value );
 
    BOOST_CHECK_EQUAL( 50, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 100000, get_balance(seller2, bitusd) );
@@ -1456,7 +1456,7 @@ BOOST_AUTO_TEST_CASE( call_limit_rounding_test2_after_hf_342 )
 
    // create a buy order which will be matched
    limit_order_id_type buy_id = create_sell_order(buyer, core.amount(1), bitusd.amount(10))->id;
-   BOOST_CHECK_EQUAL( 1, buy_id(db).for_sale.value );
+   BOOST_CHECK_EQUAL( 1, buy_id(db).for_sale.get_amount().value );
    BOOST_CHECK_EQUAL( 1000000-1, get_balance(buyer, core) );
    BOOST_CHECK_EQUAL( 0, get_balance(buyer, bitusd) );
 
@@ -1465,13 +1465,13 @@ BOOST_AUTO_TEST_CASE( call_limit_rounding_test2_after_hf_342 )
    BOOST_CHECK( !db.find<limit_order_object>( buy_id ) ); // the buy order is filled
    BOOST_CHECK_EQUAL( 1000000-1, get_balance(buyer, core) );
    BOOST_CHECK_EQUAL( 10, get_balance(buyer, bitusd) ); // buyer got 10 usd
-   BOOST_CHECK_EQUAL( 21, sell_id(db).for_sale.value ); // remaining amount of sell order is 21
+   BOOST_CHECK_EQUAL( 21, sell_id(db).for_sale.get_amount().value ); // remaining amount of sell order is 21
    BOOST_CHECK_EQUAL( 50-31, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 1, get_balance(seller, core) ); // seller got 1 core
 
    // create another limit order which will be matched later
    limit_order_id_type sell_id2 = create_sell_order(seller2, bitusd.amount(14), core.amount(1))->id;
-   BOOST_CHECK_EQUAL( 14, sell_id2(db).for_sale.value );
+   BOOST_CHECK_EQUAL( 14, sell_id2(db).for_sale.get_amount().value );
    BOOST_CHECK_EQUAL( 100000-14, get_balance(seller2, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller2, core) );
 
@@ -1493,8 +1493,8 @@ BOOST_AUTO_TEST_CASE( call_limit_rounding_test2_after_hf_342 )
    BOOST_CHECK( !db.find<limit_order_object>( sell_id ) ); // the sell order is filled
    BOOST_CHECK( !db.find<limit_order_object>( sell_id2 ) ); // the other sell order is filled
    BOOST_CHECK( db.find<call_order_object>( call_id ) != nullptr ); // the first call order did not get filled
-   BOOST_CHECK_EQUAL( 50-14-16, call_id(db).debt.value ); // call paid 14 USD and 16 USD
-   BOOST_CHECK_EQUAL( 5-1-1, call_id(db).collateral.value ); // call got 1 CORE and 1 CORE
+   BOOST_CHECK_EQUAL( 50-14-16, call_id(db).debt.get_amount().value ); // call paid 14 USD and 16 USD
+   BOOST_CHECK_EQUAL( 5-1-1, call_id(db).collateral.get_amount().value ); // call got 1 CORE and 1 CORE
    BOOST_CHECK_EQUAL( 50-31+(21-16), get_balance(seller_id, bitusd_id) ); // seller paid 31 USD then get refunded 5 USD
    BOOST_CHECK_EQUAL( 1+1, get_balance(seller_id, core_id) ); // seller got 1 more CORE
    BOOST_CHECK_EQUAL( 100000-14, get_balance(seller2_id, bitusd_id) ); // seller2 paid 14 USD

--- a/tests/tests/market_tests.cpp
+++ b/tests/tests/market_tests.cpp
@@ -77,8 +77,8 @@ BOOST_AUTO_TEST_CASE(issue_338_etc)
    call_order_id_type call3_id = call3.id;
    transfer(borrower, seller, bitusd.amount(1000));
 
-   BOOST_CHECK_EQUAL( 1000, call.debt.value );
-   BOOST_CHECK_EQUAL( 15000, call.collateral.value );
+   BOOST_CHECK_EQUAL( 1000, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15000, call.collateral.get_amount().value );
    BOOST_CHECK_EQUAL( 1000, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
 
@@ -103,32 +103,32 @@ BOOST_AUTO_TEST_CASE(issue_338_etc)
    BOOST_CHECK( !create_sell_order(seller, bitusd.amount(7), core.amount(60)) );
    BOOST_CHECK_EQUAL( 993, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 60, get_balance(seller, core) );
-   BOOST_CHECK_EQUAL( 993, call.debt.value );
-   BOOST_CHECK_EQUAL( 14940, call.collateral.value );
+   BOOST_CHECK_EQUAL( 993, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 14940, call.collateral.get_amount().value );
 
    limit_order_id_type buy_low = create_sell_order(buyer, asset(90), bitusd.amount(10))->id;
    // margin call takes precedence
    BOOST_CHECK( !create_sell_order(seller, bitusd.amount(7), core.amount(60)) );
    BOOST_CHECK_EQUAL( 986, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 120, get_balance(seller, core) );
-   BOOST_CHECK_EQUAL( 986, call.debt.value );
-   BOOST_CHECK_EQUAL( 14880, call.collateral.value );
+   BOOST_CHECK_EQUAL( 986, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 14880, call.collateral.get_amount().value );
 
    limit_order_id_type buy_med = create_sell_order(buyer, asset(105), bitusd.amount(10))->id;
    // margin call takes precedence
    BOOST_CHECK( !create_sell_order(seller, bitusd.amount(7), core.amount(70)) );
    BOOST_CHECK_EQUAL( 979, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 190, get_balance(seller, core) );
-   BOOST_CHECK_EQUAL( 979, call.debt.value );
-   BOOST_CHECK_EQUAL( 14810, call.collateral.value );
+   BOOST_CHECK_EQUAL( 979, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 14810, call.collateral.get_amount().value );
 
    limit_order_id_type buy_high = create_sell_order(buyer, asset(115), bitusd.amount(10))->id;
    // margin call still has precedence (!) #625
    BOOST_CHECK( !create_sell_order(seller, bitusd.amount(7), core.amount(77)) );
    BOOST_CHECK_EQUAL( 972, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 267, get_balance(seller, core) );
-   BOOST_CHECK_EQUAL( 972, call.debt.value );
-   BOOST_CHECK_EQUAL( 14733, call.collateral.value );
+   BOOST_CHECK_EQUAL( 972, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 14733, call.collateral.get_amount().value );
 
    cancel_limit_order( buy_high(db) );
    cancel_limit_order( buy_med(db) );
@@ -138,8 +138,8 @@ BOOST_AUTO_TEST_CASE(issue_338_etc)
    BOOST_CHECK( !create_sell_order(seller, bitusd.amount(700), core.amount(7700)) );
    BOOST_CHECK_EQUAL( 272, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 7967, get_balance(seller, core) );
-   BOOST_CHECK_EQUAL( 272, call.debt.value );
-   BOOST_CHECK_EQUAL( 7033, call.collateral.value );
+   BOOST_CHECK_EQUAL( 272, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 7033, call.collateral.get_amount().value );
 
    // at this moment, collateralization of call is 7033 / 272 = 25.8
    // collateralization of call2 is 15500 / 1000 = 15.5
@@ -149,8 +149,8 @@ BOOST_AUTO_TEST_CASE(issue_338_etc)
    BOOST_CHECK( !create_sell_order(seller, bitusd.amount(10), core.amount(110)) );
    BOOST_CHECK_EQUAL( 262, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 8077, get_balance(seller, core) );
-   BOOST_CHECK_EQUAL( 262, call.debt.value );
-   BOOST_CHECK_EQUAL( 6923, call.collateral.value );
+   BOOST_CHECK_EQUAL( 262, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 6923, call.collateral.get_amount().value );
 
    // at this moment, collateralization of call is 6923 / 262 = 26.4
    // collateralization of call2 is 15500 / 1000 = 15.5
@@ -160,18 +160,18 @@ BOOST_AUTO_TEST_CASE(issue_338_etc)
    force_settle( seller, bitusd.amount(10) );
    BOOST_CHECK_EQUAL( 252, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 8077, get_balance(seller, core) );
-   BOOST_CHECK_EQUAL( 262, call.debt.value );
-   BOOST_CHECK_EQUAL( 6923, call.collateral.value );
+   BOOST_CHECK_EQUAL( 262, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 6923, call.collateral.get_amount().value );
 
    // generate blocks to let the settle order execute (price feed will expire after it)
    generate_blocks( HARDFORK_615_TIME + fc::hours(25) );
    // call2 get settled #343
    BOOST_CHECK_EQUAL( 252, get_balance(seller_id, usd_id) );
    BOOST_CHECK_EQUAL( 8177, get_balance(seller_id, core_id) );
-   BOOST_CHECK_EQUAL( 262, call_id(db).debt.value );
-   BOOST_CHECK_EQUAL( 6923, call_id(db).collateral.value );
-   BOOST_CHECK_EQUAL( 990, call2_id(db).debt.value );
-   BOOST_CHECK_EQUAL( 15400, call2_id(db).collateral.value );
+   BOOST_CHECK_EQUAL( 262, call_id(db).debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 6923, call_id(db).collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 990, call2_id(db).debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15400, call2_id(db).collateral.get_amount().value );
 
    set_expiration( db, trx );
    update_feed_producers( usd_id(db), {feedproducer_id} );
@@ -277,12 +277,12 @@ BOOST_AUTO_TEST_CASE(hardfork_core_338_test)
    transfer(borrower2, seller, bitusd.amount(1000));
    transfer(borrower3, seller, bitusd.amount(1000));
 
-   BOOST_CHECK_EQUAL( 1000, call.debt.value );
-   BOOST_CHECK_EQUAL( 15000, call.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call2.debt.value );
-   BOOST_CHECK_EQUAL( 15500, call2.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 16000, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 1000, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15000, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call2.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15500, call2.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 16000, call3.collateral.get_amount().value );
    BOOST_CHECK_EQUAL( 3000, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
 
@@ -312,8 +312,8 @@ BOOST_AUTO_TEST_CASE(hardfork_core_338_test)
 
    // firstly it will match with buy_high, at buy_high's price: #625 fixed
    BOOST_CHECK( !db.find<limit_order_object>( buy_high ) );
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( buy_med )->for_sale.value, 110 );
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( buy_low )->for_sale.value, 90 );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( buy_med )->for_sale.get_amount().value, 110 );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( buy_low )->for_sale.get_amount().value, 90 );
 
    // buy_high pays 111 CORE, receives 10 USD goes to buyer's balance
    BOOST_CHECK_EQUAL( 10, get_balance(buyer, bitusd) );
@@ -323,12 +323,12 @@ BOOST_AUTO_TEST_CASE(hardfork_core_338_test)
    // then it will match with call, at mssp: 1/11 = 690/7590 : #338 fixed
    BOOST_CHECK_EQUAL( 2293, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 7701, get_balance(seller, core) );
-   BOOST_CHECK_EQUAL( 310, call.debt.value );
-   BOOST_CHECK_EQUAL( 7410, call.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call2.debt.value );
-   BOOST_CHECK_EQUAL( 15500, call2.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 16000, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 310, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 7410, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call2.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15500, call2.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 16000, call3.collateral.get_amount().value );
 
    // call's call_price will be updated after the match, to 741/31/1.75 CORE/USD = 2964/217
    // it's above settlement price (10/1) so won't be margin called again
@@ -337,18 +337,18 @@ BOOST_AUTO_TEST_CASE(hardfork_core_338_test)
 
    // This would match with call before, but would match with call2 after #343 fixed
    BOOST_CHECK( !create_sell_order(seller, bitusd.amount(700), core.amount(6000) ) );
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( buy_med )->for_sale.value, 110 );
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( buy_low )->for_sale.value, 90 );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( buy_med )->for_sale.get_amount().value, 110 );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( buy_low )->for_sale.get_amount().value, 90 );
 
    // fill price would be mssp: 1/11 = 700/7700 : #338 fixed
    BOOST_CHECK_EQUAL( 1593, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 15401, get_balance(seller, core) );
-   BOOST_CHECK_EQUAL( 310, call.debt.value );
-   BOOST_CHECK_EQUAL( 7410, call.collateral.value );
-   BOOST_CHECK_EQUAL( 300, call2.debt.value );
-   BOOST_CHECK_EQUAL( 7800, call2.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 16000, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 310, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 7410, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 300, call2.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 7800, call2.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 16000, call3.collateral.get_amount().value );
    // call2's call_price will be updated after the match, to 78/3/1.75 CORE/USD = 312/21
    if(!hf1270) // can use call price only if we are before hf1270
       BOOST_CHECK( price(asset(312),asset(21,usd_id)) == call2.call_price );
@@ -363,12 +363,12 @@ BOOST_AUTO_TEST_CASE(hardfork_core_338_test)
 
    BOOST_CHECK_EQUAL( 1583, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 15401, get_balance(seller, core) );
-   BOOST_CHECK_EQUAL( 310, call.debt.value );
-   BOOST_CHECK_EQUAL( 7410, call.collateral.value );
-   BOOST_CHECK_EQUAL( 300, call2.debt.value );
-   BOOST_CHECK_EQUAL( 7800, call2.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 16000, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 310, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 7410, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 300, call2.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 7800, call2.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 16000, call3.collateral.get_amount().value );
 
    // generate blocks to let the settle order execute (price feed will expire after it)
    generate_block();
@@ -377,12 +377,12 @@ BOOST_AUTO_TEST_CASE(hardfork_core_338_test)
    // call3 get settled, at settlement price 1/10: #343 fixed
    BOOST_CHECK_EQUAL( 1583, get_balance(seller_id, usd_id) );
    BOOST_CHECK_EQUAL( 15501, get_balance(seller_id, core_id) );
-   BOOST_CHECK_EQUAL( 310, call_id(db).debt.value );
-   BOOST_CHECK_EQUAL( 7410, call_id(db).collateral.value );
-   BOOST_CHECK_EQUAL( 300, call2_id(db).debt.value );
-   BOOST_CHECK_EQUAL( 7800, call2_id(db).collateral.value );
-   BOOST_CHECK_EQUAL( 990, call3_id(db).debt.value );
-   BOOST_CHECK_EQUAL( 15900, call3_id(db).collateral.value );
+   BOOST_CHECK_EQUAL( 310, call_id(db).debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 7410, call_id(db).collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 300, call2_id(db).debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 7800, call2_id(db).collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 990, call3_id(db).debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15900, call3_id(db).collateral.get_amount().value );
 
    set_expiration( db, trx );
    update_feed_producers( usd_id(db), {feedproducer_id} );
@@ -459,12 +459,12 @@ BOOST_AUTO_TEST_CASE(hardfork_core_453_test)
    transfer(borrower2, seller, bitusd.amount(1000));
    transfer(borrower3, seller, bitusd.amount(1000));
 
-   BOOST_CHECK_EQUAL( 1000, call.debt.value );
-   BOOST_CHECK_EQUAL( 15000, call.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call2.debt.value );
-   BOOST_CHECK_EQUAL( 15500, call2.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 16000, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 1000, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15000, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call2.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15500, call2.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 16000, call3.collateral.get_amount().value );
    BOOST_CHECK_EQUAL( 3000, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
 
@@ -544,12 +544,12 @@ BOOST_AUTO_TEST_CASE(hardfork_core_625_big_limit_order_test)
    transfer(borrower2, seller, bitusd.amount(1000));
    transfer(borrower3, seller, bitusd.amount(1000));
 
-   BOOST_CHECK_EQUAL( 1000, call.debt.value );
-   BOOST_CHECK_EQUAL( 15000, call.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call2.debt.value );
-   BOOST_CHECK_EQUAL( 15500, call2.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 25000, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 1000, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15000, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call2.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15500, call2.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 25000, call3.collateral.get_amount().value );
    BOOST_CHECK_EQUAL( 3000, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
    BOOST_CHECK_EQUAL( 3000, get_balance(seller, bitusd) );
@@ -567,7 +567,7 @@ BOOST_AUTO_TEST_CASE(hardfork_core_625_big_limit_order_test)
 
    // This sell order above MSSP will not be matched with a call
    limit_order_id_type sell_high = create_sell_order(seller, bitusd.amount(7), core.amount(78))->id;
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_high )->for_sale.value, 7 );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_high )->for_sale.get_amount().value, 7 );
 
    BOOST_CHECK_EQUAL( 2993, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
@@ -612,14 +612,14 @@ BOOST_AUTO_TEST_CASE(hardfork_core_625_big_limit_order_test)
    BOOST_CHECK_EQUAL( 783, get_balance(buyer2, bitusd) ); // 700*4-10-1000-1000=790, minus 1% market fee 790*100/10000=7
    BOOST_CHECK_EQUAL( init_balance - 11000, get_balance(buyer2, core) );
    // buy_med pays at 1/11 = 790/8690
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( buy_med )->for_sale.value, 11000-8690 );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( buy_med )->for_sale.get_amount().value, 11000-8690 );
 
    // call3 is not in margin call territory so won't be matched
-   BOOST_CHECK_EQUAL( 1000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 25000, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 1000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 25000, call3.collateral.get_amount().value );
 
    // buy_low's price is too low that won't be matched
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( buy_low )->for_sale.value, 80 );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( buy_low )->for_sale.get_amount().value, 80 );
 
    // check seller balance
    BOOST_CHECK_EQUAL( 193, get_balance(seller, bitusd) ); // 3000 - 7 - 700*4
@@ -633,17 +633,17 @@ BOOST_AUTO_TEST_CASE(hardfork_core_625_big_limit_order_test)
 
    // Create another sell order slightly below the call price, won't fill
    limit_order_id_type sell_med = create_sell_order( seller, bitusd.amount(7), core.amount(59) )->id;
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_med )->for_sale.value, 7 );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_med )->for_sale.get_amount().value, 7 );
    // check seller balance
    BOOST_CHECK_EQUAL( 193-7, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 30801, get_balance(seller, core) );
 
    // call3 is not in margin call territory so won't be matched
-   BOOST_CHECK_EQUAL( 1000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 25000, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 1000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 25000, call3.collateral.get_amount().value );
 
    // buy_low's price is too low that won't be matched
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( buy_low )->for_sale.value, 80 );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( buy_low )->for_sale.get_amount().value, 80 );
 
    // generate a block
    generate_block();
@@ -722,26 +722,26 @@ BOOST_AUTO_TEST_CASE(hard_fork_453_cross_test)
    transfer(borrower2, seller, bitcny.amount(1000));
    transfer(borrower3, seller, bitcny.amount(1000));
 
-   BOOST_CHECK_EQUAL( 1000, call_usd.debt.value );
-   BOOST_CHECK_EQUAL( 15000, call_usd.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call_usd2.debt.value );
-   BOOST_CHECK_EQUAL( 15500, call_usd2.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call_usd3.debt.value );
-   BOOST_CHECK_EQUAL( 16000, call_usd3.collateral.value );
+   BOOST_CHECK_EQUAL( 1000, call_usd.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15000, call_usd.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call_usd2.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15500, call_usd2.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call_usd3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 16000, call_usd3.collateral.get_amount().value );
    BOOST_CHECK_EQUAL( 3000, get_balance(seller, bitusd) );
-   BOOST_CHECK_EQUAL( 1000, call_eur.debt.value );
-   BOOST_CHECK_EQUAL( 15000, call_eur.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call_eur2.debt.value );
-   BOOST_CHECK_EQUAL( 15500, call_eur2.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call_eur3.debt.value );
-   BOOST_CHECK_EQUAL( 16000, call_eur3.collateral.value );
+   BOOST_CHECK_EQUAL( 1000, call_eur.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15000, call_eur.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call_eur2.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15500, call_eur2.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call_eur3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 16000, call_eur3.collateral.get_amount().value );
    BOOST_CHECK_EQUAL( 3000, get_balance(seller, biteur) );
-   BOOST_CHECK_EQUAL( 1000, call_cny.debt.value );
-   BOOST_CHECK_EQUAL( 15000, call_cny.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call_cny2.debt.value );
-   BOOST_CHECK_EQUAL( 15500, call_cny2.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call_cny3.debt.value );
-   BOOST_CHECK_EQUAL( 16000, call_cny3.collateral.value );
+   BOOST_CHECK_EQUAL( 1000, call_cny.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15000, call_cny.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call_cny2.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15500, call_cny2.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call_cny3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 16000, call_cny3.collateral.get_amount().value );
    BOOST_CHECK_EQUAL( 3000, get_balance(seller, bitcny) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
 
@@ -807,9 +807,9 @@ BOOST_AUTO_TEST_CASE(hard_fork_453_cross_test)
    // sell_med and call3 should get matched
    BOOST_CHECK( !db.find<limit_order_object>( sell_usd_med ) );
    // call3 now is not at margin call state, so sell_med2 won't get matched
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_usd_med2 )->for_sale.value, 7 );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_usd_med2 )->for_sale.get_amount().value, 7 );
    // sell_high should still be there, didn't match anything
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_usd_high )->for_sale.value, 7 );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_usd_high )->for_sale.get_amount().value, 7 );
 
    // sell_low and call should get matched first
    BOOST_CHECK( !db.find<limit_order_object>( sell_eur_low ) );
@@ -821,9 +821,9 @@ BOOST_AUTO_TEST_CASE(hard_fork_453_cross_test)
    // sell_med and call3 should get matched
    BOOST_CHECK( !db.find<limit_order_object>( sell_eur_med ) );
    // call3 now is not at margin call state, so sell_med2 won't get matched
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_eur_med2 )->for_sale.value, 7 );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_eur_med2 )->for_sale.get_amount().value, 7 );
    // sell_high should still be there, didn't match anything
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_eur_high )->for_sale.value, 7 );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_eur_high )->for_sale.get_amount().value, 7 );
 
    // sell_low and call should get matched first
    BOOST_CHECK( !db.find<limit_order_object>( sell_cny_low ) );
@@ -835,21 +835,21 @@ BOOST_AUTO_TEST_CASE(hard_fork_453_cross_test)
    // sell_med and call3 should get matched
    BOOST_CHECK( !db.find<limit_order_object>( sell_cny_med ) );
    // call3 now is not at margin call state, so sell_med2 won't get matched
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_cny_med2 )->for_sale.value, 7 );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_cny_med2 )->for_sale.get_amount().value, 7 );
    // sell_high should still be there, didn't match anything
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_cny_high )->for_sale.value, 7 );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_cny_high )->for_sale.get_amount().value, 7 );
 
    // all match price would be limit order price
    BOOST_CHECK_EQUAL( 3000-1000-1007-7-700-7, get_balance(seller_id, usd_id) );
    BOOST_CHECK_EQUAL( 3000-1000-1007-7-700-7, get_balance(seller_id, eur_id) );
    BOOST_CHECK_EQUAL( 3000-1000-1007-7-700-7, get_balance(seller_id, cny_id) );
    BOOST_CHECK_EQUAL( (7000+8056+6400)*3, get_balance(seller_id, core_id) );
-   BOOST_CHECK_EQUAL( 1000-7-700, call_usd3_id(db).debt.value );
-   BOOST_CHECK_EQUAL( 16000-56-6400, call_usd3_id(db).collateral.value );
-   BOOST_CHECK_EQUAL( 1000-7-700, call_eur3_id(db).debt.value );
-   BOOST_CHECK_EQUAL( 16000-56-6400, call_eur3_id(db).collateral.value );
-   BOOST_CHECK_EQUAL( 1000-7-700, call_cny3_id(db).debt.value );
-   BOOST_CHECK_EQUAL( 16000-56-6400, call_cny3_id(db).collateral.value );
+   BOOST_CHECK_EQUAL( 1000-7-700, call_usd3_id(db).debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 16000-56-6400, call_usd3_id(db).collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000-7-700, call_eur3_id(db).debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 16000-56-6400, call_eur3_id(db).collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000-7-700, call_cny3_id(db).debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 16000-56-6400, call_cny3_id(db).collateral.get_amount().value );
    // call3's call_price should be updated: 9544/293/1.75 = 9544*4 / 293*7 = 38176/2051 CORE/USD
    BOOST_CHECK( price(asset(38176),asset(2051,usd_id)) == call_usd3_id(db).call_price );
    BOOST_CHECK( price(asset(38176),asset(2051,eur_id)) == call_eur3_id(db).call_price );
@@ -907,12 +907,12 @@ BOOST_AUTO_TEST_CASE(hard_fork_338_cross_test)
    transfer(borrower2, seller, bitusd.amount(1000));
    transfer(borrower3, seller, bitusd.amount(1000));
 
-   BOOST_CHECK_EQUAL( 1000, call.debt.value );
-   BOOST_CHECK_EQUAL( 15000, call.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call2.debt.value );
-   BOOST_CHECK_EQUAL( 15500, call2.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 16000, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 1000, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15000, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call2.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15500, call2.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 16000, call3.collateral.get_amount().value );
    BOOST_CHECK_EQUAL( 3000, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
 
@@ -964,7 +964,7 @@ BOOST_AUTO_TEST_CASE(hard_fork_338_cross_test)
 
    // since 16.1 > 16, global settlement should at feed price 16/1
    // so settlement fund should be 986*16 + 1000*16
-   BOOST_CHECK_EQUAL( 1986*16, usd_id(db).bitasset_data(db).settlement_fund.value );
+   BOOST_CHECK_EQUAL( 1986*16, usd_id(db).bitasset_data(db).settlement_fund.get_amount().value );
    // global settlement price should be 16/1, since no rounding here
    BOOST_CHECK( price(asset(1,usd_id),asset(16) ) == usd_id(db).bitasset_data(db).settlement_price );
 
@@ -1024,12 +1024,12 @@ BOOST_AUTO_TEST_CASE(hard_fork_649_cross_test)
    transfer(borrower2, seller, bitusd.amount(1000));
    transfer(borrower3, seller, bitusd.amount(1000));
 
-   BOOST_CHECK_EQUAL( 1000, call.debt.value );
-   BOOST_CHECK_EQUAL( 15000, call.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call2.debt.value );
-   BOOST_CHECK_EQUAL( 15500, call2.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 16000, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 1000, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15000, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call2.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15500, call2.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 16000, call3.collateral.get_amount().value );
    BOOST_CHECK_EQUAL( 3000, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
 
@@ -1042,8 +1042,8 @@ BOOST_AUTO_TEST_CASE(hard_fork_649_cross_test)
    BOOST_CHECK( !create_sell_order(seller, bitusd.amount(707), core.amount(6464)) );
    BOOST_CHECK_EQUAL( 3000-707, get_balance(seller_id, usd_id) );
    BOOST_CHECK_EQUAL( 6464, get_balance(seller_id, core_id) );
-   BOOST_CHECK_EQUAL( 293, call.debt.value );
-   BOOST_CHECK_EQUAL( 8536, call.collateral.value );
+   BOOST_CHECK_EQUAL( 293, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 8536, call.collateral.get_amount().value );
 
    // at this moment,
    // collateralization of call is 8536 / 293 = 29.1
@@ -1076,7 +1076,7 @@ BOOST_AUTO_TEST_CASE(hard_fork_649_cross_test)
 
    // since least collateral ratio 15.5 < 20, global settlement should execute at price = least collateral ratio 15.5/1
    // so settlement fund should be 15500 + 15500 + round_up(15.5 * 293)
-   BOOST_CHECK_EQUAL( 15500*2 + (293 * 155 + 9) / 10, usd_id(db).bitasset_data(db).settlement_fund.value );
+   BOOST_CHECK_EQUAL( 15500*2 + (293 * 155 + 9) / 10, usd_id(db).bitasset_data(db).settlement_fund.get_amount().value );
    // global settlement price should be settlement_fund/(2000+293), but not 15.5/1 due to rounding
    BOOST_CHECK( price(asset(2293,usd_id),asset(15500*2+(293*155+9)/10) ) == usd_id(db).bitasset_data(db).settlement_price );
 
@@ -1138,12 +1138,12 @@ BOOST_AUTO_TEST_CASE(hard_fork_343_cross_test)
    transfer(borrower2, seller, bitusd.amount(1000));
    transfer(borrower3, seller, bitusd.amount(1000));
 
-   BOOST_CHECK_EQUAL( 1000, call.debt.value );
-   BOOST_CHECK_EQUAL( 15000, call.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call2.debt.value );
-   BOOST_CHECK_EQUAL( 15500, call2.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 17500, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 1000, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15000, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call2.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15500, call2.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 17500, call3.collateral.get_amount().value );
    BOOST_CHECK_EQUAL( 3000, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
 
@@ -1156,8 +1156,8 @@ BOOST_AUTO_TEST_CASE(hard_fork_343_cross_test)
    BOOST_CHECK( !create_sell_order(seller, bitusd.amount(700), core.amount(6400)) );
    BOOST_CHECK_EQUAL( 3000-700, get_balance(seller_id, usd_id) );
    BOOST_CHECK_EQUAL( 6400, get_balance(seller_id, core_id) );
-   BOOST_CHECK_EQUAL( 300, call.debt.value );
-   BOOST_CHECK_EQUAL( 8600, call.collateral.value );
+   BOOST_CHECK_EQUAL( 300, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 8600, call.collateral.get_amount().value );
 
    // at this moment,
    // collateralization of call is 8600 / 300 = 28.67
@@ -1175,12 +1175,12 @@ BOOST_AUTO_TEST_CASE(hard_fork_343_cross_test)
    BOOST_CHECK( !create_sell_order(seller_id(db), asset(7*50,usd_id), asset(65*50)) );
    BOOST_CHECK_EQUAL( 3000-700-7*50, get_balance(seller_id, usd_id) );
    BOOST_CHECK_EQUAL( 6400+77*50, get_balance(seller_id, core_id) );
-   BOOST_CHECK_EQUAL( 300, call_id(db).debt.value );
-   BOOST_CHECK_EQUAL( 8600, call_id(db).collateral.value );
-   BOOST_CHECK_EQUAL( 1000-7*50, call2_id(db).debt.value );
-   BOOST_CHECK_EQUAL( 15500-77*50, call2_id(db).collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call3_id(db).debt.value );
-   BOOST_CHECK_EQUAL( 17500, call3_id(db).collateral.value );
+   BOOST_CHECK_EQUAL( 300, call_id(db).debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 8600, call_id(db).collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000-7*50, call2_id(db).debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15500-77*50, call2_id(db).collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call3_id(db).debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 17500, call3_id(db).collateral.get_amount().value );
 
    // at this moment,
    // collateralization of call is 8600 / 300 = 28.67
@@ -1191,12 +1191,12 @@ BOOST_AUTO_TEST_CASE(hard_fork_343_cross_test)
    BOOST_CHECK( !create_sell_order(seller_id(db), asset(7,usd_id), asset(65)) );
    BOOST_CHECK_EQUAL( 3000-700-7*50-7, get_balance(seller_id, usd_id) );
    BOOST_CHECK_EQUAL( 6400+77*50+77, get_balance(seller_id, core_id) );
-   BOOST_CHECK_EQUAL( 300, call_id(db).debt.value );
-   BOOST_CHECK_EQUAL( 8600, call_id(db).collateral.value );
-   BOOST_CHECK_EQUAL( 1000-7*50, call2_id(db).debt.value );
-   BOOST_CHECK_EQUAL( 15500-77*50, call2_id(db).collateral.value );
-   BOOST_CHECK_EQUAL( 1000-7, call3_id(db).debt.value );
-   BOOST_CHECK_EQUAL( 17500-77, call3_id(db).collateral.value );
+   BOOST_CHECK_EQUAL( 300, call_id(db).debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 8600, call_id(db).collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000-7*50, call2_id(db).debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15500-77*50, call2_id(db).collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000-7, call3_id(db).debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 17500-77, call3_id(db).collateral.get_amount().value );
 
    // at this moment,
    // collateralization of call is 8600 / 300 = 28.67
@@ -1259,12 +1259,12 @@ BOOST_AUTO_TEST_CASE(target_cr_test_limit_call)
    transfer(borrower2, seller, bitusd.amount(1000));
    transfer(borrower3, seller, bitusd.amount(1000));
 
-   BOOST_CHECK_EQUAL( 1000, call.debt.value );
-   BOOST_CHECK_EQUAL( 15000, call.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call2.debt.value );
-   BOOST_CHECK_EQUAL( 15500, call2.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 25000, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 1000, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15000, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call2.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15500, call2.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 25000, call3.collateral.get_amount().value );
    BOOST_CHECK_EQUAL( 3000, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
    BOOST_CHECK_EQUAL( 3000, get_balance(seller, bitusd) );
@@ -1282,7 +1282,7 @@ BOOST_AUTO_TEST_CASE(target_cr_test_limit_call)
 
    // This sell order above MSSP will not be matched with a call
    limit_order_id_type sell_high = create_sell_order(seller, bitusd.amount(7), core.amount(78))->id;
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_high )->for_sale.value, 7 );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_high )->for_sale.get_amount().value, 7 );
 
    BOOST_CHECK_EQUAL( 2993, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
@@ -1305,8 +1305,8 @@ BOOST_AUTO_TEST_CASE(target_cr_test_limit_call)
    price match_price( bitusd.amount(1) / core.amount(11) );
    share_type call_to_cover = call_id(db).get_max_debt_to_cover(match_price,current_feed.settlement_price,1750);
    share_type call2_to_cover = call2_id(db).get_max_debt_to_cover(match_price,current_feed.settlement_price,1750);
-   BOOST_CHECK_LT( call_to_cover.value, call_id(db).debt.value );
-   BOOST_CHECK_LT( call2_to_cover.value, call2_id(db).debt.value );
+   BOOST_CHECK_LT( call_to_cover.value, call_id(db).debt.get_amount().value );
+   BOOST_CHECK_LT( call2_to_cover.value, call2_id(db).debt.get_amount().value );
    // even though call2 has a higher CR, since call's TCR is less than call2's TCR, so we expect call will cover less when called
    BOOST_CHECK_LT( call_to_cover.value, call2_to_cover.value );
 
@@ -1325,10 +1325,10 @@ BOOST_AUTO_TEST_CASE(target_cr_test_limit_call)
 
    // call will receive call_to_cover, pay 11*call_to_cover
    share_type call_to_pay = call_to_cover * 11;
-   BOOST_CHECK_EQUAL( 1000 - call_to_cover.value, call.debt.value );
-   BOOST_CHECK_EQUAL( 15000 - call_to_pay.value, call.collateral.value );
+   BOOST_CHECK_EQUAL( 1000 - call_to_cover.value, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15000 - call_to_pay.value, call.collateral.get_amount().value );
    // new collateral ratio should be higher than mcr as well as tcr
-   BOOST_CHECK( call.debt.value * 10 * 1750 < call.collateral.value * 1000 );
+   BOOST_CHECK( call.debt.get_amount().value * 10 * 1750 < call.collateral.get_amount().value * 1000 );
    idump( (call) );
    // borrower's balance doesn't change
    BOOST_CHECK_EQUAL( init_balance - 15000, get_balance(borrower, core) );
@@ -1340,10 +1340,10 @@ BOOST_AUTO_TEST_CASE(target_cr_test_limit_call)
 
    // call2 will receive call2_to_cover, pay 11*call2_to_cover
    share_type call2_to_pay = call2_to_cover * 11;
-   BOOST_CHECK_EQUAL( 1000 - call2_to_cover.value, call2.debt.value );
-   BOOST_CHECK_EQUAL( 15500 - call2_to_pay.value, call2.collateral.value );
+   BOOST_CHECK_EQUAL( 1000 - call2_to_cover.value, call2.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15500 - call2_to_pay.value, call2.collateral.get_amount().value );
    // new collateral ratio should be higher than mcr as well as tcr
-   BOOST_CHECK( call2.debt.value * 10 * 2000 < call2.collateral.value * 1000 );
+   BOOST_CHECK( call2.debt.get_amount().value * 10 * 2000 < call2.collateral.get_amount().value * 1000 );
    idump( (call2) );
    // borrower2's balance doesn't change
    BOOST_CHECK_EQUAL( init_balance - 15500, get_balance(borrower2, core) );
@@ -1356,14 +1356,14 @@ BOOST_AUTO_TEST_CASE(target_cr_test_limit_call)
    buy_med_get -= (buy_med_get/100); // minus 1% market fee
    BOOST_CHECK_EQUAL( buy_med_get.value, get_balance(buyer2, bitusd) );
    BOOST_CHECK_EQUAL( init_balance - 33000, get_balance(buyer2, core) );
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( buy_med )->for_sale.value, 33000-buy_med_pay.value );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( buy_med )->for_sale.get_amount().value, 33000-buy_med_pay.value );
 
    // call3 is not in margin call territory so won't be matched
-   BOOST_CHECK_EQUAL( 1000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 25000, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 1000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 25000, call3.collateral.get_amount().value );
 
    // buy_low's price is too low that won't be matched
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( buy_low )->for_sale.value, 80 );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( buy_low )->for_sale.get_amount().value, 80 );
 
    // check seller balance
    BOOST_CHECK_EQUAL( 193, get_balance(seller, bitusd) ); // 3000 - 7 - 700*4
@@ -1377,17 +1377,17 @@ BOOST_AUTO_TEST_CASE(target_cr_test_limit_call)
 
    // Create another sell order slightly below the call price, won't fill
    limit_order_id_type sell_med = create_sell_order( seller, bitusd.amount(7), core.amount(59) )->id;
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_med )->for_sale.value, 7 );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_med )->for_sale.get_amount().value, 7 );
    // check seller balance
    BOOST_CHECK_EQUAL( 193-7, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 30801, get_balance(seller, core) );
 
    // call3 is not in margin call territory so won't be matched
-   BOOST_CHECK_EQUAL( 1000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 25000, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 1000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 25000, call3.collateral.get_amount().value );
 
    // buy_low's price is too low that won't be matched
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( buy_low )->for_sale.value, 80 );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( buy_low )->for_sale.get_amount().value, 80 );
 
    // generate a block
    generate_block();
@@ -1441,12 +1441,12 @@ BOOST_AUTO_TEST_CASE(target_cr_test_call_limit)
    transfer(borrower2, seller, bitusd.amount(1000));
    transfer(borrower3, seller, bitusd.amount(1000));
 
-   BOOST_CHECK_EQUAL( 1000, call.debt.value );
-   BOOST_CHECK_EQUAL( 15000, call.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call2.debt.value );
-   BOOST_CHECK_EQUAL( 15500, call2.collateral.value );
-   BOOST_CHECK_EQUAL( 1000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 25000, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 1000, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15000, call.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call2.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15500, call2.collateral.get_amount().value );
+   BOOST_CHECK_EQUAL( 1000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 25000, call3.collateral.get_amount().value );
    BOOST_CHECK_EQUAL( 3000, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
    BOOST_CHECK_EQUAL( 3000, get_balance(seller, bitusd) );
@@ -1459,7 +1459,7 @@ BOOST_AUTO_TEST_CASE(target_cr_test_call_limit)
 
    // This sell order above MSSP will not be matched with a call
    limit_order_id_type sell_high = create_sell_order(seller, bitusd.amount(7), core.amount(78))->id;
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_high )->for_sale.value, 7 );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_high )->for_sale.get_amount().value, 7 );
 
    BOOST_CHECK_EQUAL( 2993, get_balance(seller, bitusd) );
    BOOST_CHECK_EQUAL( 0, get_balance(seller, core) );
@@ -1472,7 +1472,7 @@ BOOST_AUTO_TEST_CASE(target_cr_test_call_limit)
 
    // Create a sell order which will be matched with several call orders later, price 1/9
    limit_order_id_type sell_id = create_sell_order(seller, bitusd.amount(500), core.amount(4500) )->id;
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_id )->for_sale.value, 500 );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( sell_id )->for_sale.get_amount().value, 500 );
 
    // prepare price feed to get call and call2 (but not call3) into margin call territory
    current_feed.settlement_price = bitusd.amount( 1 ) / core.amount(10);
@@ -1481,8 +1481,8 @@ BOOST_AUTO_TEST_CASE(target_cr_test_call_limit)
    price match_price = sell_id(db).sell_price;
    share_type call_to_cover = call_id(db).get_max_debt_to_cover(match_price,current_feed.settlement_price,1750);
    share_type call2_to_cover = call2_id(db).get_max_debt_to_cover(match_price,current_feed.settlement_price,1750);
-   BOOST_CHECK_LT( call_to_cover.value, call_id(db).debt.value );
-   BOOST_CHECK_LT( call2_to_cover.value, call2_id(db).debt.value );
+   BOOST_CHECK_LT( call_to_cover.value, call_id(db).debt.get_amount().value );
+   BOOST_CHECK_LT( call2_to_cover.value, call2_id(db).debt.get_amount().value );
    // even though call2 has a higher CR, since call's TCR is less than call2's TCR, so we expect call will cover less when called
    BOOST_CHECK_LT( call_to_cover.value, call2_to_cover.value );
 
@@ -1496,10 +1496,10 @@ BOOST_AUTO_TEST_CASE(target_cr_test_call_limit)
 
    // call will receive call_to_cover, pay 9*call_to_cover
    share_type call_to_pay = call_to_cover * 9;
-   BOOST_CHECK_EQUAL( 1000 - call_to_cover.value, call.debt.value );
-   BOOST_CHECK_EQUAL( 15000 - call_to_pay.value, call.collateral.value );
+   BOOST_CHECK_EQUAL( 1000 - call_to_cover.value, call.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15000 - call_to_pay.value, call.collateral.get_amount().value );
    // new collateral ratio should be higher than mcr as well as tcr
-   BOOST_CHECK( call.debt.value * 10 * 1750 < call.collateral.value * 1000 );
+   BOOST_CHECK( call.debt.get_amount().value * 10 * 1750 < call.collateral.get_amount().value * 1000 );
    idump( (call) );
    // borrower's balance doesn't change
    BOOST_CHECK_EQUAL( init_balance - 15000, get_balance(borrower, core) );
@@ -1513,16 +1513,16 @@ BOOST_AUTO_TEST_CASE(target_cr_test_call_limit)
    // however it's not the case, so call2 will receive less
    call2_to_cover = 500 - call_to_cover;
    share_type call2_to_pay = call2_to_cover * 9;
-   BOOST_CHECK_EQUAL( 1000 - call2_to_cover.value, call2.debt.value );
-   BOOST_CHECK_EQUAL( 15500 - call2_to_pay.value, call2.collateral.value );
+   BOOST_CHECK_EQUAL( 1000 - call2_to_cover.value, call2.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 15500 - call2_to_pay.value, call2.collateral.get_amount().value );
    idump( (call2) );
    // borrower2's balance doesn't change
    BOOST_CHECK_EQUAL( init_balance - 15500, get_balance(borrower2, core) );
    BOOST_CHECK_EQUAL( 0, get_balance(borrower2, bitusd) );
 
    // call3 is not in margin call territory so won't be matched
-   BOOST_CHECK_EQUAL( 1000, call3.debt.value );
-   BOOST_CHECK_EQUAL( 25000, call3.collateral.value );
+   BOOST_CHECK_EQUAL( 1000, call3.debt.get_amount().value );
+   BOOST_CHECK_EQUAL( 25000, call3.collateral.get_amount().value );
 
    // sell_id is completely filled
    BOOST_CHECK( !db.find<limit_order_object>( sell_id ) );
@@ -1532,7 +1532,7 @@ BOOST_AUTO_TEST_CASE(target_cr_test_call_limit)
    BOOST_CHECK_EQUAL( 4500, get_balance(seller, core) ); // 500*9
 
    // buy_low's price is too low that won't be matched
-   BOOST_CHECK_EQUAL( db.find<limit_order_object>( buy_low )->for_sale.value, 80 );
+   BOOST_CHECK_EQUAL( db.find<limit_order_object>( buy_low )->for_sale.get_amount().value, 80 );
 
    // generate a block
    generate_block();

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -787,7 +787,7 @@ BOOST_AUTO_TEST_CASE( prediction_market )
 
       // force settle the rest
       force_settle( dan, pmark.amount(400) );
-      BOOST_CHECK_EQUAL( 0, pmark_dd_id(db).current_supply.value );
+      BOOST_CHECK_EQUAL( 0, pmark_dd_id(db).current_supply.get_amount().value );
 
       generate_block(~database::skip_transaction_dupe_check);
       generate_blocks( db.get_dynamic_global_properties().next_maintenance_time );
@@ -825,7 +825,7 @@ BOOST_AUTO_TEST_CASE( prediction_market_resolves_to_0 )
 
       // force settle the rest
       force_settle( dan, pmark.amount(900) );
-      BOOST_CHECK_EQUAL( 0, pmark_dd_id(db).current_supply.value );
+      BOOST_CHECK_EQUAL( 0, pmark_dd_id(db).current_supply.get_amount().value );
 
       generate_block(~database::skip_transaction_dupe_check);
       generate_blocks( db.get_dynamic_global_properties().next_maintenance_time );
@@ -1035,7 +1035,7 @@ BOOST_AUTO_TEST_CASE( create_mia )
       const asset_object& bitusd = create_bitasset( "USDBIT" );
       BOOST_CHECK(bitusd.symbol == "USDBIT");
       BOOST_CHECK(bitusd.bitasset_data(db).options.short_backing_asset == asset_id_type());
-      BOOST_CHECK(bitusd.dynamic_asset_data_id(db).current_supply == 0);
+      BOOST_CHECK(bitusd.dynamic_asset_data_id(db).current_supply.get_amount() == 0);
       GRAPHENE_REQUIRE_THROW( create_bitasset("USDBIT"), fc::exception);
    } catch ( const fc::exception& e ) {
       elog( "${e}", ("e", e.to_detail_string() ) );
@@ -1126,9 +1126,9 @@ BOOST_AUTO_TEST_CASE( create_uia )
       GRAPHENE_REQUIRE_THROW(PUSH_TX( db, trx, ~0 ), fc::exception);
 
       const asset_dynamic_data_object& test_asset_dynamic_data = test_asset.dynamic_asset_data_id(db);
-      BOOST_CHECK(test_asset_dynamic_data.current_supply == 0);
-      BOOST_CHECK(test_asset_dynamic_data.accumulated_fees == 0);
-      BOOST_CHECK(test_asset_dynamic_data.fee_pool == 0);
+      BOOST_CHECK(test_asset_dynamic_data.current_supply.get_amount()== 0);
+      BOOST_CHECK(test_asset_dynamic_data.accumulated_fees.get_amount() == 0);
+      BOOST_CHECK(test_asset_dynamic_data.fee_pool.get_amount() == 0);
 
       auto op = trx.operations.back().get<asset_create_operation>();
       op.symbol = "TESTFAIL";
@@ -1386,16 +1386,16 @@ BOOST_AUTO_TEST_CASE( issue_uia )
 
       const asset_dynamic_data_object& test_dynamic_data = test_asset.dynamic_asset_data_id(db);
       BOOST_CHECK_EQUAL(get_balance(nathan_account, test_asset), 5000000);
-      BOOST_CHECK(test_dynamic_data.current_supply == 5000000);
-      BOOST_CHECK(test_dynamic_data.accumulated_fees == 0);
-      BOOST_CHECK(test_dynamic_data.fee_pool == 0);
+      BOOST_CHECK(test_dynamic_data.current_supply.get_amount() == 5000000);
+      BOOST_CHECK(test_dynamic_data.accumulated_fees.get_amount() == 0);
+      BOOST_CHECK(test_dynamic_data.fee_pool.get_amount() == 0);
 
       PUSH_TX( db, trx, ~0 );
 
       BOOST_CHECK_EQUAL(get_balance(nathan_account, test_asset), 10000000);
-      BOOST_CHECK(test_dynamic_data.current_supply == 10000000);
-      BOOST_CHECK(test_dynamic_data.accumulated_fees == 0);
-      BOOST_CHECK(test_dynamic_data.fee_pool == 0);
+      BOOST_CHECK(test_dynamic_data.current_supply.get_amount() == 10000000);
+      BOOST_CHECK(test_dynamic_data.accumulated_fees.get_amount() == 0);
+      BOOST_CHECK(test_dynamic_data.fee_pool.get_amount() == 0);
    } catch(fc::exception& e) {
       edump((e.to_detail_string()));
       throw;
@@ -1463,7 +1463,7 @@ BOOST_AUTO_TEST_CASE( create_buy_uia_multiple_match_new )
 
    BOOST_CHECK_EQUAL( get_balance( seller_account, test_asset ), 200 );
    BOOST_CHECK_EQUAL( get_balance( buyer_account, core_asset ), 297 );
-   BOOST_CHECK_EQUAL( core_asset.dynamic_asset_data_id(db).accumulated_fees.value , 3 );
+   BOOST_CHECK_EQUAL( core_asset.dynamic_asset_data_id(db).accumulated_fees.get_amount().value , 3 );
  }
  catch ( const fc::exception& e )
  {
@@ -1503,7 +1503,7 @@ BOOST_AUTO_TEST_CASE( create_buy_exact_match_uia )
 
    BOOST_CHECK_EQUAL( get_balance( seller_account, test_asset ), 99 );
    BOOST_CHECK_EQUAL( get_balance( buyer_account, core_asset ), 100 );
-   BOOST_CHECK_EQUAL( test_asset.dynamic_asset_data_id(db).accumulated_fees.value , 1 );
+   BOOST_CHECK_EQUAL( test_asset.dynamic_asset_data_id(db).accumulated_fees.get_amount().value , 1 );
  }
  catch ( const fc::exception& e )
  {
@@ -1544,7 +1544,7 @@ BOOST_AUTO_TEST_CASE( create_buy_uia_multiple_match_new_reverse )
 
    BOOST_CHECK_EQUAL( get_balance( seller_account, test_asset ), 198 );
    BOOST_CHECK_EQUAL( get_balance( buyer_account, core_asset ), 300 );
-   BOOST_CHECK_EQUAL( test_asset.dynamic_asset_data_id(db).accumulated_fees.value , 2 );
+   BOOST_CHECK_EQUAL( test_asset.dynamic_asset_data_id(db).accumulated_fees.get_amount().value , 2 );
  }
  catch ( const fc::exception& e )
  {
@@ -1587,7 +1587,7 @@ BOOST_AUTO_TEST_CASE( create_buy_uia_multiple_match_new_reverse_fract )
    BOOST_CHECK_EQUAL( get_balance( seller_account, test_asset ), 198 );
    BOOST_CHECK_EQUAL( get_balance( buyer_account, core_asset ), 30 );
    BOOST_CHECK_EQUAL( get_balance( seller_account, core_asset ), 0 );
-   BOOST_CHECK_EQUAL( test_asset.dynamic_asset_data_id(db).accumulated_fees.value , 2 );
+   BOOST_CHECK_EQUAL( test_asset.dynamic_asset_data_id(db).accumulated_fees.get_amount().value , 2 );
  }
  catch ( const fc::exception& e )
  {
@@ -1611,7 +1611,7 @@ BOOST_AUTO_TEST_CASE( uia_fees )
       const share_type prec = asset::scaled_precision( asset_id_type()(db).precision );
 
       fund_fee_pool(committee_account, test_asset, 1000*prec);
-      BOOST_CHECK(asset_dynamic.fee_pool == 1000*prec);
+      BOOST_CHECK(asset_dynamic.fee_pool.get_amount() == 1000*prec);
 
       transfer_operation op;
       op.fee = test_asset.amount(0);
@@ -1630,16 +1630,16 @@ BOOST_AUTO_TEST_CASE( uia_fees )
       BOOST_CHECK_EQUAL(get_balance(nathan_account, test_asset),
                         (old_balance - fee - test_asset.amount(100)).amount.value);
       BOOST_CHECK_EQUAL(get_balance(committee_account, test_asset), 100);
-      BOOST_CHECK(asset_dynamic.accumulated_fees == fee.amount);
-      BOOST_CHECK(asset_dynamic.fee_pool == 1000*prec - core_fee.amount);
+      BOOST_CHECK(asset_dynamic.accumulated_fees.get_amount() == fee.amount);
+      BOOST_CHECK(asset_dynamic.fee_pool.get_amount() == 1000*prec - core_fee.amount);
 
       //Do it again, for good measure.
       PUSH_TX( db, trx, ~0 );
       BOOST_CHECK_EQUAL(get_balance(nathan_account, test_asset),
                         (old_balance - fee - fee - test_asset.amount(200)).amount.value);
       BOOST_CHECK_EQUAL(get_balance(committee_account, test_asset), 200);
-      BOOST_CHECK(asset_dynamic.accumulated_fees == fee.amount + fee.amount);
-      BOOST_CHECK(asset_dynamic.fee_pool == 1000*prec - core_fee.amount - core_fee.amount);
+      BOOST_CHECK(asset_dynamic.accumulated_fees.get_amount() == fee.amount + fee.amount);
+      BOOST_CHECK(asset_dynamic.fee_pool.get_amount() == 1000*prec - core_fee.amount - core_fee.amount);
 
       op = std::move(trx.operations.back().get<transfer_operation>());
       trx.operations.clear();
@@ -1656,8 +1656,8 @@ BOOST_AUTO_TEST_CASE( uia_fees )
       BOOST_CHECK_EQUAL(get_balance(nathan_account, test_asset),
                         (old_balance - fee - fee - fee - test_asset.amount(200)).amount.value);
       BOOST_CHECK_EQUAL(get_balance(committee_account, test_asset), 200);
-      BOOST_CHECK(asset_dynamic.accumulated_fees == fee.amount.value * 3);
-      BOOST_CHECK(asset_dynamic.fee_pool == 1000*prec - core_fee.amount.value * 3);
+      BOOST_CHECK(asset_dynamic.accumulated_fees.get_amount() == fee.amount.value * 3);
+      BOOST_CHECK(asset_dynamic.fee_pool.get_amount() == 1000*prec - core_fee.amount.value * 3);
    } catch (fc::exception& e) {
       edump((e.to_detail_string()));
       throw;
@@ -1798,7 +1798,7 @@ BOOST_AUTO_TEST_CASE( witness_pay_test )
       const witness_object& wit = db.fetch_block_by_number(db.head_block_num())->witness(db);
       if( !wit.pay_vb.valid() )
          return 0;
-      return (*wit.pay_vb)(db).balance.amount;
+      return (*wit.pay_vb)(db).balance.get_amount();
    };
 
    const auto block_interval = db.get_global_properties().parameters.block_interval;
@@ -1828,7 +1828,7 @@ BOOST_AUTO_TEST_CASE( witness_pay_test )
       _gpo.parameters.witness_pay_per_block = witness_ppb;
    } );
 
-   BOOST_CHECK_EQUAL(core->dynamic_asset_data_id(db).accumulated_fees.value, 0);
+   BOOST_CHECK_EQUAL(core->dynamic_asset_data_id(db).accumulated_fees.get_amount().value, 0);
    BOOST_TEST_MESSAGE( "Upgrading account" );
    account_upgrade_operation uop;
    uop.account_to_upgrade = nathan->get_id();
@@ -1871,26 +1871,26 @@ BOOST_AUTO_TEST_CASE( witness_pay_test )
    BOOST_CHECK( core->reserved(db).value == 8000*prec );
    generate_block();
    BOOST_CHECK_EQUAL( core->reserved(db).value, 999999406 );
-   BOOST_CHECK_EQUAL( db.get_dynamic_global_properties().witness_budget.value, (int64_t)ref_budget );
+   BOOST_CHECK_EQUAL( db.get_dynamic_global_properties().witness_budget.get_amount().value, (int64_t)ref_budget );
    // first witness paid from old budget (so no pay)
    BOOST_CHECK_EQUAL( last_witness_vbo_balance().value, 0 );
    // second witness finally gets paid!
    generate_block();
    BOOST_CHECK_EQUAL( last_witness_vbo_balance().value, (int64_t)witness_ppb );
-   BOOST_CHECK_EQUAL( db.get_dynamic_global_properties().witness_budget.value, (int64_t)(ref_budget - witness_ppb) );
+   BOOST_CHECK_EQUAL( db.get_dynamic_global_properties().witness_budget.get_amount().value, (int64_t)(ref_budget - witness_ppb) );
 
    generate_block();
    BOOST_CHECK_EQUAL( last_witness_vbo_balance().value, (int64_t)witness_ppb );
-   BOOST_CHECK_EQUAL( db.get_dynamic_global_properties().witness_budget.value, (int64_t)(ref_budget - 2 * witness_ppb) );
+   BOOST_CHECK_EQUAL( db.get_dynamic_global_properties().witness_budget.get_amount().value, (int64_t)(ref_budget - 2 * witness_ppb) );
 
    generate_block();
    BOOST_CHECK_LT( last_witness_vbo_balance().value, (int64_t)witness_ppb );
    BOOST_CHECK_EQUAL( last_witness_vbo_balance().value, (int64_t)(ref_budget - 2 * witness_ppb) );
-   BOOST_CHECK_EQUAL( db.get_dynamic_global_properties().witness_budget.value, 0 );
+   BOOST_CHECK_EQUAL( db.get_dynamic_global_properties().witness_budget.get_amount().value, 0 );
 
    generate_block();
    BOOST_CHECK_EQUAL( last_witness_vbo_balance().value, 0 );
-   BOOST_CHECK_EQUAL( db.get_dynamic_global_properties().witness_budget.value, 0 );
+   BOOST_CHECK_EQUAL( db.get_dynamic_global_properties().witness_budget.get_amount().value, 0 );
    BOOST_CHECK_EQUAL(core->reserved(db).value, 999999406 );
 
 } FC_LOG_AND_RETHROW() }
@@ -2144,7 +2144,7 @@ BOOST_AUTO_TEST_CASE( cover_with_collateral_test )
       const limit_order_object* order = create_sell_order( bob_id, bitusd.amount(99), asset(4950) );
       BOOST_REQUIRE( order != nullptr );
       limit_order_id_type order1_id = order->id;
-      BOOST_CHECK_EQUAL( order->for_sale.value, 99 );
+      BOOST_CHECK_EQUAL( order->for_sale.get_amount().value, 99 );
       // wdump( (*call_order) );
 
       BOOST_TEST_MESSAGE( "Alice still cannot decrease her collateral to maint level" );
@@ -2155,7 +2155,7 @@ BOOST_AUTO_TEST_CASE( cover_with_collateral_test )
       order = create_sell_order( bob_id, bitusd.amount(1), asset(50) );
       BOOST_REQUIRE( order != nullptr );
       limit_order_id_type order2_id = order->id;
-      BOOST_CHECK_EQUAL( order->for_sale.value, 1 );
+      BOOST_CHECK_EQUAL( order->for_sale.get_amount().value, 1 );
       // wdump( (*call_order) );
 
       BOOST_TEST_MESSAGE( "Alice decreases her collateral to maint level and Bob's orders fill" );

--- a/tests/tests/settle_tests.cpp
+++ b/tests/tests/settle_tests.cpp
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       operation_result result = force_settle(rachel, bitusd.amount(4));
 
       force_settlement_id_type settle_id = result.get<object_id_type>();
-      BOOST_CHECK_EQUAL( settle_id(db).balance.amount.value, 4 );
+      BOOST_CHECK_EQUAL( settle_id(db).balance.get_amount().value, 4 );
 
       BOOST_CHECK_EQUAL(get_balance(rachel, core), 0);
       BOOST_CHECK_EQUAL(get_balance(rachel, bitusd), 196);
@@ -99,10 +99,10 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       BOOST_CHECK_EQUAL(get_balance(paul, core), 9999900);
       BOOST_CHECK_EQUAL(get_balance(paul, bitusd), 800);
 
-      BOOST_CHECK_EQUAL( 1000, call_paul.debt.value );
-      BOOST_CHECK_EQUAL( 100, call_paul.collateral.value );
-      BOOST_CHECK_EQUAL( 6, call_michael.debt.value );
-      BOOST_CHECK_EQUAL( 8, call_michael.collateral.value );
+      BOOST_CHECK_EQUAL( 1000, call_paul.debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 100, call_paul.collateral.get_amount().value );
+      BOOST_CHECK_EQUAL( 6, call_michael.debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 8, call_michael.collateral.get_amount().value );
 
       generate_blocks( db.head_block_time() + fc::hours(20) );
       set_expiration( db, trx );
@@ -127,12 +127,12 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), core_id(db)), 9999900);
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), bitusd_id(db)), 800);
 
-      BOOST_CHECK_EQUAL( 996, call_paul_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 100, call_paul_id(db).collateral.value );
-      BOOST_CHECK_EQUAL( 6, call_michael_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 8, call_michael_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 996, call_paul_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 100, call_paul_id(db).collateral.get_amount().value );
+      BOOST_CHECK_EQUAL( 6, call_michael_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 8, call_michael_id(db).collateral.get_amount().value );
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 1002 ); // 1000 + 6 - 4
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 1002 ); // 1000 + 6 - 4
 
       // settle more and check rounding issue
       // by default 20% of total supply can be settled per maintenance interval, here we test less than it
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       operation_result result2 = force_settle(rachel_id(db), bitusd_id(db).amount(34));
 
       force_settlement_id_type settle_id2 = result2.get<object_id_type>();
-      BOOST_CHECK_EQUAL( settle_id2(db).balance.amount.value, 34 );
+      BOOST_CHECK_EQUAL( settle_id2(db).balance.get_amount().value, 34 );
 
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), core_id(db)), 0);
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), bitusd_id(db)), 162); // 196-34
@@ -149,10 +149,10 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), core_id(db)), 9999900);
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), bitusd_id(db)), 800);
 
-      BOOST_CHECK_EQUAL( 996, call_paul_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 100, call_paul_id(db).collateral.value );
-      BOOST_CHECK_EQUAL( 6, call_michael_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 8, call_michael_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 996, call_paul_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 100, call_paul_id(db).collateral.get_amount().value );
+      BOOST_CHECK_EQUAL( 6, call_michael_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 8, call_michael_id(db).collateral.get_amount().value );
 
       generate_blocks( db.head_block_time() + fc::hours(10) );
       set_expiration( db, trx );
@@ -177,12 +177,12 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), core_id(db)), 9999900);
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), bitusd_id(db)), 800);
 
-      BOOST_CHECK_EQUAL( 962, call_paul_id(db).debt.value ); // 996 - 34
-      BOOST_CHECK_EQUAL( 99, call_paul_id(db).collateral.value ); // 100 - 1
-      BOOST_CHECK_EQUAL( 6, call_michael_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 8, call_michael_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 962, call_paul_id(db).debt.get_amount().value ); // 996 - 34
+      BOOST_CHECK_EQUAL( 99, call_paul_id(db).collateral.get_amount().value ); // 100 - 1
+      BOOST_CHECK_EQUAL( 6, call_michael_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 8, call_michael_id(db).collateral.get_amount().value );
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 968 ); // 1002 - 34
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 968 ); // 1002 - 34
 
       // prepare for more tests
       transfer(paul_id, rachel_id, asset(300, bitusd_id));
@@ -195,13 +195,13 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       const operation_result result5 = force_settle(rachel_id(db), bitusd_id(db).amount(5));
 
       force_settlement_id_type settle_id3 = result3.get<object_id_type>();
-      BOOST_CHECK_EQUAL( settle_id3(db).balance.amount.value, 3 );
+      BOOST_CHECK_EQUAL( settle_id3(db).balance.get_amount().value, 3 );
 
       force_settlement_id_type settle_id4 = result4.get<object_id_type>();
-      BOOST_CHECK_EQUAL( settle_id4(db).balance.amount.value, 434 );
+      BOOST_CHECK_EQUAL( settle_id4(db).balance.get_amount().value, 434 );
 
       force_settlement_id_type settle_id5 = result5.get<object_id_type>();
-      BOOST_CHECK_EQUAL( settle_id5(db).balance.amount.value, 5 );
+      BOOST_CHECK_EQUAL( settle_id5(db).balance.get_amount().value, 5 );
 
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), core_id(db)), 1);
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), bitusd_id(db)), 20); // 162 + 300 - 3 - 434 - 5
@@ -210,12 +210,12 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), core_id(db)), 9999900);
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), bitusd_id(db)), 500); // 800 - 300
 
-      BOOST_CHECK_EQUAL( 962, call_paul_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 99, call_paul_id(db).collateral.value );
-      BOOST_CHECK_EQUAL( 8, call_michael_id(db).debt.value ); // 6 + 2
-      BOOST_CHECK_EQUAL( 11, call_michael_id(db).collateral.value ); // 8 + 3
+      BOOST_CHECK_EQUAL( 962, call_paul_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 99, call_paul_id(db).collateral.get_amount().value );
+      BOOST_CHECK_EQUAL( 8, call_michael_id(db).debt.get_amount().value ); // 6 + 2
+      BOOST_CHECK_EQUAL( 11, call_michael_id(db).collateral.get_amount().value ); // 8 + 3
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 970 ); // 968 + 2
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 970 ); // 968 + 2
 
       generate_blocks( db.head_block_time() + fc::hours(4) );
       set_expiration( db, trx );
@@ -242,8 +242,8 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       // settle_id3 (amount was 3) will be filled and get nothing.
       // settle_id4 will pay 194 - 3 = 191 usd, will get round_down(191*5/101) = 9 core
       BOOST_CHECK( !db.find( settle_id3 ) );
-      BOOST_CHECK_EQUAL( settle_id4(db).balance.amount.value, 243 ); // 434 - 191
-      BOOST_CHECK_EQUAL( settle_id5(db).balance.amount.value, 5 ); // no change, since it's after settle_id4
+      BOOST_CHECK_EQUAL( settle_id4(db).balance.get_amount().value, 243 ); // 434 - 191
+      BOOST_CHECK_EQUAL( settle_id5(db).balance.get_amount().value, 5 ); // no change, since it's after settle_id4
 
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), core_id(db)), 10); // 1 + 9
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), bitusd_id(db)), 20); // no change
@@ -252,12 +252,12 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), core_id(db)), 9999900);
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), bitusd_id(db)), 500);
 
-      BOOST_CHECK_EQUAL( 768, call_paul_id(db).debt.value ); // 962 - 3 - 191
-      BOOST_CHECK_EQUAL( 90, call_paul_id(db).collateral.value ); // 99 - 9
-      BOOST_CHECK_EQUAL( 8, call_michael_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 11, call_michael_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 768, call_paul_id(db).debt.get_amount().value ); // 962 - 3 - 191
+      BOOST_CHECK_EQUAL( 90, call_paul_id(db).collateral.get_amount().value ); // 99 - 9
+      BOOST_CHECK_EQUAL( 8, call_michael_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 11, call_michael_id(db).collateral.get_amount().value );
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 776 ); // 970 - 3 - 191
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 776 ); // 970 - 3 - 191
       BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).force_settled_volume.value, 194 ); // 3 + 191
 
       generate_block();
@@ -266,8 +266,8 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       set_expiration( db, trx );
       borrow(michael_id(db), bitusd_id(db).amount(18), core_id(db).amount(200));
 
-      BOOST_CHECK_EQUAL( settle_id4(db).balance.amount.value, 243 );
-      BOOST_CHECK_EQUAL( settle_id5(db).balance.amount.value, 5 );
+      BOOST_CHECK_EQUAL( settle_id4(db).balance.get_amount().value, 243 );
+      BOOST_CHECK_EQUAL( settle_id5(db).balance.get_amount().value, 5 );
 
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), core_id(db)), 10);
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), bitusd_id(db)), 20);
@@ -276,12 +276,12 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), core_id(db)), 9999900);
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), bitusd_id(db)), 500);
 
-      BOOST_CHECK_EQUAL( 768, call_paul_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 90, call_paul_id(db).collateral.value );
-      BOOST_CHECK_EQUAL( 26, call_michael_id(db).debt.value ); // 8 + 18
-      BOOST_CHECK_EQUAL( 211, call_michael_id(db).collateral.value ); // 11 + 200
+      BOOST_CHECK_EQUAL( 768, call_paul_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 90, call_paul_id(db).collateral.get_amount().value );
+      BOOST_CHECK_EQUAL( 26, call_michael_id(db).debt.get_amount().value ); // 8 + 18
+      BOOST_CHECK_EQUAL( 211, call_michael_id(db).collateral.get_amount().value ); // 11 + 200
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 794 ); // 776 + 18
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 794 ); // 776 + 18
       BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).force_settled_volume.value, 194 );
 
       generate_block();
@@ -289,8 +289,8 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       // maximum amount that can be settled now is round_down((794+194) * 20%) = 197,
       //   already settled 194, so 197 - 194 = 3 more usd can be settled,
       //   so settle_id3 will pay 3 usd and get nothing
-      BOOST_CHECK_EQUAL( settle_id4(db).balance.amount.value, 240 ); // 243 - 3
-      BOOST_CHECK_EQUAL( settle_id5(db).balance.amount.value, 5 );
+      BOOST_CHECK_EQUAL( settle_id4(db).balance.get_amount().value, 240 ); // 243 - 3
+      BOOST_CHECK_EQUAL( settle_id5(db).balance.get_amount().value, 5 );
 
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), core_id(db)), 10);
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), bitusd_id(db)), 20);
@@ -299,20 +299,20 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), core_id(db)), 9999900);
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), bitusd_id(db)), 500);
 
-      BOOST_CHECK_EQUAL( 765, call_paul_id(db).debt.value ); // 768 - 3
-      BOOST_CHECK_EQUAL( 90, call_paul_id(db).collateral.value );
-      BOOST_CHECK_EQUAL( 26, call_michael_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 211, call_michael_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 765, call_paul_id(db).debt.get_amount().value ); // 768 - 3
+      BOOST_CHECK_EQUAL( 90, call_paul_id(db).collateral.get_amount().value );
+      BOOST_CHECK_EQUAL( 26, call_michael_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 211, call_michael_id(db).collateral.get_amount().value );
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 791 ); // 794 - 3
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 791 ); // 794 - 3
       BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).force_settled_volume.value, 197 ); // 194 + 3
 
       // michael borrows a little more
       set_expiration( db, trx );
       borrow(michael_id(db), bitusd_id(db).amount(20), core_id(db).amount(20));
 
-      BOOST_CHECK_EQUAL( settle_id4(db).balance.amount.value, 240 );
-      BOOST_CHECK_EQUAL( settle_id5(db).balance.amount.value, 5 );
+      BOOST_CHECK_EQUAL( settle_id4(db).balance.get_amount().value, 240 );
+      BOOST_CHECK_EQUAL( settle_id5(db).balance.get_amount().value, 5 );
 
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), core_id(db)), 10);
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), bitusd_id(db)), 20);
@@ -321,12 +321,12 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), core_id(db)), 9999900);
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), bitusd_id(db)), 500);
 
-      BOOST_CHECK_EQUAL( 765, call_paul_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 90, call_paul_id(db).collateral.value );
-      BOOST_CHECK_EQUAL( 46, call_michael_id(db).debt.value ); // 26 + 20
-      BOOST_CHECK_EQUAL( 231, call_michael_id(db).collateral.value ); // 211 + 20
+      BOOST_CHECK_EQUAL( 765, call_paul_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 90, call_paul_id(db).collateral.get_amount().value );
+      BOOST_CHECK_EQUAL( 46, call_michael_id(db).debt.get_amount().value ); // 26 + 20
+      BOOST_CHECK_EQUAL( 231, call_michael_id(db).collateral.get_amount().value ); // 211 + 20
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 811 ); // 791 + 20
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 811 ); // 791 + 20
       BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).force_settled_volume.value, 197 );
 
       generate_block();
@@ -335,8 +335,8 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       //   already settled 197, so 201 - 197 = 4 more usd can be settled,
       //   so settle_id4 will pay 4 usd and get nothing
 
-      BOOST_CHECK_EQUAL( settle_id4(db).balance.amount.value, 236 ); // 240 - 4
-      BOOST_CHECK_EQUAL( settle_id5(db).balance.amount.value, 5 ); // no change, since it's after settle_id4
+      BOOST_CHECK_EQUAL( settle_id4(db).balance.get_amount().value, 236 ); // 240 - 4
+      BOOST_CHECK_EQUAL( settle_id5(db).balance.get_amount().value, 5 ); // no change, since it's after settle_id4
 
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), core_id(db)), 10);
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), bitusd_id(db)), 20);
@@ -345,12 +345,12 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), core_id(db)), 9999900);
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), bitusd_id(db)), 500);
 
-      BOOST_CHECK_EQUAL( 761, call_paul_id(db).debt.value ); // 765 - 4
-      BOOST_CHECK_EQUAL( 90, call_paul_id(db).collateral.value );
-      BOOST_CHECK_EQUAL( 46, call_michael_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 231, call_michael_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 761, call_paul_id(db).debt.get_amount().value ); // 765 - 4
+      BOOST_CHECK_EQUAL( 90, call_paul_id(db).collateral.get_amount().value );
+      BOOST_CHECK_EQUAL( 46, call_michael_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 231, call_michael_id(db).collateral.get_amount().value );
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 807 ); // 811 - 4
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 807 ); // 811 - 4
       BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).force_settled_volume.value, 201 ); // 197 + 4
 
       generate_block();
@@ -358,8 +358,8 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       // jim borrow some cny
       call_order_id_type call_jim_id = borrow(jim_id(db), bitcny_id(db).amount(2000), core_id(db).amount(2000))->id;
 
-      BOOST_CHECK_EQUAL( 2000, call_jim_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 2000, call_jim_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 2000, call_jim_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 2000, call_jim_id(db).collateral.get_amount().value );
 
       BOOST_CHECK_EQUAL(get_balance(jim_id(db), core_id(db)), 9998000);
       BOOST_CHECK_EQUAL(get_balance(jim_id(db), bitcny_id(db)), 2000);
@@ -387,13 +387,13 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       const operation_result result8 = force_settle(ted_id(db), bitusd_id(db).amount(22));
 
       force_settlement_id_type settle_id6 = result6.get<object_id_type>();
-      BOOST_CHECK_EQUAL( settle_id6(db).balance.amount.value, 20 );
+      BOOST_CHECK_EQUAL( settle_id6(db).balance.get_amount().value, 20 );
 
       force_settlement_id_type settle_id7 = result7.get<object_id_type>();
-      BOOST_CHECK_EQUAL( settle_id7(db).balance.amount.value, 21 );
+      BOOST_CHECK_EQUAL( settle_id7(db).balance.get_amount().value, 21 );
 
       force_settlement_id_type settle_id8 = result8.get<object_id_type>();
-      BOOST_CHECK_EQUAL( settle_id8(db).balance.amount.value, 22 );
+      BOOST_CHECK_EQUAL( settle_id8(db).balance.get_amount().value, 22 );
 
       BOOST_CHECK_EQUAL(get_balance(ted_id(db), core_id(db)), 0);
       BOOST_CHECK_EQUAL(get_balance(ted_id(db), bitusd_id(db)), 37); // 100 - 20 - 21 - 22
@@ -404,13 +404,13 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       const operation_result result103 = force_settle(joe_id(db), bitcny_id(db).amount(300));
 
       force_settlement_id_type settle_id101 = result101.get<object_id_type>();
-      BOOST_CHECK_EQUAL( settle_id101(db).balance.amount.value, 100 );
+      BOOST_CHECK_EQUAL( settle_id101(db).balance.get_amount().value, 100 );
 
       force_settlement_id_type settle_id102 = result102.get<object_id_type>();
-      BOOST_CHECK_EQUAL( settle_id102(db).balance.amount.value, 1000 );
+      BOOST_CHECK_EQUAL( settle_id102(db).balance.get_amount().value, 1000 );
 
       force_settlement_id_type settle_id103 = result103.get<object_id_type>();
-      BOOST_CHECK_EQUAL( settle_id103(db).balance.amount.value, 300 );
+      BOOST_CHECK_EQUAL( settle_id103(db).balance.get_amount().value, 300 );
 
       BOOST_CHECK_EQUAL(get_balance(joe_id(db), core_id(db)), 0);
       BOOST_CHECK_EQUAL(get_balance(joe_id(db), bitcny_id(db)), 100); // 1500 - 100 - 1000 - 300
@@ -436,11 +436,11 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
 
       // maximum amount that can be settled now is round_down(807 * 20%) = 161,
       // settle_id4 will pay 161 usd, will get round_down(161*5/101) = 7 core
-      BOOST_CHECK_EQUAL( settle_id4(db).balance.amount.value, 75 ); // 236 - 161
-      BOOST_CHECK_EQUAL( settle_id5(db).balance.amount.value, 5 ); // no change, since it's after settle_id4
-      BOOST_CHECK_EQUAL( settle_id6(db).balance.amount.value, 20 ); // no change since not expired
-      BOOST_CHECK_EQUAL( settle_id7(db).balance.amount.value, 21 ); // no change since not expired
-      BOOST_CHECK_EQUAL( settle_id8(db).balance.amount.value, 22 ); // no change since not expired
+      BOOST_CHECK_EQUAL( settle_id4(db).balance.get_amount().value, 75 ); // 236 - 161
+      BOOST_CHECK_EQUAL( settle_id5(db).balance.get_amount().value, 5 ); // no change, since it's after settle_id4
+      BOOST_CHECK_EQUAL( settle_id6(db).balance.get_amount().value, 20 ); // no change since not expired
+      BOOST_CHECK_EQUAL( settle_id7(db).balance.get_amount().value, 21 ); // no change since not expired
+      BOOST_CHECK_EQUAL( settle_id8(db).balance.get_amount().value, 22 ); // no change since not expired
 
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), core_id(db)), 17); // 10 + 7
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), bitusd_id(db)), 20); // no change
@@ -451,28 +451,28 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       BOOST_CHECK_EQUAL(get_balance(ted_id(db), core_id(db)), 0);
       BOOST_CHECK_EQUAL(get_balance(ted_id(db), bitusd_id(db)), 37);
 
-      BOOST_CHECK_EQUAL( 600, call_paul_id(db).debt.value ); // 761 - 161
-      BOOST_CHECK_EQUAL( 83, call_paul_id(db).collateral.value ); // 90 - 7
-      BOOST_CHECK_EQUAL( 46, call_michael_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 231, call_michael_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 600, call_paul_id(db).debt.get_amount().value ); // 761 - 161
+      BOOST_CHECK_EQUAL( 83, call_paul_id(db).collateral.get_amount().value ); // 90 - 7
+      BOOST_CHECK_EQUAL( 46, call_michael_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 231, call_michael_id(db).collateral.get_amount().value );
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 646 ); // 807 - 161
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 646 ); // 807 - 161
       BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).force_settled_volume.value, 161 ); // reset to 0, then 161 more
 
       // current cny data
-      BOOST_CHECK_EQUAL( settle_id101(db).balance.amount.value, 100 ); // no change since not expired
-      BOOST_CHECK_EQUAL( settle_id102(db).balance.amount.value, 1000 ); // no change since not expired
-      BOOST_CHECK_EQUAL( settle_id103(db).balance.amount.value, 300 ); // no change since not expired
+      BOOST_CHECK_EQUAL( settle_id101(db).balance.get_amount().value, 100 ); // no change since not expired
+      BOOST_CHECK_EQUAL( settle_id102(db).balance.get_amount().value, 1000 ); // no change since not expired
+      BOOST_CHECK_EQUAL( settle_id103(db).balance.get_amount().value, 300 ); // no change since not expired
 
       BOOST_CHECK_EQUAL(get_balance(jim_id(db), core_id(db)), 9998000);
       BOOST_CHECK_EQUAL(get_balance(jim_id(db), bitcny_id(db)), 500);
       BOOST_CHECK_EQUAL(get_balance(joe_id(db), core_id(db)), 0);
       BOOST_CHECK_EQUAL(get_balance(joe_id(db), bitcny_id(db)), 100); // 1500 - 100 - 1000 - 300
 
-      BOOST_CHECK_EQUAL( 2000, call_jim_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 2000, call_jim_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 2000, call_jim_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 2000, call_jim_id(db).collateral.get_amount().value );
 
-      BOOST_CHECK_EQUAL( bitcny_id(db).dynamic_data(db).current_supply.value, 2000 );
+      BOOST_CHECK_EQUAL( bitcny_id(db).dynamic_data(db).current_supply.get_amount().value, 2000 );
       BOOST_CHECK_EQUAL( bitcny_id(db).bitasset_data(db).force_settled_volume.value, 0 );
 
       // bob borrow some
@@ -482,10 +482,10 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       BOOST_CHECK_EQUAL(get_balance(bob_id(db), core_id(db)), 9999998); // 10000000 - 2
       BOOST_CHECK_EQUAL(get_balance(bob_id(db), bitusd_id(db)), 19); // new
 
-      BOOST_CHECK_EQUAL( 19, call_bob_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 2, call_bob_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 19, call_bob_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 2, call_bob_id(db).collateral.get_amount().value );
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 665 ); // 646 + 19
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 665 ); // 646 + 19
       BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).force_settled_volume.value, 161 );
 
       generate_block();
@@ -493,11 +493,11 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       // maximum amount that can be settled now is round_down((665+161) * 20%) = 165,
       // settle_id4 will pay 165-161=4 usd, will get nothing
       // bob's call order will get partially settled since its collateral ratio is the lowest
-      BOOST_CHECK_EQUAL( settle_id4(db).balance.amount.value, 71 ); // 75 - 4
-      BOOST_CHECK_EQUAL( settle_id5(db).balance.amount.value, 5 ); // no change, since it's after settle_id4
-      BOOST_CHECK_EQUAL( settle_id6(db).balance.amount.value, 20 ); // no change since not expired
-      BOOST_CHECK_EQUAL( settle_id7(db).balance.amount.value, 21 ); // no change since not expired
-      BOOST_CHECK_EQUAL( settle_id8(db).balance.amount.value, 22 ); // no change since not expired
+      BOOST_CHECK_EQUAL( settle_id4(db).balance.get_amount().value, 71 ); // 75 - 4
+      BOOST_CHECK_EQUAL( settle_id5(db).balance.get_amount().value, 5 ); // no change, since it's after settle_id4
+      BOOST_CHECK_EQUAL( settle_id6(db).balance.get_amount().value, 20 ); // no change since not expired
+      BOOST_CHECK_EQUAL( settle_id7(db).balance.get_amount().value, 21 ); // no change since not expired
+      BOOST_CHECK_EQUAL( settle_id8(db).balance.get_amount().value, 22 ); // no change since not expired
 
       BOOST_CHECK_EQUAL(get_balance(bob_id(db), core_id(db)), 9999998);
       BOOST_CHECK_EQUAL(get_balance(bob_id(db), bitusd_id(db)), 19);
@@ -510,14 +510,14 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       BOOST_CHECK_EQUAL(get_balance(ted_id(db), core_id(db)), 0);
       BOOST_CHECK_EQUAL(get_balance(ted_id(db), bitusd_id(db)), 37);
 
-      BOOST_CHECK_EQUAL( 15, call_bob_id(db).debt.value ); // 19 - 4
-      BOOST_CHECK_EQUAL( 2, call_bob_id(db).collateral.value ); // no change
-      BOOST_CHECK_EQUAL( 600, call_paul_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 83, call_paul_id(db).collateral.value );
-      BOOST_CHECK_EQUAL( 46, call_michael_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 231, call_michael_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 15, call_bob_id(db).debt.get_amount().value ); // 19 - 4
+      BOOST_CHECK_EQUAL( 2, call_bob_id(db).collateral.get_amount().value ); // no change
+      BOOST_CHECK_EQUAL( 600, call_paul_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 83, call_paul_id(db).collateral.get_amount().value );
+      BOOST_CHECK_EQUAL( 46, call_michael_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 231, call_michael_id(db).collateral.get_amount().value );
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 661 ); // 665 - 4
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 661 ); // 665 - 4
       BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).force_settled_volume.value, 165 ); // 161 + 4
 
       // adding new feed so we have valid price to exit
@@ -545,18 +545,18 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       //      according to price 50 core / 101 cny, it will get 148 core and pay 300 cny;
       //   settle_id103 won't be processed since it's after settle_id102
       BOOST_CHECK( !db.find( settle_id101 ) );
-      BOOST_CHECK_EQUAL( settle_id102(db).balance.amount.value, 700 ); // 1000 - 300
-      BOOST_CHECK_EQUAL( settle_id103(db).balance.amount.value, 300 ); // no change since it's after settle_id102
+      BOOST_CHECK_EQUAL( settle_id102(db).balance.get_amount().value, 700 ); // 1000 - 300
+      BOOST_CHECK_EQUAL( settle_id103(db).balance.get_amount().value, 300 ); // no change since it's after settle_id102
 
       BOOST_CHECK_EQUAL(get_balance(jim_id(db), core_id(db)), 9998000);
       BOOST_CHECK_EQUAL(get_balance(jim_id(db), bitcny_id(db)), 500);
       BOOST_CHECK_EQUAL(get_balance(joe_id(db), core_id(db)), 197); // 49 + 148
       BOOST_CHECK_EQUAL(get_balance(joe_id(db), bitcny_id(db)), 100);
 
-      BOOST_CHECK_EQUAL( 1600, call_jim_id(db).debt.value ); // 2000 - 100 - 300
-      BOOST_CHECK_EQUAL( 1803, call_jim_id(db).collateral.value ); // 2000 - 49 - 148
+      BOOST_CHECK_EQUAL( 1600, call_jim_id(db).debt.get_amount().value ); // 2000 - 100 - 300
+      BOOST_CHECK_EQUAL( 1803, call_jim_id(db).collateral.get_amount().value ); // 2000 - 49 - 148
 
-      BOOST_CHECK_EQUAL( bitcny_id(db).dynamic_data(db).current_supply.value, 1600 );
+      BOOST_CHECK_EQUAL( bitcny_id(db).dynamic_data(db).current_supply.get_amount().value, 1600 );
       BOOST_CHECK_EQUAL( bitcny_id(db).bitasset_data(db).force_settled_volume.value, 400 ); // 100 + 300
 
       // adding new feed so we have valid price to exit
@@ -589,7 +589,7 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       BOOST_CHECK( !db.find( settle_id5 ) );
       BOOST_CHECK( !db.find( settle_id6 ) );
       BOOST_CHECK( !db.find( settle_id7 ) );
-      BOOST_CHECK_EQUAL( settle_id8(db).balance.amount.value, 7 ); // 22 - 15
+      BOOST_CHECK_EQUAL( settle_id8(db).balance.get_amount().value, 7 ); // 22 - 15
 
       BOOST_CHECK_EQUAL(get_balance(bob_id(db), core_id(db)), 10000000); // 9999998 + 2
       BOOST_CHECK_EQUAL(get_balance(bob_id(db), bitusd_id(db)), 19);
@@ -603,12 +603,12 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       BOOST_CHECK_EQUAL(get_balance(ted_id(db), bitusd_id(db)), 37);
 
       BOOST_CHECK( !db.find( call_bob_id ) );
-      BOOST_CHECK_EQUAL( 483, call_paul_id(db).debt.value ); // 600 - 56 - 5 - 20 - 21 - 15
-      BOOST_CHECK_EQUAL( 80, call_paul_id(db).collateral.value ); // 83 - 2 - 1
-      BOOST_CHECK_EQUAL( 46, call_michael_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 231, call_michael_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 483, call_paul_id(db).debt.get_amount().value ); // 600 - 56 - 5 - 20 - 21 - 15
+      BOOST_CHECK_EQUAL( 80, call_paul_id(db).collateral.get_amount().value ); // 83 - 2 - 1
+      BOOST_CHECK_EQUAL( 46, call_michael_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 231, call_michael_id(db).collateral.get_amount().value );
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 529 ); // 661 - 132
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 529 ); // 661 - 132
       BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).force_settled_volume.value, 132 ); // reset to 0, then 132 more
 
       // check cny
@@ -617,18 +617,18 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test )
       //      according to price 50 core / 101 cny, it will get 158 core and pay 320 cny;
       //   settle_id103 won't be processed since it's after settle_id102
       BOOST_CHECK( !db.find( settle_id101 ) );
-      BOOST_CHECK_EQUAL( settle_id102(db).balance.amount.value, 380 ); // 700 - 320
-      BOOST_CHECK_EQUAL( settle_id103(db).balance.amount.value, 300 ); // no change since it's after settle_id102
+      BOOST_CHECK_EQUAL( settle_id102(db).balance.get_amount().value, 380 ); // 700 - 320
+      BOOST_CHECK_EQUAL( settle_id103(db).balance.get_amount().value, 300 ); // no change since it's after settle_id102
 
       BOOST_CHECK_EQUAL(get_balance(jim_id(db), core_id(db)), 9998000);
       BOOST_CHECK_EQUAL(get_balance(jim_id(db), bitcny_id(db)), 500);
       BOOST_CHECK_EQUAL(get_balance(joe_id(db), core_id(db)), 355); // 197 + 158
       BOOST_CHECK_EQUAL(get_balance(joe_id(db), bitcny_id(db)), 100);
 
-      BOOST_CHECK_EQUAL( 1280, call_jim_id(db).debt.value ); // 1600 - 320
-      BOOST_CHECK_EQUAL( 1645, call_jim_id(db).collateral.value ); // 1803 - 158
+      BOOST_CHECK_EQUAL( 1280, call_jim_id(db).debt.get_amount().value ); // 1600 - 320
+      BOOST_CHECK_EQUAL( 1645, call_jim_id(db).collateral.get_amount().value ); // 1803 - 158
 
-      BOOST_CHECK_EQUAL( bitcny_id(db).dynamic_data(db).current_supply.value, 1280 );
+      BOOST_CHECK_EQUAL( bitcny_id(db).dynamic_data(db).current_supply.get_amount().value, 1280 );
       BOOST_CHECK_EQUAL( bitcny_id(db).bitasset_data(db).force_settled_volume.value, 320 ); // reset to 0, then 320
 
       generate_block();
@@ -694,7 +694,7 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       const operation_result result = force_settle(rachel, bitusd.amount(4));
 
       force_settlement_id_type settle_id = result.get<object_id_type>();
-      BOOST_CHECK_EQUAL( settle_id(db).balance.amount.value, 4 );
+      BOOST_CHECK_EQUAL( settle_id(db).balance.get_amount().value, 4 );
 
       BOOST_CHECK_EQUAL(get_balance(rachel, core), 0);
       BOOST_CHECK_EQUAL(get_balance(rachel, bitusd), 196);
@@ -703,10 +703,10 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       BOOST_CHECK_EQUAL(get_balance(paul, core), 9999900);
       BOOST_CHECK_EQUAL(get_balance(paul, bitusd), 800);
 
-      BOOST_CHECK_EQUAL( 1000, call_paul.debt.value );
-      BOOST_CHECK_EQUAL( 100, call_paul.collateral.value );
-      BOOST_CHECK_EQUAL( 6, call_michael.debt.value );
-      BOOST_CHECK_EQUAL( 8, call_michael.collateral.value );
+      BOOST_CHECK_EQUAL( 1000, call_paul.debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 100, call_paul.collateral.get_amount().value );
+      BOOST_CHECK_EQUAL( 6, call_michael.debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 8, call_michael.collateral.get_amount().value );
 
       generate_blocks( db.head_block_time() + fc::hours(20) );
       set_expiration( db, trx );
@@ -731,12 +731,12 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), core_id(db)), 9999900);
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), bitusd_id(db)), 800);
 
-      BOOST_CHECK_EQUAL( 1000, call_paul_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 100, call_paul_id(db).collateral.value );
-      BOOST_CHECK_EQUAL( 6, call_michael_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 8, call_michael_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 1000, call_paul_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 100, call_paul_id(db).collateral.get_amount().value );
+      BOOST_CHECK_EQUAL( 6, call_michael_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 8, call_michael_id(db).collateral.get_amount().value );
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 1006 ); // 1000 + 6
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 1006 ); // 1000 + 6
 
       // settle more and check rounding issue
       // by default 20% of total supply can be settled per maintenance interval, here we test less than it
@@ -744,7 +744,7 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       const operation_result result2 = force_settle(rachel_id(db), bitusd_id(db).amount(34));
 
       force_settlement_id_type settle_id2 = result2.get<object_id_type>();
-      BOOST_CHECK_EQUAL( settle_id2(db).balance.amount.value, 34 );
+      BOOST_CHECK_EQUAL( settle_id2(db).balance.get_amount().value, 34 );
 
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), core_id(db)), 0);
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), bitusd_id(db)), 166); // 200-34
@@ -753,10 +753,10 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), core_id(db)), 9999900);
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), bitusd_id(db)), 800);
 
-      BOOST_CHECK_EQUAL( 1000, call_paul_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 100, call_paul_id(db).collateral.value );
-      BOOST_CHECK_EQUAL( 6, call_michael_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 8, call_michael_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 1000, call_paul_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 100, call_paul_id(db).collateral.get_amount().value );
+      BOOST_CHECK_EQUAL( 6, call_michael_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 8, call_michael_id(db).collateral.get_amount().value );
 
       generate_blocks( db.head_block_time() + fc::hours(10) );
       set_expiration( db, trx );
@@ -781,12 +781,12 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), core_id(db)), 9999900);
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), bitusd_id(db)), 800);
 
-      BOOST_CHECK_EQUAL( 979, call_paul_id(db).debt.value ); // 1000 - 21
-      BOOST_CHECK_EQUAL( 99, call_paul_id(db).collateral.value ); // 100 - 1
-      BOOST_CHECK_EQUAL( 6, call_michael_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 8, call_michael_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 979, call_paul_id(db).debt.get_amount().value ); // 1000 - 21
+      BOOST_CHECK_EQUAL( 99, call_paul_id(db).collateral.get_amount().value ); // 100 - 1
+      BOOST_CHECK_EQUAL( 6, call_michael_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 8, call_michael_id(db).collateral.get_amount().value );
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 985 ); // 1006 - 21
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 985 ); // 1006 - 21
 
       // prepare for more tests
       transfer(paul_id, rachel_id, asset(300, bitusd_id));
@@ -799,13 +799,13 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       const operation_result result5 = force_settle(rachel_id(db), bitusd_id(db).amount(5));
 
       force_settlement_id_type settle_id3 = result3.get<object_id_type>();
-      BOOST_CHECK_EQUAL( settle_id3(db).balance.amount.value, 3 );
+      BOOST_CHECK_EQUAL( settle_id3(db).balance.get_amount().value, 3 );
 
       force_settlement_id_type settle_id4 = result4.get<object_id_type>();
-      BOOST_CHECK_EQUAL( settle_id4(db).balance.amount.value, 434 );
+      BOOST_CHECK_EQUAL( settle_id4(db).balance.get_amount().value, 434 );
 
       force_settlement_id_type settle_id5 = result5.get<object_id_type>();
-      BOOST_CHECK_EQUAL( settle_id5(db).balance.amount.value, 5 );
+      BOOST_CHECK_EQUAL( settle_id5(db).balance.get_amount().value, 5 );
 
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), core_id(db)), 1);
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), bitusd_id(db)), 37); // 179 + 300 - 3 - 434 - 5
@@ -814,12 +814,12 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), core_id(db)), 9999900);
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), bitusd_id(db)), 500); // 800 - 300
 
-      BOOST_CHECK_EQUAL( 979, call_paul_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 99, call_paul_id(db).collateral.value );
-      BOOST_CHECK_EQUAL( 8, call_michael_id(db).debt.value ); // 6 + 2
-      BOOST_CHECK_EQUAL( 11, call_michael_id(db).collateral.value ); // 8 + 3
+      BOOST_CHECK_EQUAL( 979, call_paul_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 99, call_paul_id(db).collateral.get_amount().value );
+      BOOST_CHECK_EQUAL( 8, call_michael_id(db).debt.get_amount().value ); // 6 + 2
+      BOOST_CHECK_EQUAL( 11, call_michael_id(db).collateral.get_amount().value ); // 8 + 3
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 987 ); // 985 + 2
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 987 ); // 985 + 2
 
       generate_blocks( db.head_block_time() + fc::hours(4) );
       set_expiration( db, trx );
@@ -847,8 +847,8 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       //   according to price (101/5), the amount worths more than 9 core but less than 10 core, so 9 core will be settled,
       //   and 9 core worths 181.5 usd, so rachel will pay 182 usd and get 9 core
       BOOST_CHECK( !db.find( settle_id3 ) );
-      BOOST_CHECK_EQUAL( settle_id4(db).balance.amount.value, 252 ); // 434 - 182
-      BOOST_CHECK_EQUAL( settle_id5(db).balance.amount.value, 5 ); // no change, since it's after settle_id4
+      BOOST_CHECK_EQUAL( settle_id4(db).balance.get_amount().value, 252 ); // 434 - 182
+      BOOST_CHECK_EQUAL( settle_id5(db).balance.get_amount().value, 5 ); // no change, since it's after settle_id4
 
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), core_id(db)), 10); // 1 + 9
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), bitusd_id(db)), 40); // 37 + 3
@@ -857,12 +857,12 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), core_id(db)), 9999900);
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), bitusd_id(db)), 500);
 
-      BOOST_CHECK_EQUAL( 797, call_paul_id(db).debt.value ); // 979 - 182
-      BOOST_CHECK_EQUAL( 90, call_paul_id(db).collateral.value ); // 99 - 9
-      BOOST_CHECK_EQUAL( 8, call_michael_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 11, call_michael_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 797, call_paul_id(db).debt.get_amount().value ); // 979 - 182
+      BOOST_CHECK_EQUAL( 90, call_paul_id(db).collateral.get_amount().value ); // 99 - 9
+      BOOST_CHECK_EQUAL( 8, call_michael_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 11, call_michael_id(db).collateral.get_amount().value );
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 805 ); // 987 - 182
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 805 ); // 987 - 182
       BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).force_settled_volume.value, 182 );
 
       generate_block();
@@ -871,8 +871,8 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       set_expiration( db, trx );
       borrow(michael_id(db), bitusd_id(db).amount(18), core_id(db).amount(200));
 
-      BOOST_CHECK_EQUAL( settle_id4(db).balance.amount.value, 252 );
-      BOOST_CHECK_EQUAL( settle_id5(db).balance.amount.value, 5 );
+      BOOST_CHECK_EQUAL( settle_id4(db).balance.get_amount().value, 252 );
+      BOOST_CHECK_EQUAL( settle_id5(db).balance.get_amount().value, 5 );
 
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), core_id(db)), 10);
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), bitusd_id(db)), 40);
@@ -881,12 +881,12 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), core_id(db)), 9999900);
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), bitusd_id(db)), 500);
 
-      BOOST_CHECK_EQUAL( 797, call_paul_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 90, call_paul_id(db).collateral.value );
-      BOOST_CHECK_EQUAL( 26, call_michael_id(db).debt.value ); // 8 + 18
-      BOOST_CHECK_EQUAL( 211, call_michael_id(db).collateral.value ); // 11 + 200
+      BOOST_CHECK_EQUAL( 797, call_paul_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 90, call_paul_id(db).collateral.get_amount().value );
+      BOOST_CHECK_EQUAL( 26, call_michael_id(db).debt.get_amount().value ); // 8 + 18
+      BOOST_CHECK_EQUAL( 211, call_michael_id(db).collateral.get_amount().value ); // 11 + 200
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 823 ); // 805 + 18
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 823 ); // 805 + 18
       BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).force_settled_volume.value, 182 );
 
       generate_block();
@@ -895,8 +895,8 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       //   already settled 182, so 201 - 182 = 19 more usd can be settled,
       //   according to price (101/5), the amount worths less than 1 core,
       //   so nothing will happen.
-      BOOST_CHECK_EQUAL( settle_id4(db).balance.amount.value, 252 );
-      BOOST_CHECK_EQUAL( settle_id5(db).balance.amount.value, 5 );
+      BOOST_CHECK_EQUAL( settle_id4(db).balance.get_amount().value, 252 );
+      BOOST_CHECK_EQUAL( settle_id5(db).balance.get_amount().value, 5 );
 
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), core_id(db)), 10);
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), bitusd_id(db)), 40);
@@ -905,20 +905,20 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), core_id(db)), 9999900);
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), bitusd_id(db)), 500);
 
-      BOOST_CHECK_EQUAL( 797, call_paul_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 90, call_paul_id(db).collateral.value );
-      BOOST_CHECK_EQUAL( 26, call_michael_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 211, call_michael_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 797, call_paul_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 90, call_paul_id(db).collateral.get_amount().value );
+      BOOST_CHECK_EQUAL( 26, call_michael_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 211, call_michael_id(db).collateral.get_amount().value );
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 823 );
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 823 );
       BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).force_settled_volume.value, 182 );
 
       // michael borrows a little more
       set_expiration( db, trx );
       borrow(michael_id(db), bitusd_id(db).amount(20), core_id(db).amount(20));
 
-      BOOST_CHECK_EQUAL( settle_id4(db).balance.amount.value, 252 );
-      BOOST_CHECK_EQUAL( settle_id5(db).balance.amount.value, 5 );
+      BOOST_CHECK_EQUAL( settle_id4(db).balance.get_amount().value, 252 );
+      BOOST_CHECK_EQUAL( settle_id5(db).balance.get_amount().value, 5 );
 
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), core_id(db)), 10);
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), bitusd_id(db)), 40);
@@ -927,12 +927,12 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), core_id(db)), 9999900);
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), bitusd_id(db)), 500);
 
-      BOOST_CHECK_EQUAL( 797, call_paul_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 90, call_paul_id(db).collateral.value );
-      BOOST_CHECK_EQUAL( 46, call_michael_id(db).debt.value ); // 26 + 20
-      BOOST_CHECK_EQUAL( 231, call_michael_id(db).collateral.value ); // 211 + 20
+      BOOST_CHECK_EQUAL( 797, call_paul_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 90, call_paul_id(db).collateral.get_amount().value );
+      BOOST_CHECK_EQUAL( 46, call_michael_id(db).debt.get_amount().value ); // 26 + 20
+      BOOST_CHECK_EQUAL( 231, call_michael_id(db).collateral.get_amount().value ); // 211 + 20
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 843 ); // 823 + 20
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 843 ); // 823 + 20
       BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).force_settled_volume.value, 182 );
 
       generate_block();
@@ -943,8 +943,8 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       //   so settle order will fill 1 more core, since 1 core worth more than 20 usd but less than 21 usd,
       //   so rachel will pay 21 usd and get 1 core
 
-      BOOST_CHECK_EQUAL( settle_id4(db).balance.amount.value, 231 ); // 252 - 21
-      BOOST_CHECK_EQUAL( settle_id5(db).balance.amount.value, 5 ); // no change, since it's after settle_id4
+      BOOST_CHECK_EQUAL( settle_id4(db).balance.get_amount().value, 231 ); // 252 - 21
+      BOOST_CHECK_EQUAL( settle_id5(db).balance.get_amount().value, 5 ); // no change, since it's after settle_id4
 
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), core_id(db)), 11); // 10 + 1
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), bitusd_id(db)), 40); // no change
@@ -953,19 +953,19 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), core_id(db)), 9999900);
       BOOST_CHECK_EQUAL(get_balance(paul_id(db), bitusd_id(db)), 500);
 
-      BOOST_CHECK_EQUAL( 776, call_paul_id(db).debt.value ); // 797 - 21
-      BOOST_CHECK_EQUAL( 89, call_paul_id(db).collateral.value ); // 90 - 1
-      BOOST_CHECK_EQUAL( 46, call_michael_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 231, call_michael_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 776, call_paul_id(db).debt.get_amount().value ); // 797 - 21
+      BOOST_CHECK_EQUAL( 89, call_paul_id(db).collateral.get_amount().value ); // 90 - 1
+      BOOST_CHECK_EQUAL( 46, call_michael_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 231, call_michael_id(db).collateral.get_amount().value );
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 822 ); // 843 - 21
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 822 ); // 843 - 21
       BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).force_settled_volume.value, 203 ); // 182 + 21
 
       // jim borrow some cny
       call_order_id_type call_jim_id = borrow(jim_id(db), bitcny_id(db).amount(2000), core_id(db).amount(2000))->id;
 
-      BOOST_CHECK_EQUAL( 2000, call_jim_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 2000, call_jim_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 2000, call_jim_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 2000, call_jim_id(db).collateral.get_amount().value );
 
       BOOST_CHECK_EQUAL(get_balance(jim_id(db), core_id(db)), 9998000);
       BOOST_CHECK_EQUAL(get_balance(jim_id(db), bitcny_id(db)), 2000);
@@ -993,13 +993,13 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       const operation_result result8 = force_settle(ted_id(db), bitusd_id(db).amount(22));
 
       force_settlement_id_type settle_id6 = result6.get<object_id_type>();
-      BOOST_CHECK_EQUAL( settle_id6(db).balance.amount.value, 20 );
+      BOOST_CHECK_EQUAL( settle_id6(db).balance.get_amount().value, 20 );
 
       force_settlement_id_type settle_id7 = result7.get<object_id_type>();
-      BOOST_CHECK_EQUAL( settle_id7(db).balance.amount.value, 21 );
+      BOOST_CHECK_EQUAL( settle_id7(db).balance.get_amount().value, 21 );
 
       force_settlement_id_type settle_id8 = result8.get<object_id_type>();
-      BOOST_CHECK_EQUAL( settle_id8(db).balance.amount.value, 22 );
+      BOOST_CHECK_EQUAL( settle_id8(db).balance.get_amount().value, 22 );
 
       BOOST_CHECK_EQUAL(get_balance(ted_id(db), core_id(db)), 0);
       BOOST_CHECK_EQUAL(get_balance(ted_id(db), bitusd_id(db)), 37); // 100 - 20 - 21 - 22
@@ -1010,13 +1010,13 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       const operation_result result103 = force_settle(joe_id(db), bitcny_id(db).amount(300));
 
       force_settlement_id_type settle_id101 = result101.get<object_id_type>();
-      BOOST_CHECK_EQUAL( settle_id101(db).balance.amount.value, 100 );
+      BOOST_CHECK_EQUAL( settle_id101(db).balance.get_amount().value, 100 );
 
       force_settlement_id_type settle_id102 = result102.get<object_id_type>();
-      BOOST_CHECK_EQUAL( settle_id102(db).balance.amount.value, 1000 );
+      BOOST_CHECK_EQUAL( settle_id102(db).balance.get_amount().value, 1000 );
 
       force_settlement_id_type settle_id103 = result103.get<object_id_type>();
-      BOOST_CHECK_EQUAL( settle_id103(db).balance.amount.value, 300 );
+      BOOST_CHECK_EQUAL( settle_id103(db).balance.get_amount().value, 300 );
 
       BOOST_CHECK_EQUAL(get_balance(joe_id(db), core_id(db)), 0);
       BOOST_CHECK_EQUAL(get_balance(joe_id(db), bitcny_id(db)), 100); // 1500 - 100 - 1000 - 300
@@ -1044,11 +1044,11 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       //   according to price (101/5), the amount worths more than 8 core but less than 9 core,
       //   so settle order will fill 8 more core, since 8 core worth more than 161 usd but less than 162 usd,
       //   so rachel will pay 162 usd and get 8 core
-      BOOST_CHECK_EQUAL( settle_id4(db).balance.amount.value, 69 ); // 231 - 162
-      BOOST_CHECK_EQUAL( settle_id5(db).balance.amount.value, 5 ); // no change, since it's after settle_id4
-      BOOST_CHECK_EQUAL( settle_id6(db).balance.amount.value, 20 ); // no change since not expired
-      BOOST_CHECK_EQUAL( settle_id7(db).balance.amount.value, 21 ); // no change since not expired
-      BOOST_CHECK_EQUAL( settle_id8(db).balance.amount.value, 22 ); // no change since not expired
+      BOOST_CHECK_EQUAL( settle_id4(db).balance.get_amount().value, 69 ); // 231 - 162
+      BOOST_CHECK_EQUAL( settle_id5(db).balance.get_amount().value, 5 ); // no change, since it's after settle_id4
+      BOOST_CHECK_EQUAL( settle_id6(db).balance.get_amount().value, 20 ); // no change since not expired
+      BOOST_CHECK_EQUAL( settle_id7(db).balance.get_amount().value, 21 ); // no change since not expired
+      BOOST_CHECK_EQUAL( settle_id8(db).balance.get_amount().value, 22 ); // no change since not expired
 
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), core_id(db)), 19); // 11 + 8
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), bitusd_id(db)), 40); // no change
@@ -1059,28 +1059,28 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       BOOST_CHECK_EQUAL(get_balance(ted_id(db), core_id(db)), 0);
       BOOST_CHECK_EQUAL(get_balance(ted_id(db), bitusd_id(db)), 37);
 
-      BOOST_CHECK_EQUAL( 614, call_paul_id(db).debt.value ); // 776 - 162
-      BOOST_CHECK_EQUAL( 81, call_paul_id(db).collateral.value ); // 89 - 8
-      BOOST_CHECK_EQUAL( 46, call_michael_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 231, call_michael_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 614, call_paul_id(db).debt.get_amount().value ); // 776 - 162
+      BOOST_CHECK_EQUAL( 81, call_paul_id(db).collateral.get_amount().value ); // 89 - 8
+      BOOST_CHECK_EQUAL( 46, call_michael_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 231, call_michael_id(db).collateral.get_amount().value );
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 660 ); // 822 - 162
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 660 ); // 822 - 162
       BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).force_settled_volume.value, 162 ); // reset to 0, then 162 more
 
       // current cny data
-      BOOST_CHECK_EQUAL( settle_id101(db).balance.amount.value, 100 ); // no change since not expired
-      BOOST_CHECK_EQUAL( settle_id102(db).balance.amount.value, 1000 ); // no change since not expired
-      BOOST_CHECK_EQUAL( settle_id103(db).balance.amount.value, 300 ); // no change since not expired
+      BOOST_CHECK_EQUAL( settle_id101(db).balance.get_amount().value, 100 ); // no change since not expired
+      BOOST_CHECK_EQUAL( settle_id102(db).balance.get_amount().value, 1000 ); // no change since not expired
+      BOOST_CHECK_EQUAL( settle_id103(db).balance.get_amount().value, 300 ); // no change since not expired
 
       BOOST_CHECK_EQUAL(get_balance(jim_id(db), core_id(db)), 9998000);
       BOOST_CHECK_EQUAL(get_balance(jim_id(db), bitcny_id(db)), 500);
       BOOST_CHECK_EQUAL(get_balance(joe_id(db), core_id(db)), 0);
       BOOST_CHECK_EQUAL(get_balance(joe_id(db), bitcny_id(db)), 100); // 1500 - 100 - 1000 - 300
 
-      BOOST_CHECK_EQUAL( 2000, call_jim_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 2000, call_jim_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 2000, call_jim_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 2000, call_jim_id(db).collateral.get_amount().value );
 
-      BOOST_CHECK_EQUAL( bitcny_id(db).dynamic_data(db).current_supply.value, 2000 );
+      BOOST_CHECK_EQUAL( bitcny_id(db).dynamic_data(db).current_supply.get_amount().value, 2000 );
       BOOST_CHECK_EQUAL( bitcny_id(db).bitasset_data(db).force_settled_volume.value, 0 );
 
       // bob borrow some
@@ -1090,10 +1090,10 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       BOOST_CHECK_EQUAL(get_balance(bob_id(db), core_id(db)), 9999998); // 10000000 - 2
       BOOST_CHECK_EQUAL(get_balance(bob_id(db), bitusd_id(db)), 19); // new
 
-      BOOST_CHECK_EQUAL( 19, call_bob_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 2, call_bob_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 19, call_bob_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 2, call_bob_id(db).collateral.get_amount().value );
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 679 ); // 660 + 19
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 679 ); // 660 + 19
       BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).force_settled_volume.value, 162 );
 
       generate_block();
@@ -1102,11 +1102,11 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       //   already settled 162, so 168 - 162 = 6 more usd can be settled,
       //   according to price (101/5), the amount worths less than 1 core,
       //   so nothing will happen.
-      BOOST_CHECK_EQUAL( settle_id4(db).balance.amount.value, 69 );
-      BOOST_CHECK_EQUAL( settle_id5(db).balance.amount.value, 5 );
-      BOOST_CHECK_EQUAL( settle_id6(db).balance.amount.value, 20 );
-      BOOST_CHECK_EQUAL( settle_id7(db).balance.amount.value, 21 );
-      BOOST_CHECK_EQUAL( settle_id8(db).balance.amount.value, 22 );
+      BOOST_CHECK_EQUAL( settle_id4(db).balance.get_amount().value, 69 );
+      BOOST_CHECK_EQUAL( settle_id5(db).balance.get_amount().value, 5 );
+      BOOST_CHECK_EQUAL( settle_id6(db).balance.get_amount().value, 20 );
+      BOOST_CHECK_EQUAL( settle_id7(db).balance.get_amount().value, 21 );
+      BOOST_CHECK_EQUAL( settle_id8(db).balance.get_amount().value, 22 );
 
       BOOST_CHECK_EQUAL(get_balance(bob_id(db), core_id(db)), 9999998);
       BOOST_CHECK_EQUAL(get_balance(bob_id(db), bitusd_id(db)), 19);
@@ -1119,14 +1119,14 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       BOOST_CHECK_EQUAL(get_balance(ted_id(db), core_id(db)), 0);
       BOOST_CHECK_EQUAL(get_balance(ted_id(db), bitusd_id(db)), 37);
 
-      BOOST_CHECK_EQUAL( 19, call_bob_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 2, call_bob_id(db).collateral.value );
-      BOOST_CHECK_EQUAL( 614, call_paul_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 81, call_paul_id(db).collateral.value );
-      BOOST_CHECK_EQUAL( 46, call_michael_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 231, call_michael_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 19, call_bob_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 2, call_bob_id(db).collateral.get_amount().value );
+      BOOST_CHECK_EQUAL( 614, call_paul_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 81, call_paul_id(db).collateral.get_amount().value );
+      BOOST_CHECK_EQUAL( 46, call_michael_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 231, call_michael_id(db).collateral.get_amount().value );
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 679 );
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 679 );
       BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).force_settled_volume.value, 162 );
 
       // adding new feed so we have valid price to exit
@@ -1154,18 +1154,18 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       //      according to price 50 core / 101 cny, it will get 149 core and pay 301 cny;
       //   settle_id103 won't be processed since it's after settle_id102
       BOOST_CHECK( !db.find( settle_id101 ) );
-      BOOST_CHECK_EQUAL( settle_id102(db).balance.amount.value, 699 ); // 1000 - 301
-      BOOST_CHECK_EQUAL( settle_id103(db).balance.amount.value, 300 ); // no change since it's after settle_id102
+      BOOST_CHECK_EQUAL( settle_id102(db).balance.get_amount().value, 699 ); // 1000 - 301
+      BOOST_CHECK_EQUAL( settle_id103(db).balance.get_amount().value, 300 ); // no change since it's after settle_id102
 
       BOOST_CHECK_EQUAL(get_balance(jim_id(db), core_id(db)), 9998000);
       BOOST_CHECK_EQUAL(get_balance(jim_id(db), bitcny_id(db)), 500);
       BOOST_CHECK_EQUAL(get_balance(joe_id(db), core_id(db)), 198); // 49 + 149
       BOOST_CHECK_EQUAL(get_balance(joe_id(db), bitcny_id(db)), 101); // 100 + 1
 
-      BOOST_CHECK_EQUAL( 1600, call_jim_id(db).debt.value ); // 2000 - 99 - 301
-      BOOST_CHECK_EQUAL( 1802, call_jim_id(db).collateral.value ); // 2000 - 49 - 149
+      BOOST_CHECK_EQUAL( 1600, call_jim_id(db).debt.get_amount().value ); // 2000 - 99 - 301
+      BOOST_CHECK_EQUAL( 1802, call_jim_id(db).collateral.get_amount().value ); // 2000 - 49 - 149
 
-      BOOST_CHECK_EQUAL( bitcny_id(db).dynamic_data(db).current_supply.value, 1600 );
+      BOOST_CHECK_EQUAL( bitcny_id(db).dynamic_data(db).current_supply.get_amount().value, 1600 );
       BOOST_CHECK_EQUAL( bitcny_id(db).bitasset_data(db).force_settled_volume.value, 400 ); // 99 + 301
 
       // adding new feed so we have valid price to exit
@@ -1215,12 +1215,12 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       BOOST_CHECK_EQUAL(get_balance(ted_id(db), bitusd_id(db)), 58); // 37 + 20 + 1
 
       BOOST_CHECK( !db.find( call_bob_id ) );
-      BOOST_CHECK_EQUAL( 531, call_paul_id(db).debt.value ); // 614 - 41 - 21 - 21
-      BOOST_CHECK_EQUAL( 77, call_paul_id(db).collateral.value ); // 81 - 2 - 1 - 1
-      BOOST_CHECK_EQUAL( 46, call_michael_id(db).debt.value );
-      BOOST_CHECK_EQUAL( 231, call_michael_id(db).collateral.value );
+      BOOST_CHECK_EQUAL( 531, call_paul_id(db).debt.get_amount().value ); // 614 - 41 - 21 - 21
+      BOOST_CHECK_EQUAL( 77, call_paul_id(db).collateral.get_amount().value ); // 81 - 2 - 1 - 1
+      BOOST_CHECK_EQUAL( 46, call_michael_id(db).debt.get_amount().value );
+      BOOST_CHECK_EQUAL( 231, call_michael_id(db).collateral.get_amount().value );
 
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 577 ); // 679 - 19 - 41 - 21 - 21
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 577 ); // 679 - 19 - 41 - 21 - 21
       BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).force_settled_volume.value, 102 ); // reset to 0, then 19 + 41 + 21 + 21
 
       // check cny
@@ -1229,18 +1229,18 @@ BOOST_AUTO_TEST_CASE( settle_rounding_test_after_hf_184 )
       //      according to price 50 core / 101 cny, it will get 158 core and pay 320 cny;
       //   settle_id103 won't be processed since it's after settle_id102
       BOOST_CHECK( !db.find( settle_id101 ) );
-      BOOST_CHECK_EQUAL( settle_id102(db).balance.amount.value, 379 ); // 699 - 320
-      BOOST_CHECK_EQUAL( settle_id103(db).balance.amount.value, 300 ); // no change since it's after settle_id102
+      BOOST_CHECK_EQUAL( settle_id102(db).balance.get_amount().value, 379 ); // 699 - 320
+      BOOST_CHECK_EQUAL( settle_id103(db).balance.get_amount().value, 300 ); // no change since it's after settle_id102
 
       BOOST_CHECK_EQUAL(get_balance(jim_id(db), core_id(db)), 9998000);
       BOOST_CHECK_EQUAL(get_balance(jim_id(db), bitcny_id(db)), 500);
       BOOST_CHECK_EQUAL(get_balance(joe_id(db), core_id(db)), 356); // 198 + 158
       BOOST_CHECK_EQUAL(get_balance(joe_id(db), bitcny_id(db)), 101);
 
-      BOOST_CHECK_EQUAL( 1280, call_jim_id(db).debt.value ); // 1600 - 320
-      BOOST_CHECK_EQUAL( 1644, call_jim_id(db).collateral.value ); // 1802 - 158
+      BOOST_CHECK_EQUAL( 1280, call_jim_id(db).debt.get_amount().value ); // 1600 - 320
+      BOOST_CHECK_EQUAL( 1644, call_jim_id(db).collateral.get_amount().value ); // 1802 - 158
 
-      BOOST_CHECK_EQUAL( bitcny_id(db).dynamic_data(db).current_supply.value, 1280 );
+      BOOST_CHECK_EQUAL( bitcny_id(db).dynamic_data(db).current_supply.get_amount().value, 1280 );
       BOOST_CHECK_EQUAL( bitcny_id(db).bitasset_data(db).force_settled_volume.value, 320 ); // reset to 0, then 320
 
       generate_block();
@@ -1326,8 +1326,8 @@ BOOST_AUTO_TEST_CASE( global_settle_rounding_test )
 
       BOOST_CHECK( bitusd_id(db).bitasset_data(db).settlement_price
                    == price( bitusd_id(db).amount(1007), core_id(db).amount(100) ) );
-      BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).settlement_fund.value, 100 ); // 100 from paul, and 0 from michael
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 1007 );
+      BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).settlement_fund.get_amount().value, 100 ); // 100 from paul, and 0 from michael
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 1007 );
 
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), core_id(db)), 0);
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), bitusd_id(db)), 200);
@@ -1346,8 +1346,8 @@ BOOST_AUTO_TEST_CASE( global_settle_rounding_test )
 
       BOOST_CHECK( bitusd_id(db).bitasset_data(db).settlement_price
                    == price( bitusd_id(db).amount(1007), core_id(db).amount(100) ) );
-      BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).settlement_fund.value, 100 ); // paid nothing
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 1003 ); // settled 4 usd
+      BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).settlement_fund.get_amount().value, 100 ); // paid nothing
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 1003 ); // settled 4 usd
 
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), core_id(db)), 0);
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), bitusd_id(db)), 196); // rachel paid 4 usd and got nothing
@@ -1362,8 +1362,8 @@ BOOST_AUTO_TEST_CASE( global_settle_rounding_test )
 
       BOOST_CHECK( bitusd_id(db).bitasset_data(db).settlement_price
                    == price( bitusd_id(db).amount(1007), core_id(db).amount(100) ) );
-      BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).settlement_fund.value, 99 ); // paid 1 core
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 990 ); // settled 13 usd
+      BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).settlement_fund.get_amount().value, 99 ); // paid 1 core
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 990 ); // settled 13 usd
 
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), core_id(db)), 1);
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), bitusd_id(db)), 183); // rachel paid 13 usd and got 1 core
@@ -1449,8 +1449,8 @@ BOOST_AUTO_TEST_CASE( global_settle_rounding_test_after_hf_184 )
 
       BOOST_CHECK( bitusd_id(db).bitasset_data(db).settlement_price
                    == price( bitusd_id(db).amount(1007), core_id(db).amount(102) ) );
-      BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).settlement_fund.value, 102 ); // 101 from paul, and 1 from michael
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 1007 );
+      BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).settlement_fund.get_amount().value, 102 ); // 101 from paul, and 1 from michael
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 1007 );
 
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), core_id(db)), 0);
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), bitusd_id(db)), 200);
@@ -1471,8 +1471,8 @@ BOOST_AUTO_TEST_CASE( global_settle_rounding_test_after_hf_184 )
       // balances unchanged
       BOOST_CHECK( bitusd_id(db).bitasset_data(db).settlement_price
                    == price( bitusd_id(db).amount(1007), core_id(db).amount(102) ) );
-      BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).settlement_fund.value, 102 );
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 1007 );
+      BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).settlement_fund.get_amount().value, 102 );
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 1007 );
 
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), core_id(db)), 0);
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), bitusd_id(db)), 200);
@@ -1487,8 +1487,8 @@ BOOST_AUTO_TEST_CASE( global_settle_rounding_test_after_hf_184 )
 
       BOOST_CHECK( bitusd_id(db).bitasset_data(db).settlement_price
                    == price( bitusd_id(db).amount(1007), core_id(db).amount(102) ) );
-      BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).settlement_fund.value, 101 ); // paid 1 core
-      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.value, 997 ); // settled 10 usd
+      BOOST_CHECK_EQUAL( bitusd_id(db).bitasset_data(db).settlement_fund.get_amount().value, 101 ); // paid 1 core
+      BOOST_CHECK_EQUAL( bitusd_id(db).dynamic_data(db).current_supply.get_amount().value, 997 ); // settled 10 usd
 
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), core_id(db)), 1);
       BOOST_CHECK_EQUAL(get_balance(rachel_id(db), bitusd_id(db)), 190); // rachel paid 10 usd and got 1 core, 3 usd returned

--- a/tests/tests/swan_tests.cpp
+++ b/tests/tests/swan_tests.cpp
@@ -351,8 +351,8 @@ BOOST_AUTO_TEST_CASE( recollateralize )
       // can't bid wrong collateral type
       GRAPHENE_REQUIRE_THROW( bid_collateral( borrower2(), bitcny.amount(100), swan().amount(100) ), fc::exception );
 
-      BOOST_CHECK( swan().dynamic_data(db).current_supply == 1400 );
-      BOOST_CHECK( swan().bitasset_data(db).settlement_fund == 2800 );
+      BOOST_CHECK( swan().dynamic_data(db).current_supply.get_amount() == 1400 );
+      BOOST_CHECK( swan().bitasset_data(db).settlement_fund.get_amount() == 2800 );
       BOOST_CHECK( swan().bitasset_data(db).has_settlement() );
       BOOST_CHECK( swan().bitasset_data(db).current_feed.settlement_price.is_null() );
 
@@ -383,7 +383,7 @@ BOOST_AUTO_TEST_CASE( recollateralize )
       graphene::app::database_api db_api( db, &( app.get_options() ));
       GRAPHENE_REQUIRE_THROW( db_api.get_collateral_bids(back().symbol, 100, 0), fc::assert_exception );
       auto swan_symbol = _swan(db).symbol;
-      vector<collateral_bid_object> bids = db_api.get_collateral_bids(swan_symbol, 100, 1);
+      vector<graphene::app::collateral_bid_api_object> bids = db_api.get_collateral_bids(swan_symbol, 100, 1);
       BOOST_CHECK_EQUAL( 1u, bids.size() );
       FC_ASSERT( _borrower2 == bids[0].bidder );
       bids = db_api.get_collateral_bids(swan_symbol, 1, 0);
@@ -421,8 +421,8 @@ BOOST_AUTO_TEST_CASE( revive_empty_recovered )
       cancel_limit_order( oid(db) );
       force_settle( borrower(), swan().amount(1000) );
       force_settle( borrower2(), swan().amount(1000) );
-      BOOST_CHECK_EQUAL( 0, swan().dynamic_data(db).current_supply.value );
-      BOOST_CHECK_EQUAL( 0, swan().bitasset_data(db).settlement_fund.value );
+      BOOST_CHECK_EQUAL( 0, swan().dynamic_data(db).current_supply.get_amount().value );
+      BOOST_CHECK_EQUAL( 0, swan().bitasset_data(db).settlement_fund.get_amount().value );
       BOOST_CHECK( swan().bitasset_data(db).has_settlement() );
 
       // revive after price recovers
@@ -452,7 +452,7 @@ BOOST_AUTO_TEST_CASE( revive_empty )
       cancel_limit_order( oid(db) );
       force_settle( borrower(), swan().amount(1000) );
       force_settle( borrower2(), swan().amount(1000) );
-      BOOST_CHECK_EQUAL( 0, swan().dynamic_data(db).current_supply.value );
+      BOOST_CHECK_EQUAL( 0, swan().dynamic_data(db).current_supply.get_amount().value );
 
       BOOST_CHECK( swan().bitasset_data(db).has_settlement() );
 
@@ -491,8 +491,8 @@ BOOST_AUTO_TEST_CASE( revive_empty_with_bid )
       force_settle( borrower(), swan().amount(500) );
       force_settle( borrower2(), swan().amount(667) );
       force_settle( borrower2(), swan().amount(333) );
-      BOOST_CHECK_EQUAL( 0, swan().dynamic_data(db).current_supply.value );
-      BOOST_CHECK_EQUAL( 0, swan().bitasset_data(db).settlement_fund.value );
+      BOOST_CHECK_EQUAL( 0, swan().dynamic_data(db).current_supply.get_amount().value );
+      BOOST_CHECK_EQUAL( 0, swan().bitasset_data(db).settlement_fund.get_amount().value );
 
       bid_collateral( borrower(), back().amount(3000), swan().amount(700) );
 
@@ -503,7 +503,7 @@ BOOST_AUTO_TEST_CASE( revive_empty_with_bid )
       BOOST_CHECK( !swan().bitasset_data(db).has_settlement() );
       graphene::app::database_api db_api( db, &( app.get_options() ));
       auto swan_symbol = _swan(db).symbol;
-      vector<collateral_bid_object> bids = db_api.get_collateral_bids(swan_symbol, 100, 0);
+      vector<graphene::app::collateral_bid_api_object> bids = db_api.get_collateral_bids(swan_symbol, 100, 0);
       BOOST_CHECK( bids.empty() );
 
       auto& call_idx = db.get_index_type<call_order_index>().indices().get<by_account>();
@@ -577,10 +577,10 @@ BOOST_AUTO_TEST_CASE( overflow )
    auto& call_idx = db.get_index_type<call_order_index>().indices().get<by_account>();
    auto itr = call_idx.find( boost::make_tuple(_borrower, _swan) );
    BOOST_REQUIRE( itr != call_idx.end() );
-   BOOST_CHECK_EQUAL( 1, itr->debt.value );
+   BOOST_CHECK_EQUAL( 1, itr->debt.get_amount().value );
    itr = call_idx.find( boost::make_tuple(_borrower2, _swan) );
    BOOST_REQUIRE( itr != call_idx.end() );
-   BOOST_CHECK_EQUAL( 1399, itr->debt.value );
+   BOOST_CHECK_EQUAL( 1399, itr->debt.get_amount().value );
 
    BOOST_CHECK( !swan().bitasset_data(db).has_settlement() );
 } FC_LOG_AND_RETHROW() }

--- a/tests/tests/uia_tests.cpp
+++ b/tests/tests/uia_tests.cpp
@@ -71,9 +71,9 @@ BOOST_AUTO_TEST_CASE( create_advanced_uia )
       BOOST_CHECK(test_asset.options.market_fee_percent == GRAPHENE_MAX_MARKET_FEE_PERCENT/100);
 
       const asset_dynamic_data_object& test_asset_dynamic_data = test_asset.dynamic_asset_data_id(db);
-      BOOST_CHECK(test_asset_dynamic_data.current_supply == 0);
-      BOOST_CHECK(test_asset_dynamic_data.accumulated_fees == 0);
-      BOOST_CHECK(test_asset_dynamic_data.fee_pool == 0);
+      BOOST_CHECK(test_asset_dynamic_data.current_supply.get_amount() == 0);
+      BOOST_CHECK(test_asset_dynamic_data.accumulated_fees.get_amount() == 0);
+      BOOST_CHECK(test_asset_dynamic_data.fee_pool.get_amount() == 0);
 
    } catch(fc::exception& e) {
       edump((e.to_detail_string()));

--- a/tests/tests/voting_tests.cpp
+++ b/tests/tests/voting_tests.cpp
@@ -464,7 +464,7 @@ BOOST_AUTO_TEST_CASE(last_voting_date)
       // we are going to vote for this witness
       auto witness1 = witness_id_type(1)(db);
 
-      auto stats_obj = db.get_account_stats_by_owner(alice_id);
+      const auto& stats_obj = db.get_account_stats_by_owner(alice_id);
       BOOST_CHECK_EQUAL(stats_obj.last_vote_time.sec_since_epoch(), 0u);
 
       // alice votes
@@ -479,7 +479,6 @@ BOOST_AUTO_TEST_CASE(last_voting_date)
       auto now = db.head_block_time().sec_since_epoch();
 
       // last_vote_time is updated for alice
-      stats_obj = db.get_account_stats_by_owner(alice_id);
       BOOST_CHECK_EQUAL(stats_obj.last_vote_time.sec_since_epoch(), now);
 
    } FC_LOG_AND_RETHROW()
@@ -510,7 +509,7 @@ BOOST_AUTO_TEST_CASE(last_voting_date_proxy)
          PUSH_TX( db, trx, ~0 );
       }
       // alice last_vote_time is updated
-      auto alice_stats_obj = db.get_account_stats_by_owner(alice_id);
+      const auto& alice_stats_obj = db.get_account_stats_by_owner(alice_id);
       auto round1 = db.head_block_time().sec_since_epoch();
       BOOST_CHECK_EQUAL(alice_stats_obj.last_vote_time.sec_since_epoch(), round1);
 
@@ -527,7 +526,6 @@ BOOST_AUTO_TEST_CASE(last_voting_date_proxy)
          PUSH_TX( db, trx, ~0 );
       }
       // last_vote_time is not updated
-      alice_stats_obj = db.get_account_stats_by_owner(alice_id);
       BOOST_CHECK_EQUAL(alice_stats_obj.last_vote_time.sec_since_epoch(), round1);
 
       generate_block();
@@ -546,7 +544,7 @@ BOOST_AUTO_TEST_CASE(last_voting_date_proxy)
 
       // last_vote_time for bob is updated as he voted
       auto round3 = db.head_block_time().sec_since_epoch();
-      auto bob_stats_obj = db.get_account_stats_by_owner(bob_id);
+      const auto& bob_stats_obj = db.get_account_stats_by_owner(bob_id);
       BOOST_CHECK_EQUAL(bob_stats_obj.last_vote_time.sec_since_epoch(), round3);
 
       generate_block();
@@ -564,15 +562,13 @@ BOOST_AUTO_TEST_CASE(last_voting_date_proxy)
 
       // proxy just voted so the last_vote_time is updated
       auto round4 = db.head_block_time().sec_since_epoch();
-      auto proxy_stats_obj = db.get_account_stats_by_owner(proxy_id);
+      const auto& proxy_stats_obj = db.get_account_stats_by_owner(proxy_id);
       BOOST_CHECK_EQUAL(proxy_stats_obj.last_vote_time.sec_since_epoch(), round4);
 
       // alice haves proxy, proxy votes but last_vote_time is not updated for alice
-      alice_stats_obj = db.get_account_stats_by_owner(alice_id);
       BOOST_CHECK_EQUAL(alice_stats_obj.last_vote_time.sec_since_epoch(), round1);
 
       // bob haves nothing to do with proxy so last_vote_time is not updated
-      bob_stats_obj = db.get_account_stats_by_owner(bob_id);
       BOOST_CHECK_EQUAL(bob_stats_obj.last_vote_time.sec_since_epoch(), round3);
 
    } FC_LOG_AND_RETHROW()


### PR DESCRIPTION
This PR implements an idea originally mentioned by @nathanhourt . His observation was that we use the `asset` type for two fundamentally different concepts, which is inherently dangerous.

A real-world analogy for the asset type could be, for example, a slip of paper reading "$ 1.00". The two fundamentally different concepts that match this type are, for example, a price tag in a supermarket on the one hand, and a bank note on the other. The important difference is that the bank note carries value, whereas the price tag only carries information. A consequence of this is, for example, that it is not possible to copy a bank note (or at least strictly forbidden), whereas it is perfectly ok to copy the price tag.

So, in order to model an equivalent for the "bank note" concept, this PR creates a new type `stored_value`. It employs RAII concepts, in the sense that it can only be moved around, not copied.

On top of that, this PR implements a simple bookkeeping concept: account balances cannot be created from nothing, nor can they be destroyed into nothing. Every creation or destruction of a balance must have a counterpart in another account. For this, a `stored_debt` type is introduced. Every token balance is issued by a `stored_debt`, and only a `stored_debt` can destroy (aka burn) balances. Instances of `stored_debt` and `stored_value` can only be destructed successfully if their contained amount is zero. This should ensure that no tokens are lost, and none can be created from nothing, as happened e. g. in #604.

Unfortunately, the beauty of the general concept is somewhat undermined by the way in which our database transaction system works. I. e. `undo_db` copies objects, and restores them upon rollback, by copying back the original value. Similarly, things are complicated by API calls returning copies of internal database objects.

This PR effects some API changes, i. e. the structure of certain database objects has changed slightly.