### PR TITLE
Improve get_account_stats_by_owner performance

### DIFF
--- a/libraries/chain/db_getter.cpp
+++ b/libraries/chain/db_getter.cpp
@@ -138,10 +138,7 @@ uint32_t database::last_non_undoable_block_num() const
 
 const account_statistics_object& database::get_account_stats_by_owner( account_id_type owner )const
 {
-   auto& idx = get_index_type<account_stats_index>().indices().get<by_owner>();
-   auto itr = idx.find( owner );
-   FC_ASSERT( itr != idx.end(), "Can not find account statistics object for owner ${a}", ("a",owner) );
-   return *itr;
+   return account_statistics_id_type(owner.instance)(*this);
 }
 
 const witness_schedule_object& database::get_witness_schedule_object()const

--- a/libraries/chain/include/graphene/chain/account_object.hpp
+++ b/libraries/chain/include/graphene/chain/account_object.hpp
@@ -398,7 +398,6 @@ namespace graphene { namespace chain {
     */
    typedef generic_index<account_object, account_multi_index_type> account_index;
 
-   struct by_owner;
    struct by_maintenance_seq;
 
    /**
@@ -408,8 +407,6 @@ namespace graphene { namespace chain {
       account_statistics_object,
       indexed_by<
          ordered_unique< tag<by_id>, member< object, object_id_type, &object::id > >,
-         ordered_unique< tag<by_owner>,
-                         member< account_statistics_object, account_id_type, &account_statistics_object::owner > >,
          ordered_unique< tag<by_maintenance_seq>,
             composite_key<
                account_statistics_object,


### PR DESCRIPTION
Since every account owns an account object and an account statistics object with the same instance, it's possible to improve performance by directly converting the data types.