### PR TITLE
Merge release332 branch to release branch for SonarQube cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: c++
 
-cache: ccache
+cache:
+  ccache: true
+  directories:
+  - sonar_cache
 
 git:
   depth: 1

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ BitShares Core
 * [License](#license)
 
 BitShares Core is the BitShares blockchain implementation and command-line interface.
-The web wallet is [BitShares UI](https://github.com/bitshares/bitshares-ui).
+The web browser based wallet is [BitShares UI](https://github.com/bitshares/bitshares-ui).
 
 Visit [BitShares.org](https://bitshares.org/) to learn about BitShares and join the community at [BitSharesTalk.org](https://bitsharestalk.org/).
 
@@ -31,7 +31,7 @@ Build instructions and additional documentation are available in the
 
 We recommend building on Ubuntu 16.04 LTS (64-bit) 
 
-**Build Dependencies**:
+**Build Dependencies:**
 
     sudo apt-get update
     sudo apt-get install autoconf cmake make automake libtool git libboost-all-dev libssl-dev g++ libcurl4-openssl-dev
@@ -45,7 +45,7 @@ We recommend building on Ubuntu 16.04 LTS (64-bit)
     cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo .
     make
 
-**Upgrade Script** (prepend to the Build Script above if you built a prior release):
+**Upgrade Script:** (prepend to the Build Script above if you built a prior release):
 
     git remote set-url origin https://github.com/bitshares/bitshares-core.git
     git checkout master
@@ -94,6 +94,13 @@ Set your inital password:
 
     >>> set_password <PASSWORD>
     >>> unlock <PASSWORD>
+
+**IMPORTANT:** The cli_wallet or API interfaces to the witness node wouldn't be fully functional unless the witness node is fully synchronized with the blockchain. The cli_wallet command `info` will show result `head_block_age` which will tell you how far you are from the live current block of the blockchain.
+
+
+To check your current block:
+
+    >>> info
 
 To import your initial balance:
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,6 +12,8 @@ sonar.sources=libraries,programs
 sonar.cfamily.build-wrapper-output=bw-output
 sonar.cfamily.gcov.reportsPath=.
 sonar.cfamily.threads=2
+sonar.cfamily.cache.enabled=true
+sonar.cfamily.cache.path=sonar_cache
 
 # should be changed in hardfork branch and removed in release branches
 sonar.branch.target=develop


### PR DESCRIPTION
See #2096.

The Travis build status and link for `continuous-integration/travis-ci/pr` showing in the PR is sometimes incorrect. The correct link for this PR is https://travis-ci.org/bitshares/bitshares-core/builds/647351439. It didn't pass. Retry after merged #2097.