### PR TITLE
Add market history plugin asserts

### DIFF
--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -310,6 +310,8 @@ namespace graphene { namespace app {
 
     vector<order_history_object> history_api::get_fill_order_history( std::string asset_a, std::string asset_b, uint32_t limit  )const
     {
+       auto hist = _app.get_plugin<market_history_plugin>( "market_history" );
+       FC_ASSERT( hist );
        FC_ASSERT(_app.chain_database());
        const auto& db = *_app.chain_database();
        asset_id_type a = database_api.get_asset_id_from_string( asset_a );
@@ -488,7 +490,11 @@ namespace graphene { namespace app {
     vector<bucket_object> history_api::get_market_history( std::string asset_a, std::string asset_b,
                                                            uint32_t bucket_seconds, fc::time_point_sec start, fc::time_point_sec end )const
     { try {
+
+       auto hist = _app.get_plugin<market_history_plugin>( "market_history" );
+       FC_ASSERT( hist );
        FC_ASSERT(_app.chain_database());
+
        const auto& db = *_app.chain_database();
        asset_id_type a = database_api.get_asset_id_from_string( asset_a );
        asset_id_type b = database_api.get_asset_id_from_string( asset_b );

--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -308,10 +308,11 @@ namespace graphene { namespace app {
        return *_custom_operations_api;
     }
 
-    vector<order_history_object> history_api::get_fill_order_history( std::string asset_a, std::string asset_b, uint32_t limit  )const
+    vector<order_history_object> history_api::get_fill_order_history( std::string asset_a, std::string asset_b,
+                                                                      uint32_t limit )const
     {
-       auto hist = _app.get_plugin<market_history_plugin>( "market_history" );
-       FC_ASSERT( hist );
+       auto market_hist_plugin = _app.get_plugin<market_history_plugin>( "market_history" );
+       FC_ASSERT( market_hist_plugin, "Market history plugin is not enabled" );
        FC_ASSERT(_app.chain_database());
        const auto& db = *_app.chain_database();
        asset_id_type a = database_api.get_asset_id_from_string( asset_a );
@@ -466,9 +467,9 @@ namespace graphene { namespace app {
 
     flat_set<uint32_t> history_api::get_market_history_buckets()const
     {
-       auto hist = _app.get_plugin<market_history_plugin>( "market_history" );
-       FC_ASSERT( hist );
-       return hist->tracked_buckets();
+       auto market_hist_plugin = _app.get_plugin<market_history_plugin>( "market_history" );
+       FC_ASSERT( market_hist_plugin, "Market history plugin is not enabled" );
+       return market_hist_plugin->tracked_buckets();
     }
 
     history_operation_detail history_api::get_account_history_by_operations(const std::string account_id_or_name, vector<uint16_t> operation_types, uint32_t start, unsigned limit)
@@ -488,11 +489,12 @@ namespace graphene { namespace app {
     }
 
     vector<bucket_object> history_api::get_market_history( std::string asset_a, std::string asset_b,
-                                                           uint32_t bucket_seconds, fc::time_point_sec start, fc::time_point_sec end )const
+                                                           uint32_t bucket_seconds,
+                                                           fc::time_point_sec start, fc::time_point_sec end )const
     { try {
 
-       auto hist = _app.get_plugin<market_history_plugin>( "market_history" );
-       FC_ASSERT( hist );
+       auto market_hist_plugin = _app.get_plugin<market_history_plugin>( "market_history" );
+       FC_ASSERT( market_hist_plugin, "Market history plugin is not enabled" );
        FC_ASSERT(_app.chain_database());
 
        const auto& db = *_app.chain_database();


### PR DESCRIPTION
Fix for issue https://github.com/bitshares/bitshares-core/issues/2021

I was expecting that calls like `get_account_history` and related will need `account_history_plugin` however it seems this is not the case as when i added asserts i got failures in the `history_api_tests`.

So i left those alone and just added asserts to the ones related to `market_history_plugin` where missing. This are are the same calls mentioned in the issue: `get_fill_order_history` and `get_market_history`.