### PR TITLE
DoxyDocs could not be found without this

### DIFF
--- a/libraries/wallet/generate_api_documentation.pl
+++ b/libraries/wallet/generate_api_documentation.pl
@@ -3,7 +3,7 @@
 use Text::Wrap;
 use IO::File;
 
-require 'doxygen/perlmod/DoxyDocs.pm';
+require './doxygen/perlmod/DoxyDocs.pm';
 
 my($outputFileName) = @ARGV;
 die "usage: $0 output_file_name" unless $outputFileName;


### PR DESCRIPTION
Could not build the develop branch without the missing `./` don't know, maybe this is only for me because I am doing something wrong. 

Got this message: Can't locate doxygen/perlmod/DoxyDocs.pm in @INC (you may need to install the doxygen::perlmod::DoxyDocs module) (@INC contains: /home/dimfred/perl5/lib/perl5 /home/dimfred/perl5/lib/perl5 /home/dimfred/perl5/lib/perl5 /home/dimfred/perl5/lib/perl5 /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.26.1 /usr/local/share/perl/5.26.1 /usr/lib/x86_64-linux-gnu/perl5/5.26 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.26 /usr/share/perl/5.26 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at /home/dimfred/00_workspaces/bitshares-core/libraries/wallet/generate_api_documentation.pl line 6.

Build on Ubuntu 18.04
