### PR TITLE
return lowest_ask and highest_bid order volume

### DIFF
--- a/libraries/app/api_objects.cpp
+++ b/libraries/app/api_objects.cpp
@@ -38,8 +38,11 @@ market_ticker::market_ticker(const market_ticker_object& mto,
    quote = asset_quote.symbol;
    percent_change = "0";
    lowest_ask = "0";
+   lowest_ask_base_size = "0";
+   lowest_ask_quote_size = "0";
    highest_bid = "0";
-
+   highest_bid_base_size = "0";
+   highest_bid_quote_size = "0";
    fc::uint128_t bv;
    fc::uint128_t qv;
    price latest_price = asset( mto.latest_base, mto.base ) / asset( mto.latest_quote, mto.quote );
@@ -69,8 +72,12 @@ market_ticker::market_ticker(const market_ticker_object& mto,
 
    if(!orders.asks.empty())
       lowest_ask = orders.asks[0].price;
+      lowest_ask_base_size =orders.asks[0].base;
+      lowest_ask_quote_size =orders.asks[0].quote;
    if(!orders.bids.empty())
       highest_bid = orders.bids[0].price;
+      highest_bid_base_size =orders.bids[0].base;
+      highest_bid_quote_size =orders.bids[0].quote;
 }
 
 market_ticker::market_ticker(const fc::time_point_sec& now,
@@ -82,7 +89,11 @@ market_ticker::market_ticker(const fc::time_point_sec& now,
    quote = asset_quote.symbol;
    latest = "0";
    lowest_ask = "0";
+   lowest_ask_base_size = "0";
+   lowest_ask_quote_size = "0";
    highest_bid = "0";
+   highest_bid_base_size = "0";
+   highest_bid_quote_size = "0";
    percent_change = "0";
    base_volume = "0";
    quote_volume = "0";

--- a/libraries/app/api_objects.cpp
+++ b/libraries/app/api_objects.cpp
@@ -71,13 +71,19 @@ market_ticker::market_ticker(const market_ticker_object& mto,
    quote_volume = uint128_amount_to_string( qv, asset_quote.precision );
 
    if(!orders.asks.empty())
-      lowest_ask = orders.asks[0].price;
-      lowest_ask_base_size =orders.asks[0].base;
-      lowest_ask_quote_size =orders.asks[0].quote;
+   {
+       lowest_ask = orders.asks[0].price;
+       lowest_ask_base_size = orders.asks[0].base;
+       lowest_ask_quote_size = orders.asks[0].quote;
+   }
+
    if(!orders.bids.empty())
-      highest_bid = orders.bids[0].price;
-      highest_bid_base_size =orders.bids[0].base;
-      highest_bid_quote_size =orders.bids[0].quote;
+   {
+       highest_bid = orders.bids[0].price;
+       highest_bid_base_size = orders.bids[0].base;
+       highest_bid_quote_size = orders.bids[0].quote;
+   }
+
 }
 
 market_ticker::market_ticker(const fc::time_point_sec& now,

--- a/libraries/app/include/graphene/app/api_objects.hpp
+++ b/libraries/app/include/graphene/app/api_objects.hpp
@@ -100,7 +100,11 @@ namespace graphene { namespace app {
       string                     quote;
       string                     latest;
       string                     lowest_ask;
+      string                     lowest_ask_base_size;
+      string                     lowest_ask_quote_size;
       string                     highest_bid;
+      string                     highest_bid_base_size;
+      string                     highest_bid_quote_size;
       string                     percent_change;
       string                     base_volume;
       string                     quote_volume;
@@ -178,7 +182,7 @@ FC_REFLECT( graphene::app::full_account,
 FC_REFLECT( graphene::app::order, (price)(quote)(base) );
 FC_REFLECT( graphene::app::order_book, (base)(quote)(bids)(asks) );
 FC_REFLECT( graphene::app::market_ticker,
-            (time)(base)(quote)(latest)(lowest_ask)(highest_bid)(percent_change)(base_volume)(quote_volume) );
+            (time)(base)(quote)(latest)(lowest_ask)(lowest_ask_base_size)(lowest_ask_quote_size)(highest_bid)(highest_bid_base_size)(highest_bid_quote_size)(percent_change)(base_volume)(quote_volume) );
 FC_REFLECT( graphene::app::market_volume, (time)(base)(quote)(base_volume)(quote_volume) );
 FC_REFLECT( graphene::app::market_trade, (sequence)(date)(price)(amount)(value)(side1_account_id)(side2_account_id) );
 

--- a/libraries/app/include/graphene/app/api_objects.hpp
+++ b/libraries/app/include/graphene/app/api_objects.hpp
@@ -182,7 +182,8 @@ FC_REFLECT( graphene::app::full_account,
 FC_REFLECT( graphene::app::order, (price)(quote)(base) );
 FC_REFLECT( graphene::app::order_book, (base)(quote)(bids)(asks) );
 FC_REFLECT( graphene::app::market_ticker,
-            (time)(base)(quote)(latest)(lowest_ask)(lowest_ask_base_size)(lowest_ask_quote_size)(highest_bid)(highest_bid_base_size)(highest_bid_quote_size)(percent_change)(base_volume)(quote_volume) );
+            (time)(base)(quote)(latest)(lowest_ask)(lowest_ask_base_size)(lowest_ask_quote_size)
+            (highest_bid)(highest_bid_base_size)(highest_bid_quote_size)(percent_change)(base_volume)(quote_volume) );
 FC_REFLECT( graphene::app::market_volume, (time)(base)(quote)(base_volume)(quote_volume) );
 FC_REFLECT( graphene::app::market_trade, (sequence)(date)(price)(amount)(value)(side1_account_id)(side2_account_id) );
 


### PR DESCRIPTION
this PR related to discussion of #2001 to return more useful data in ticker.

before change

```
{
    "id":3,
    "result":{
        "time":"2020-04-28T15:22:24",
        "base":"CNY",
        "quote":"BTS",
        "latest":"0.224489795918367346",
        "lowest_ask":"0.224634524247316643",
        "highest_bid":"0.224529552603249653",
        "percent_change":"-0.01",
        "base_volume":"386624.9459",
        "quote_volume":"1722080.6122"
    }
}
```

after change
```
{
    "id":3,
    "result":{
        "time":"2020-04-28T15:22:24",
        "base":"CNY",
        "quote":"BTS",
        "latest":"0.224489795918367346",
        "lowest_ask":"0.224634524247316643",
        "lowest_ask_base_size":"304.8588",
        "lowest_ask_quote_size":"1357.13244",
        "highest_bid":"0.224529552603249653",
        "highest_bid_base_size":"2288.6050",
        "highest_bid_quote_size":"10192.88986",
        "percent_change":"-0.01",
        "base_volume":"386624.9459",
        "quote_volume":"1722080.6122"
    }
}
```