### PR TITLE
Fix disk space issue about Github Autobuild

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -117,9 +117,10 @@ jobs:
         pwd
         df -h .
         mkdir -p _build
-        sudo mkdir -p /_build/libraries
-        sudo chmod a+rwx /_build/libraries
+        sudo mkdir -p /_build/libraries /_build/programs
+        sudo chmod a+rwx /_build/libraries /_build/programs
         ln -s /_build/libraries _build/libraries
+        ln -s /_build/programs _build/programs
         ls -al _build
         pushd _build
         export -n BOOST_ROOT BOOST_INCLUDEDIR BOOST_LIBRARYDIR
@@ -146,6 +147,9 @@ jobs:
         df -h
         make -j 2 -C _build
         df -h
+        du -hs _build/libraries/* _build/programs/* _build/tests/*
+        du -hs _build/*
+        du -hs /_build/*
     - name: Unit-Tests
       run: |
         _build/tests/app_test -l message

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -114,11 +114,13 @@ jobs:
         submodules: recursive
     - name: Configure
       run: |
+        pwd
+        df -h .
         mkdir -p _build
-        sudo mkdir -p /mnt/libraries /mnt/tests
-        sudo chmod a+rwx /mnt/libraries /mnt/tests
-        ln -s /mnt/libraries _build/libraries
-        ln -s /mnt/tests _build/tests
+        sudo mkdir -p /_build/libraries
+        sudo chmod a+rwx /_build/libraries
+        ln -s /_build/libraries _build/libraries
+        ls -al _build
         pushd _build
         export -n BOOST_ROOT BOOST_INCLUDEDIR BOOST_LIBRARYDIR
         cmake -D CMAKE_BUILD_TYPE=Debug \


### PR DESCRIPTION
For Ubuntu build in debug mode, build `libraries` and `programs` in a volume which is not the default volume, build others in the default volume.