### PR TITLE
Fix Github Autobuild for Ubuntu debug mode

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -117,10 +117,14 @@ jobs:
         pwd
         df -h .
         mkdir -p _build
-        sudo mkdir -p /_build/libraries /_build/programs
-        sudo chmod a+rwx /_build/libraries /_build/programs
+        sudo mkdir -p /_build/libraries /_build/programs /mnt/_build/tests
+        sudo chmod a+rwx /_build/libraries /_build/programs /mnt/_build/tests
         ln -s /_build/libraries _build/libraries
         ln -s /_build/programs _build/programs
+        ln -s /mnt/_build/tests _build/tests
+        sudo ln -s /_build/libraries /mnt/_build/libraries
+        sudo ln -s /_build/programs /mnt/_build/programs
+        sudo ln -s /mnt/_build/tests /_build/tests
         ls -al _build
         pushd _build
         export -n BOOST_ROOT BOOST_INCLUDEDIR BOOST_LIBRARYDIR


### PR DESCRIPTION
Github Autobuild failed to build `develop` branch after merged #2178, since the default work volume is different. This PR tries to fix it by explicitly specifying the location of `_build` directory.