### PR TITLE
Explicitly list cpp files for building wallet lib, fix Gitian build

### DIFF
--- a/libraries/wallet/CMakeLists.txt
+++ b/libraries/wallet/CMakeLists.txt
@@ -29,7 +29,21 @@ else()
                       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/api_documentation_standin.cpp )
 endif()
 
-file (GLOB SOURCES "*.cpp")
+set( SOURCES
+     operation_printer.cpp
+     reflect_util.cpp
+     wallet.cpp
+     wallet_account.cpp
+     wallet_api_impl.cpp
+     wallet_asset.cpp
+     wallet_builder.cpp
+     wallet_debug.cpp
+     wallet_network.cpp
+     wallet_results.cpp
+     wallet_sign.cpp
+     wallet_transfer.cpp
+     wallet_voting.cpp
+   )
 
 add_library( graphene_wallet ${SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/api_documentation.cpp ${HEADERS} )
 target_link_libraries( graphene_wallet PRIVATE graphene_app graphene_net graphene_chain graphene_utilities fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )


### PR DESCRIPTION
The Linux build was not reproducible due to the unstable ordering of source files for building the `graphene_wallet` library. This PR fixes it.

See https://github.com/bitshares/bitshares-gitian/pull/38.
