### PR TITLE
BSIP 40: Tests of special custom authorities

### DIFF
--- a/tests/tests/custom_authority_tests.cpp
+++ b/tests/tests/custom_authority_tests.cpp
@@ -1315,7 +1315,7 @@ BOOST_AUTO_TEST_CASE(custom_auths) { try {
          //////
 
          // Lambda for issuing an asset to an account
-         auto issue_amount_to = [&](const account_id_type &issuer, const asset &amount, const account_id_type &to) {
+         auto issue_amount_to = [](const account_id_type &issuer, const asset &amount, const account_id_type &to) {
             asset_issue_operation op;
             op.issuer = issuer;
             op.asset_to_issue = amount;


### PR DESCRIPTION
Tests to confirm new custom authority templates [for restricted trading](https://github.com/bitshares/bitshares-core/wiki/Custom-Authority-Templates#template-authorized-restricted-trading), [for voting](https://github.com/bitshares/bitshares-core/wiki/Custom-Authority-Templates#template-authorized-voting-by-a-key), and [for changing a witness signing key](https://github.com/bitshares/bitshares-core/wiki/Custom-Authority-Templates#template-authorized-changing-of-a-witness-signing-key-by-a-key)