### PR TITLE
Enable cache for SonarQube Scanner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: c++
 
-cache: ccache
+cache:
+  ccache: true
+  directories:
+  - sonar_cache
 
 git:
   depth: 1

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,6 +12,8 @@ sonar.sources=libraries,programs
 sonar.cfamily.build-wrapper-output=bw-output
 sonar.cfamily.gcov.reportsPath=.
 sonar.cfamily.threads=2
+sonar.cfamily.cache.enabled=true
+sonar.cfamily.cache.path=sonar_cache
 
 # should be changed in hardfork branch and removed in release branches
 sonar.branch.target=develop


### PR DESCRIPTION
The cache would speed up Travis CI greatly.

I'd like to make it into `master` branch asap to speed up even the first build of new branches and pull requests, since [Travis docs](https://docs.travis-ci.com/user/caching/) say "If a branch does not have its own cache, Travis CI fetches the cache of the repository’s default branch".