### PR TITLE
Fix Github auto-build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -69,7 +69,7 @@ jobs:
         _build/tests/app_test
         libraries/fc/tests/run-parallel-tests.sh _build/tests/chain_test
         libraries/fc/tests/run-parallel-tests.sh _build/tests/cli_test
-        libraries/fc/tests/run-parallel-tests.sh _build/tests/es_test
+        _build/tests/es_test
     - name: Node-Test
       run: |
         pushd _build
@@ -133,7 +133,7 @@ jobs:
         _build/tests/app_test
         libraries/fc/tests/run-parallel-tests.sh _build/tests/chain_test
         libraries/fc/tests/run-parallel-tests.sh _build/tests/cli_test
-        libraries/fc/tests/run-parallel-tests.sh _build/tests/es_test
+        _build/tests/es_test
     - name: Node-Test
       run: |
         pushd _build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,6 +42,7 @@ jobs:
       run: |
         mkdir -p _build
         pushd _build
+        export -n BOOST_ROOT BOOST_INCLUDEDIR BOOST_LIBRARYDIR
         cmake -D CMAKE_BUILD_TYPE=Release \
               -D CMAKE_CXX_OUTPUT_EXTENSION_REPLACE=ON \
               -D CMAKE_C_COMPILER=gcc \
@@ -105,6 +106,7 @@ jobs:
       run: |
         mkdir -p _build
         pushd _build
+        export -n BOOST_ROOT BOOST_INCLUDEDIR BOOST_LIBRARYDIR
         cmake -D CMAKE_BUILD_TYPE=Debug \
               -D CMAKE_CXX_OUTPUT_EXTENSION_REPLACE=ON \
               -D CMAKE_C_COMPILER=gcc \


### PR DESCRIPTION
Remove the predefined boost related environment variables.

Follow-up work of #2062 for issue #2054.

See also: #2110.

Errors (also mentioned in #2062):
- [x] The `es_tests` still seem to be not completely deterministic, see https://github.com/bitshares/bitshares-core/pull/2112#issuecomment-590616614.
- [ ] The failing "Node Test" in native mac and Ubuntu build is due to #2033 not yet being in `develop`.