### PR TITLE
Add a `type` field to trade history APIs

### DIFF
--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -1669,9 +1669,12 @@ vector<market_trade> database_api_impl::get_trade_history_by_sequence(
          {
             trade.sequence = -itr->key.sequence;
             trade.side1_account_id = itr->op.account_id;
+            trade.side1_was_selling = itr->op.receives;
          }
-         else
+         else {
             trade.side2_account_id = itr->op.account_id;
+            trade.side2_was_selling = itr->op.receives;
+         }
 
          auto next_itr = std::next(itr);
          // Trades are usually tracked in each direction, exception: for global settlement only one side is recorded
@@ -1682,9 +1685,12 @@ vector<market_trade> database_api_impl::get_trade_history_by_sequence(
             {
                trade.sequence = -next_itr->key.sequence;
                trade.side1_account_id = next_itr->op.account_id;
+               trade.side1_was_selling = next_itr->op.receives;
             }
-            else
+            else {
                trade.side2_account_id = next_itr->op.account_id;
+               trade.side2_was_selling = next_itr->op.receives;
+            }
             // skip the other direction
             itr = next_itr;
          }

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -1554,11 +1554,17 @@ vector<market_trade> database_api_impl::get_trade_history( const string& base,
          {
             trade.sequence = -itr->key.sequence;
             trade.side1_account_id = itr->op.account_id;
-            trade.side1_was_selling = itr->op.pays.asset_id == assets[0]->id ? base : quote;
+            if(itr->op.receives.asset_id == assets[0]->id)
+               trade.type = "buy";
+            else
+               trade.type = "sell";
          }
          else {
             trade.side2_account_id = itr->op.account_id;
-            trade.side2_was_selling = itr->op.pays.asset_id == assets[0]->id ? base : quote;
+            if(itr->op.receives.asset_id == assets[1]->id)
+               trade.type = "sell";
+            else
+               trade.type = "buy";
          }
          auto next_itr = std::next(itr);
          // Trades are usually tracked in each direction, exception: for global settlement only one side is recorded
@@ -1569,11 +1575,17 @@ vector<market_trade> database_api_impl::get_trade_history( const string& base,
             {
                trade.sequence = -next_itr->key.sequence;
                trade.side1_account_id = next_itr->op.account_id;
-               trade.side1_was_selling = next_itr->op.pays.asset_id == assets[0]->id ? base : quote;
+               if(next_itr->op.receives.asset_id == assets[0]->id)
+                  trade.type = "buy";
+               else
+                  trade.type = "sell";
             }
             else {
                trade.side2_account_id = next_itr->op.account_id;
-               trade.side2_was_selling = next_itr->op.pays.asset_id == assets[0]->id ? base : quote;
+               if(next_itr->op.receives.asset_id == assets[1]->id)
+                  trade.type = "sell";
+               else
+                  trade.type = "buy";
             }
             // skip the other direction
             itr = next_itr;
@@ -1669,11 +1681,17 @@ vector<market_trade> database_api_impl::get_trade_history_by_sequence(
          {
             trade.sequence = -itr->key.sequence;
             trade.side1_account_id = itr->op.account_id;
-            trade.side1_was_selling = itr->op.pays.asset_id == assets[0]->id ? base : quote;
+            if(itr->op.receives.asset_id == assets[0]->id)
+               trade.type = "buy";
+            else
+               trade.type = "sell";
          }
          else {
             trade.side2_account_id = itr->op.account_id;
-            trade.side2_was_selling = itr->op.pays.asset_id == assets[0]->id ? base : quote;
+            if(itr->op.receives.asset_id == assets[1]->id)
+               trade.type = "sell";
+            else
+               trade.type = "buy";
          }
 
          auto next_itr = std::next(itr);
@@ -1685,11 +1703,17 @@ vector<market_trade> database_api_impl::get_trade_history_by_sequence(
             {
                trade.sequence = -next_itr->key.sequence;
                trade.side1_account_id = next_itr->op.account_id;
-               trade.side1_was_selling = next_itr->op.pays.asset_id == assets[0]->id ? base : quote;
+               if(next_itr->op.receives.asset_id == assets[0]->id)
+                  trade.type = "buy";
+               else
+                  trade.type = "sell";
             }
             else {
                trade.side2_account_id = next_itr->op.account_id;
-               trade.side2_was_selling = next_itr->op.pays.asset_id == assets[0]->id ? base : quote;
+               if(next_itr->op.receives.asset_id == assets[1]->id)
+                  trade.type = "sell";
+               else
+                  trade.type = "buy";
             }
             // skip the other direction
             itr = next_itr;

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -1555,17 +1555,13 @@ vector<market_trade> database_api_impl::get_trade_history( const string& base,
             trade.sequence = -itr->key.sequence;
             trade.side1_account_id = itr->op.account_id;
             if(itr->op.receives.asset_id == assets[0]->id)
-               trade.type = "buy";
-            else
                trade.type = "sell";
+            else
+               trade.type = "buy";
          }
-         else {
+         else
             trade.side2_account_id = itr->op.account_id;
-            if(itr->op.receives.asset_id == assets[1]->id)
-               trade.type = "sell";
-            else
-               trade.type = "buy";
-         }
+
          auto next_itr = std::next(itr);
          // Trades are usually tracked in each direction, exception: for global settlement only one side is recorded
          if( next_itr != history_idx.end() && next_itr->key.base == base_id && next_itr->key.quote == quote_id
@@ -1576,17 +1572,12 @@ vector<market_trade> database_api_impl::get_trade_history( const string& base,
                trade.sequence = -next_itr->key.sequence;
                trade.side1_account_id = next_itr->op.account_id;
                if(next_itr->op.receives.asset_id == assets[0]->id)
-                  trade.type = "buy";
-               else
                   trade.type = "sell";
+               else
+                  trade.type = "buy";
             }
-            else {
+            else
                trade.side2_account_id = next_itr->op.account_id;
-               if(next_itr->op.receives.asset_id == assets[1]->id)
-                  trade.type = "sell";
-               else
-                  trade.type = "buy";
-            }
             // skip the other direction
             itr = next_itr;
          }
@@ -1682,17 +1673,12 @@ vector<market_trade> database_api_impl::get_trade_history_by_sequence(
             trade.sequence = -itr->key.sequence;
             trade.side1_account_id = itr->op.account_id;
             if(itr->op.receives.asset_id == assets[0]->id)
-               trade.type = "buy";
-            else
                trade.type = "sell";
+            else
+               trade.type = "buy";
          }
-         else {
+         else
             trade.side2_account_id = itr->op.account_id;
-            if(itr->op.receives.asset_id == assets[1]->id)
-               trade.type = "sell";
-            else
-               trade.type = "buy";
-         }
 
          auto next_itr = std::next(itr);
          // Trades are usually tracked in each direction, exception: for global settlement only one side is recorded
@@ -1704,17 +1690,12 @@ vector<market_trade> database_api_impl::get_trade_history_by_sequence(
                trade.sequence = -next_itr->key.sequence;
                trade.side1_account_id = next_itr->op.account_id;
                if(next_itr->op.receives.asset_id == assets[0]->id)
-                  trade.type = "buy";
-               else
                   trade.type = "sell";
+               else
+                  trade.type = "buy";
             }
-            else {
+            else
                trade.side2_account_id = next_itr->op.account_id;
-               if(next_itr->op.receives.asset_id == assets[1]->id)
-                  trade.type = "sell";
-               else
-                  trade.type = "buy";
-            }
             // skip the other direction
             itr = next_itr;
          }

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -1554,10 +1554,12 @@ vector<market_trade> database_api_impl::get_trade_history( const string& base,
          {
             trade.sequence = -itr->key.sequence;
             trade.side1_account_id = itr->op.account_id;
+            trade.side1_was_selling = itr->op.receives;
          }
-         else
+         else {
             trade.side2_account_id = itr->op.account_id;
-
+            trade.side2_was_selling = itr->op.receives;
+         }
          auto next_itr = std::next(itr);
          // Trades are usually tracked in each direction, exception: for global settlement only one side is recorded
          if( next_itr != history_idx.end() && next_itr->key.base == base_id && next_itr->key.quote == quote_id
@@ -1567,9 +1569,12 @@ vector<market_trade> database_api_impl::get_trade_history( const string& base,
             {
                trade.sequence = -next_itr->key.sequence;
                trade.side1_account_id = next_itr->op.account_id;
+               trade.side1_was_selling = next_itr->op.receives;
             }
-            else
+            else {
                trade.side2_account_id = next_itr->op.account_id;
+               trade.side2_was_selling = next_itr->op.receives;
+            }
             // skip the other direction
             itr = next_itr;
          }

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -1554,11 +1554,11 @@ vector<market_trade> database_api_impl::get_trade_history( const string& base,
          {
             trade.sequence = -itr->key.sequence;
             trade.side1_account_id = itr->op.account_id;
-            trade.side1_was_selling = itr->op.receives;
+            trade.side1_was_selling = itr->op.pays.asset_id == assets[0]->id ? base : quote;
          }
          else {
             trade.side2_account_id = itr->op.account_id;
-            trade.side2_was_selling = itr->op.receives;
+            trade.side2_was_selling = itr->op.pays.asset_id == assets[0]->id ? base : quote;
          }
          auto next_itr = std::next(itr);
          // Trades are usually tracked in each direction, exception: for global settlement only one side is recorded
@@ -1569,11 +1569,11 @@ vector<market_trade> database_api_impl::get_trade_history( const string& base,
             {
                trade.sequence = -next_itr->key.sequence;
                trade.side1_account_id = next_itr->op.account_id;
-               trade.side1_was_selling = next_itr->op.receives;
+               trade.side1_was_selling = next_itr->op.pays.asset_id == assets[0]->id ? base : quote;
             }
             else {
                trade.side2_account_id = next_itr->op.account_id;
-               trade.side2_was_selling = next_itr->op.receives;
+               trade.side2_was_selling = next_itr->op.pays.asset_id == assets[0]->id ? base : quote;
             }
             // skip the other direction
             itr = next_itr;
@@ -1669,11 +1669,11 @@ vector<market_trade> database_api_impl::get_trade_history_by_sequence(
          {
             trade.sequence = -itr->key.sequence;
             trade.side1_account_id = itr->op.account_id;
-            trade.side1_was_selling = itr->op.receives;
+            trade.side1_was_selling = itr->op.pays.asset_id == assets[0]->id ? base : quote;
          }
          else {
             trade.side2_account_id = itr->op.account_id;
-            trade.side2_was_selling = itr->op.receives;
+            trade.side2_was_selling = itr->op.pays.asset_id == assets[0]->id ? base : quote;
          }
 
          auto next_itr = std::next(itr);
@@ -1685,11 +1685,11 @@ vector<market_trade> database_api_impl::get_trade_history_by_sequence(
             {
                trade.sequence = -next_itr->key.sequence;
                trade.side1_account_id = next_itr->op.account_id;
-               trade.side1_was_selling = next_itr->op.receives;
+               trade.side1_was_selling = next_itr->op.pays.asset_id == assets[0]->id ? base : quote;
             }
             else {
                trade.side2_account_id = next_itr->op.account_id;
-               trade.side2_was_selling = next_itr->op.receives;
+               trade.side2_was_selling = next_itr->op.pays.asset_id == assets[0]->id ? base : quote;
             }
             // skip the other direction
             itr = next_itr;

--- a/libraries/app/include/graphene/app/api_objects.hpp
+++ b/libraries/app/include/graphene/app/api_objects.hpp
@@ -137,9 +137,9 @@ namespace graphene { namespace app {
       string                     amount;
       string                     value;
       account_id_type            side1_account_id = GRAPHENE_NULL_ACCOUNT;
-      asset                      side1_was_selling;
+      string                     side1_was_selling;
       account_id_type            side2_account_id = GRAPHENE_NULL_ACCOUNT;
-      asset                      side2_was_selling;
+      string                     side2_was_selling;
    };
 
    struct extended_asset_object : asset_object

--- a/libraries/app/include/graphene/app/api_objects.hpp
+++ b/libraries/app/include/graphene/app/api_objects.hpp
@@ -136,10 +136,9 @@ namespace graphene { namespace app {
       string                     price;
       string                     amount;
       string                     value;
+      string                     type;
       account_id_type            side1_account_id = GRAPHENE_NULL_ACCOUNT;
-      string                     side1_was_selling;
       account_id_type            side2_account_id = GRAPHENE_NULL_ACCOUNT;
-      string                     side2_was_selling;
    };
 
    struct extended_asset_object : asset_object
@@ -187,8 +186,8 @@ FC_REFLECT( graphene::app::market_ticker,
             (time)(base)(quote)(latest)(lowest_ask)(lowest_ask_base_size)(lowest_ask_quote_size)
             (highest_bid)(highest_bid_base_size)(highest_bid_quote_size)(percent_change)(base_volume)(quote_volume) );
 FC_REFLECT( graphene::app::market_volume, (time)(base)(quote)(base_volume)(quote_volume) );
-FC_REFLECT( graphene::app::market_trade, (sequence)(date)(price)(amount)(value)(side1_account_id)(side2_account_id)
-            (side1_was_selling)(side2_was_selling));
+FC_REFLECT( graphene::app::market_trade, (sequence)(date)(price)(amount)(value)(type)
+            (side1_account_id)(side2_account_id));
 
 FC_REFLECT_DERIVED( graphene::app::extended_asset_object, (graphene::chain::asset_object),
                     (total_in_collateral)(total_backing_collateral) );

--- a/libraries/app/include/graphene/app/api_objects.hpp
+++ b/libraries/app/include/graphene/app/api_objects.hpp
@@ -137,7 +137,9 @@ namespace graphene { namespace app {
       string                     amount;
       string                     value;
       account_id_type            side1_account_id = GRAPHENE_NULL_ACCOUNT;
+      asset                      side1_was_selling;
       account_id_type            side2_account_id = GRAPHENE_NULL_ACCOUNT;
+      asset                      side2_was_selling;
    };
 
    struct extended_asset_object : asset_object
@@ -185,7 +187,8 @@ FC_REFLECT( graphene::app::market_ticker,
             (time)(base)(quote)(latest)(lowest_ask)(lowest_ask_base_size)(lowest_ask_quote_size)
             (highest_bid)(highest_bid_base_size)(highest_bid_quote_size)(percent_change)(base_volume)(quote_volume) );
 FC_REFLECT( graphene::app::market_volume, (time)(base)(quote)(base_volume)(quote_volume) );
-FC_REFLECT( graphene::app::market_trade, (sequence)(date)(price)(amount)(value)(side1_account_id)(side2_account_id) );
+FC_REFLECT( graphene::app::market_trade, (sequence)(date)(price)(amount)(value)(side1_account_id)(side2_account_id)
+            (side1_was_selling)(side2_was_selling));
 
 FC_REFLECT_DERIVED( graphene::app::extended_asset_object, (graphene::chain::asset_object),
                     (total_in_collateral)(total_backing_collateral) );

--- a/tests/tests/database_api_tests.cpp
+++ b/tests/tests/database_api_tests.cpp
@@ -1875,8 +1875,8 @@ BOOST_AUTO_TEST_CASE( get_trade_history )
    BOOST_CHECK_EQUAL( "1", history[0].value );
    BOOST_CHECK_EQUAL( maker_id.instance.value, history[0].side1_account_id.instance.value );
    BOOST_CHECK_EQUAL( taker_id.instance.value, history[0].side2_account_id.instance.value );
-   BOOST_CHECK_EQUAL( 20000, history[0].side1_was_selling.amount.value );
-   BOOST_CHECK_EQUAL( 100000, history[0].side2_was_selling.amount.value );
+   BOOST_CHECK_EQUAL( "BTS", history[0].side1_was_selling );
+   BOOST_CHECK_EQUAL( "CNY", history[0].side2_was_selling );
 
    // opposite side
    history = db_api.get_trade_history( "CNY", core.symbol, db.head_block_time(), db.head_block_time() - fc::days(1) );
@@ -1886,8 +1886,8 @@ BOOST_AUTO_TEST_CASE( get_trade_history )
    BOOST_CHECK_EQUAL( "200", history[0].value );
    BOOST_CHECK_EQUAL( maker_id.instance.value, history[0].side1_account_id.instance.value );
    BOOST_CHECK_EQUAL( taker_id.instance.value, history[0].side2_account_id.instance.value );
-   BOOST_CHECK_EQUAL( 20000, history[0].side1_was_selling.amount.value );
-   BOOST_CHECK_EQUAL( 100000, history[0].side2_was_selling.amount.value );
+   BOOST_CHECK_EQUAL( "BTS", history[0].side1_was_selling );
+   BOOST_CHECK_EQUAL( "CNY", history[0].side2_was_selling );
 
    // by sequence
    history = db_api.get_trade_history_by_sequence( core.symbol, "CNY", 2, db.head_block_time() - fc::days(1) );
@@ -1897,8 +1897,8 @@ BOOST_AUTO_TEST_CASE( get_trade_history )
    BOOST_CHECK_EQUAL( "1", history[0].value );
    BOOST_CHECK_EQUAL( maker_id.instance.value, history[0].side1_account_id.instance.value );
    BOOST_CHECK_EQUAL( taker_id.instance.value, history[0].side2_account_id.instance.value );
-   BOOST_CHECK_EQUAL( 20000, history[0].side1_was_selling.amount.value );
-   BOOST_CHECK_EQUAL( 100000, history[0].side2_was_selling.amount.value );
+   BOOST_CHECK_EQUAL( "BTS", history[0].side1_was_selling );
+   BOOST_CHECK_EQUAL( "CNY", history[0].side2_was_selling );
 
    // opposite side
    history = db_api.get_trade_history_by_sequence( "CNY", core.symbol, 2, db.head_block_time() - fc::days(1) );
@@ -1908,8 +1908,8 @@ BOOST_AUTO_TEST_CASE( get_trade_history )
    BOOST_CHECK_EQUAL( "200", history[0].value );
    BOOST_CHECK_EQUAL( maker_id.instance.value, history[0].side1_account_id.instance.value );
    BOOST_CHECK_EQUAL( taker_id.instance.value, history[0].side2_account_id.instance.value );
-   BOOST_CHECK_EQUAL( 20000, history[0].side1_was_selling.amount.value );
-   BOOST_CHECK_EQUAL( 100000, history[0].side2_was_selling.amount.value );
+   BOOST_CHECK_EQUAL( "BTS", history[0].side1_was_selling );
+   BOOST_CHECK_EQUAL( "CNY", history[0].side2_was_selling );
 
 } FC_LOG_AND_RETHROW() }
 

--- a/tests/tests/database_api_tests.cpp
+++ b/tests/tests/database_api_tests.cpp
@@ -1864,7 +1864,7 @@ BOOST_AUTO_TEST_CASE( get_trade_history )
    create_sell_order(maker, core.amount(100000), bitcny.amount(20000));
 
    // taker match it
-   create_sell_order(taker, bitcny.amount(200000), core.amount(100000));
+   create_sell_order(taker, bitcny.amount(20000), core.amount(100000));
 
    generate_block();
 
@@ -1880,6 +1880,28 @@ BOOST_AUTO_TEST_CASE( get_trade_history )
 
    // opposite side
    history = db_api.get_trade_history( "CNY", core.symbol, db.head_block_time(), db.head_block_time() - fc::days(1) );
+   BOOST_REQUIRE_EQUAL( 1, history.size() );
+   BOOST_CHECK_EQUAL( "200", history[0].price );
+   BOOST_CHECK_EQUAL( "1", history[0].amount );
+   BOOST_CHECK_EQUAL( "200", history[0].value );
+   BOOST_CHECK_EQUAL( maker_id.instance.value, history[0].side1_account_id.instance.value );
+   BOOST_CHECK_EQUAL( taker_id.instance.value, history[0].side2_account_id.instance.value );
+   BOOST_CHECK_EQUAL( 20000, history[0].side1_was_selling.amount.value );
+   BOOST_CHECK_EQUAL( 100000, history[0].side2_was_selling.amount.value );
+
+   // by sequence
+   history = db_api.get_trade_history_by_sequence( core.symbol, "CNY", 2, db.head_block_time() - fc::days(1) );
+   BOOST_REQUIRE_EQUAL( 1, history.size() );
+   BOOST_CHECK_EQUAL( "0.005", history[0].price );
+   BOOST_CHECK_EQUAL( "200", history[0].amount );
+   BOOST_CHECK_EQUAL( "1", history[0].value );
+   BOOST_CHECK_EQUAL( maker_id.instance.value, history[0].side1_account_id.instance.value );
+   BOOST_CHECK_EQUAL( taker_id.instance.value, history[0].side2_account_id.instance.value );
+   BOOST_CHECK_EQUAL( 20000, history[0].side1_was_selling.amount.value );
+   BOOST_CHECK_EQUAL( 100000, history[0].side2_was_selling.amount.value );
+
+   // opposite side
+   history = db_api.get_trade_history_by_sequence( "CNY", core.symbol, 2, db.head_block_time() - fc::days(1) );
    BOOST_REQUIRE_EQUAL( 1, history.size() );
    BOOST_CHECK_EQUAL( "200", history[0].price );
    BOOST_CHECK_EQUAL( "1", history[0].amount );


### PR DESCRIPTION
This PR adds a `type` field to the entries in the results of `get_trade_history` and `get_trade_history_by_sequence` APIs, to indicate each trade is proactive `buy` (or "pump"), or a proactive `sell` (or "dump").

Cherry-picked from #2175, for issue #2163 for 4.0 release.

Thanks to @oxarbitrage.

