### PR TITLE
Remove seeds.bitshares.eu from seed list

### DIFF
--- a/libraries/egenesis/seed-nodes.txt
+++ b/libraries/egenesis/seed-nodes.txt
@@ -6,4 +6,3 @@
 "node.blckchnd.com:4243",            // blckchnd     (Germany)
 "seed.roelandp.nl:1776",             // roelandp     (Canada)
 "seed.bts.bangzi.info:55501",        // Bangzi       (Germany)
-"seeds.bitshares.eu:1776",           // pc


### PR DESCRIPTION
The `seeds.bitshares.eu` domain name doesn't resolve. It seems the service has been taken down. Confirmed with the domain owner that we should remove it.