### PR TITLE
Update workers API

### DIFF
--- a/libraries/app/database_api_impl.hxx
+++ b/libraries/app/database_api_impl.hxx
@@ -150,8 +150,8 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       uint64_t get_committee_count()const;
 
       // Workers
-      vector<worker_object> get_all_workers()const;
-      vector<optional<worker_object>> get_workers_by_account(const std::string account_id_or_name)const;
+      vector<worker_object> get_all_workers( const optional<bool> is_expired = optional<bool>() )const;
+      vector<worker_object> get_workers_by_account(const std::string account_id_or_name)const;
       uint64_t get_worker_count()const;
 
       // Votes

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -674,18 +674,19 @@ class database_api
       ///////////////////////
 
       /**
-       * @brief Get all workers
-       * @return All the workers
+       * @brief Get workers
+       * @param is_expired null for all workers, true for expired workers only, false for non-expired workers only
+       * @return A list of worker objects
        *
       */
-      vector<worker_object> get_all_workers()const;
+      vector<worker_object> get_all_workers( const optional<bool> is_expired = optional<bool>() )const;
 
       /**
        * @brief Get the workers owned by a given account
        * @param account_name_or_id The name or ID of the account whose worker should be retrieved
        * @return A list of worker objects owned by the account
        */
-      vector<optional<worker_object>> get_workers_by_account(const std::string account_name_or_id)const;
+      vector<worker_object> get_workers_by_account(const std::string account_name_or_id)const;
 
       /**
        * @brief Get the total number of workers registered with the blockchain

--- a/libraries/chain/include/graphene/chain/worker_object.hpp
+++ b/libraries/chain/include/graphene/chain/worker_object.hpp
@@ -145,13 +145,15 @@ class worker_object : public abstract_object<worker_object>
 struct by_account;
 struct by_vote_for;
 struct by_vote_against;
+struct by_end_date;
 typedef multi_index_container<
    worker_object,
    indexed_by<
       ordered_unique< tag<by_id>, member< object, object_id_type, &object::id > >,
       ordered_non_unique< tag<by_account>, member< worker_object, account_id_type, &worker_object::worker_account > >,
       ordered_unique< tag<by_vote_for>, member< worker_object, vote_id_type, &worker_object::vote_for > >,
-   ordered_unique< tag<by_vote_against>, member< worker_object, vote_id_type, &worker_object::vote_against > >
+      ordered_unique< tag<by_vote_against>, member< worker_object, vote_id_type, &worker_object::vote_against > >,
+      ordered_non_unique< tag<by_end_date>, member< worker_object, time_point_sec, &worker_object::work_end_date> >
    >
 > worker_object_multi_index_type;
 

--- a/tests/tests/database_api_tests.cpp
+++ b/tests/tests/database_api_tests.cpp
@@ -1170,6 +1170,42 @@ BOOST_AUTO_TEST_CASE( get_all_workers )
 
 } FC_LOG_AND_RETHROW() }
 
+BOOST_AUTO_TEST_CASE( get_workers_by_account )
+{ try {
+   graphene::app::database_api db_api( db, &( app.get_options() ));
+   ACTORS( (connie)(whitney)(wolverine) );
+
+   fund(connie);
+   upgrade_to_lifetime_member(connie);
+   fund(whitney);
+   upgrade_to_lifetime_member(whitney);
+   fund(wolverine);
+   upgrade_to_lifetime_member(wolverine);
+
+   vector<worker_object> results;
+
+   const auto& worker1 = create_worker( connie_id );
+   worker_id_type worker1_id = worker1.id;
+
+   const auto& worker2 = create_worker( whitney_id, 1000, fc::days(50) );
+   worker_id_type worker2_id = worker2.id;
+
+   const auto& worker3 = create_worker( whitney_id, 1000, fc::days(100) );
+   worker_id_type worker3_id = worker3.id;
+
+   BOOST_REQUIRE_EQUAL( db_api.get_workers_by_account("connie").size(), 1 );
+   BOOST_CHECK( db_api.get_workers_by_account("connie").front().id == worker1_id );
+
+   BOOST_REQUIRE_EQUAL( db_api.get_workers_by_account(string(whitney.id)).size(), 2 );
+   BOOST_CHECK( db_api.get_workers_by_account(string(whitney.id)).front().id == worker2_id );
+   BOOST_CHECK( db_api.get_workers_by_account(string(whitney.id)).back().id == worker3_id );
+
+   BOOST_REQUIRE_EQUAL( db_api.get_workers_by_account("wolverine").size(), 0 );
+
+   BOOST_REQUIRE_THROW( db_api.get_workers_by_account("not-a-user"), fc::exception );
+
+} FC_LOG_AND_RETHROW() }
+
 BOOST_AUTO_TEST_CASE( lookup_vote_ids )
 { try {
    graphene::app::database_api db_api( db, &( app.get_options() ));


### PR DESCRIPTION
PR for #2121 

- get_all_workers: add an optional `is_expired` parameter
- get_workers_by_account: remove `optional` from the return type, improve performance