### PR TITLE
P2P improvement: periodically re-check addresses of seed nodes

### DIFF
--- a/libraries/app/application_impl.hxx
+++ b/libraries/app/application_impl.hxx
@@ -22,8 +22,6 @@ class application_impl : public net::node_delegate
 
       void reset_p2p_node(const fc::path& data_dir);
 
-      std::vector<fc::ip::endpoint> resolve_string_to_ip_endpoints(const std::string& endpoint_string);
-
       void new_connection( const fc::http::websocket_connection_ptr& c );
 
       void reset_websocket_server();

--- a/libraries/net/include/graphene/net/node.hpp
+++ b/libraries/net/include/graphene/net/node.hpp
@@ -211,10 +211,33 @@ namespace graphene { namespace net {
          */
         void      add_node( const fc::ip::endpoint& ep );
 
+        /*****
+         * @brief add a list of nodes to seed the p2p network
+         * @param seeds a vector of url strings
+         */
+        void add_seed_nodes( std::vector<std::string> seeds );
+
+        /****
+         * @brief add a node to seed the p2p network
+         * @param in the url as a string
+         */
+        void add_seed_node( const std::string& in);
+
         /**
          *  Attempt to connect to the specified endpoint immediately.
          */
         virtual void connect_to_endpoint( const fc::ip::endpoint& ep );
+
+        /**
+         * @brief Helper to convert a string to a collection of endpoints
+         *
+         * This converts a string (i.e. "bitshares.eu:665535" to a collection of endpoints.
+         * NOTE: Throws an exception if not in correct format or was unable to resolve URL.
+         *
+         * @param in the incoming string
+         * @returns a vector of endpoints
+         */
+        static std::vector<fc::ip::endpoint> resolve_string_to_ip_endpoints( const std::string& in );
 
         /**
          *  Specifies the network interface and port upon which incoming

--- a/libraries/net/node_impl.hxx
+++ b/libraries/net/node_impl.hxx
@@ -337,6 +337,14 @@ class node_impl : public peer_connection_delegate
 
       std::list<fc::future<void> > _handle_message_calls_in_progress;
 
+      /// used by the task that checks whether addresses of seed nodes have been updated
+      // @{
+      boost::container::flat_set<std::string> _seed_nodes;
+      fc::future<void> _update_seed_nodes_loop_done;
+      void update_seed_nodes_task();
+      void schedule_next_update_seed_nodes_task();
+      // @}
+
       node_impl(const std::string& user_agent);
       virtual ~node_impl();
 
@@ -483,6 +491,7 @@ class node_impl : public peer_connection_delegate
       void connect_to_p2p_network();
       void add_node( const fc::ip::endpoint& ep );
       void add_seed_node( const std::string& seed_string );
+      void resolve_seed_node_and_add( const std::string& seed_string );
       void initiate_connect_to(const peer_connection_ptr& peer);
       void connect_to_endpoint(const fc::ip::endpoint& ep);
       void listen_on_endpoint(const fc::ip::endpoint& ep , bool wait_if_not_available);

--- a/libraries/net/node_impl.hxx
+++ b/libraries/net/node_impl.hxx
@@ -482,6 +482,7 @@ class node_impl : public peer_connection_delegate
       void listen_to_p2p_network();
       void connect_to_p2p_network();
       void add_node( const fc::ip::endpoint& ep );
+      void add_seed_node( const std::string& seed_string );
       void initiate_connect_to(const peer_connection_ptr& peer);
       void connect_to_endpoint(const fc::ip::endpoint& ep);
       void listen_on_endpoint(const fc::ip::endpoint& ep , bool wait_if_not_available);


### PR DESCRIPTION
For issue https://github.com/bitshares/bitshares-core/issues/2153.

Ready for review.

* The first commit contains a code refactory and a small fix ported from #1764, in order to mitigate potential conflicts when merging #1764 in the future. Note that it also moves the logging about seed nodes from default to p2p, thus future issues about seed nodes (unable to resolve and etc) will be less visible for node admins.
* The second commit contains code for checking seed nodes updates.