### PR TITLE
Set default docker cfg max-ops-per-account to 100

### DIFF
--- a/docker/default_config.ini
+++ b/docker/default_config.ini
@@ -164,7 +164,7 @@ enable-stale-production = false
 partial-operations = true
 
 # Maximum number of operations per account will be kept in memory
-max-ops-per-account = 1000
+max-ops-per-account = 100
 
 
 # ==============================================================================


### PR DESCRIPTION
A Docker node with the current `max-ops-per-account` value as `1000` will use more than 20G RAM. Update it to `100` which is the default value for non-Docker nodes.