### PR TITLE
Fix supply issue

### DIFF
--- a/libraries/chain/hardfork.d/CORE_2103.hf
+++ b/libraries/chain/hardfork.d/CORE_2103.hf
@@ -1,0 +1,5 @@
+// bitshares-core issue #2103 250M BTS supply
+#ifndef HARDFORK_CORE_2103_TIME
+#define HARDFORK_CORE_2103_TIME (fc::time_point_sec( 1600000000 ) ) // Sep 2020
+#define HARDFORK_CORE_2103_BALANCE_ID 56720 // 1.15.56720
+#endif

--- a/programs/build_helpers/cat-parts.cmake
+++ b/programs/build_helpers/cat-parts.cmake
@@ -10,7 +10,7 @@ file( MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include/graphene/chain/" )
 
 set( HARDFORK_REGENERATE TRUE )
 
-file( GLOB HARDFORKS "${CMAKE_CURRENT_SOURCE_DIR}/hardfork.d/*" )
+file( GLOB HARDFORKS "${CMAKE_CURRENT_SOURCE_DIR}/hardfork.d/*.hf" )
 foreach( HF ${HARDFORKS} )
   file( READ "${HF}" INCL )
   string( CONCAT HARDFORK_CONTENT ${HARDFORK_CONTENT} ${INCL} )


### PR DESCRIPTION
PR for #2103.

The `cat-parts` change is to avoid building issues when there is a temporary file in the directory (E.G. when a file is opened with `vim`).