### PR TITLE
Set BitShares Mainnet 4.0 protocol activation time

### DIFF
--- a/libraries/chain/hardfork.d/BSIP_48_75.hf
+++ b/libraries/chain/hardfork.d/BSIP_48_75.hf
@@ -2,7 +2,6 @@
 // - BSIP 48 : new issuer permissions "lock_max_supply" and "disable_new_supply", precision update, skip cer
 // - BSIP 75 : asset owner set MCR, ICR and MSSR
 #ifndef HARDFORK_BSIP_48_75_TIME
-// Jan 1 2030, midnight; this is a dummy date until a hardfork date is scheduled
-#define HARDFORK_BSIP_48_75_TIME (fc::time_point_sec( 1893456000 ))
+#define HARDFORK_BSIP_48_75_TIME (fc::time_point_sec( 1596117300 )) // Thursday, July 30, 2020 13:55:00 UTC
 #define HARDFORK_BSIP_48_75_PASSED(now) (now >= HARDFORK_BSIP_48_75_TIME)
 #endif

--- a/libraries/chain/hardfork.d/BSIP_77.hf
+++ b/libraries/chain/hardfork.d/BSIP_77.hf
@@ -1,6 +1,5 @@
 // BSIP 77 ("Initial Collateral Ratio" (ICR)) hardfork check
 #ifndef HARDFORK_BSIP_77_TIME
-// Jan 1 2030, midnight; this is a dummy date until a hardfork date is scheduled
-#define HARDFORK_BSIP_77_TIME (fc::time_point_sec( 1893456000 ))
+#define HARDFORK_BSIP_77_TIME (fc::time_point_sec( 1596117300 )) // Thursday, July 30, 2020 13:55:00 UTC
 #define HARDFORK_BSIP_77_PASSED(now) (now >= HARDFORK_BSIP_77_TIME)
 #endif

--- a/libraries/chain/hardfork.d/BSIP_81.hf
+++ b/libraries/chain/hardfork.d/BSIP_81.hf
@@ -1,5 +1,4 @@
 // BSIP 81 (Simple Maker-Taker Market Fees) hardfork check
 #ifndef HARDFORK_BSIP_81_TIME
-// Jan 1 2030, midnight this is a dummy date until a hardfork date is scheduled
-#define HARDFORK_BSIP_81_TIME (fc::time_point_sec( 1893456000 ))
+#define HARDFORK_BSIP_81_TIME (fc::time_point_sec( 1596117300 )) // Thursday, July 30, 2020 13:55:00 UTC
 #endif

--- a/libraries/chain/hardfork.d/BSIP_85.hf
+++ b/libraries/chain/hardfork.d/BSIP_85.hf
@@ -1,6 +1,5 @@
 // BSIP 85 (Maker order creation fee discount) hardfork check
 #ifndef HARDFORK_BSIP_85_TIME
-// Jan 1 2030, midnight; this is a dummy date until a hardfork date is scheduled
-#define HARDFORK_BSIP_85_TIME (fc::time_point_sec( 1893456000 ))
+#define HARDFORK_BSIP_85_TIME (fc::time_point_sec( 1596117300 )) // Thursday, July 30, 2020 13:55:00 UTC
 #define HARDFORK_BSIP_85_PASSED(now) (now >= HARDFORK_BSIP_85_TIME)
 #endif

--- a/libraries/chain/hardfork.d/BSIP_86.hf
+++ b/libraries/chain/hardfork.d/BSIP_86.hf
@@ -1,6 +1,5 @@
 // BSIP 86 (Share market fees to the network) hardfork check
 #ifndef HARDFORK_BSIP_86_TIME
-// Jan 1 2030, midnight; this is a dummy date until a hardfork date is scheduled
-#define HARDFORK_BSIP_86_TIME (fc::time_point_sec( 1893456000 ))
+#define HARDFORK_BSIP_86_TIME (fc::time_point_sec( 1596117300 )) // Thursday, July 30, 2020 13:55:00 UTC
 #define HARDFORK_BSIP_86_PASSED(now) (now >= HARDFORK_BSIP_86_TIME)
 #endif

--- a/libraries/chain/hardfork.d/CORE_1669.hf
+++ b/libraries/chain/hardfork.d/CORE_1669.hf
@@ -1,4 +1,4 @@
 // bitshares-core issue #1669 Stop using call_price when globally settling
 #ifndef HARDFORK_CORE_1669_TIME
-#define HARDFORK_CORE_1669_TIME (fc::time_point_sec( 1600000000 )) // a temporary date in the future
+#define HARDFORK_CORE_1669_TIME (fc::time_point_sec( 1596117300 )) // Thursday, July 30, 2020 13:55:00 UTC
 #endif

--- a/libraries/chain/hardfork.d/CORE_1692.hf
+++ b/libraries/chain/hardfork.d/CORE_1692.hf
@@ -1,4 +1,4 @@
 // bitshares-core issue #1692 validation check of bid_collateral
 #ifndef HARDFORK_CORE_1692_TIME
-#define HARDFORK_CORE_1692_TIME (fc::time_point_sec( 1600000000 ) ) // Sep 2020
+#define HARDFORK_CORE_1692_TIME (fc::time_point_sec( 1596117300 )) // Thursday, July 30, 2020 13:55:00 UTC
 #endif

--- a/libraries/chain/hardfork.d/CORE_1774.hf
+++ b/libraries/chain/hardfork.d/CORE_1774.hf
@@ -1,4 +1,4 @@
 // #1774 Too restrictive check in market fee sharing
 #ifndef HARDFORK_1774_TIME
-#define HARDFORK_1774_TIME (fc::time_point_sec( 1600000000 ) ) // September 13, 2020 12:26:40 PM
+#define HARDFORK_1774_TIME (fc::time_point_sec( 1596117300 )) // Thursday, July 30, 2020 13:55:00 UTC
 #endif

--- a/libraries/chain/hardfork.d/CORE_1780.hf
+++ b/libraries/chain/hardfork.d/CORE_1780.hf
@@ -1,4 +1,4 @@
 // Market fees of settle orders aren't shared to referral program
 #ifndef HARDFORK_CORE_1780_TIME
-#define HARDFORK_CORE_1780_TIME (fc::time_point_sec( 1600000000 ) ) // September 13, 2020 3:26:40 PM (GMT)
+#define HARDFORK_CORE_1780_TIME (fc::time_point_sec( 1596117300 )) // Thursday, July 30, 2020 13:55:00 UTC
 #endif

--- a/libraries/chain/hardfork.d/CORE_1800.hf
+++ b/libraries/chain/hardfork.d/CORE_1800.hf
@@ -1,4 +1,4 @@
 // bitshares-core issue #1800 Fix "Temp-account market fee sharing"
 #ifndef HARDFORK_CORE_1800_TIME
-#define HARDFORK_CORE_1800_TIME (fc::time_point_sec( 1600000000 )) // Tue, 23 Jul 2019 13:35:00 UTC
+#define HARDFORK_CORE_1800_TIME (fc::time_point_sec( 1596117300 )) // Thursday, July 30, 2020 13:55:00 UTC
 #endif

--- a/libraries/chain/hardfork.d/CORE_210.hf
+++ b/libraries/chain/hardfork.d/CORE_210.hf
@@ -1,6 +1,6 @@
 // #210 Check authorities on custom_operation
 #ifndef HARDFORK_CORE_210_TIME
-#define HARDFORK_CORE_210_TIME (fc::time_point_sec(1893456000)) // Jan 1 00:00:00 2030 (Not yet scheduled)
+#define HARDFORK_CORE_210_TIME (fc::time_point_sec( 1596117300 )) // Thursday, July 30, 2020 13:55:00 UTC
 // Bugfix: pre-HF 210, custom_operation's required_auths field was ignored.
 #define MUST_IGNORE_CUSTOM_OP_REQD_AUTHS(chain_time) (chain_time <= HARDFORK_CORE_210_TIME)
 #endif

--- a/libraries/chain/hardfork.d/CORE_2103.hf
+++ b/libraries/chain/hardfork.d/CORE_2103.hf
@@ -1,6 +1,6 @@
 // bitshares-core issue #2103 250M BTS supply
 #ifndef HARDFORK_CORE_2103_TIME
-#define HARDFORK_CORE_2103_TIME (fc::time_point_sec( 1600000000 ) ) // Sep 2020
+#define HARDFORK_CORE_2103_TIME (fc::time_point_sec( 1596117300 )) // Thursday, July 30, 2020 13:55:00 UTC
 #define HARDFORK_CORE_2103_PASSED(now) (now >= HARDFORK_CORE_2103_TIME)
 #define HARDFORK_CORE_2103_BALANCE_ID 56720 // 1.15.56720
 #endif

--- a/libraries/chain/hardfork.d/CORE_460.hf
+++ b/libraries/chain/hardfork.d/CORE_460.hf
@@ -1,4 +1,4 @@
 // bitshares-core issue #460 Prediction Market price feed should not cause black swan
 #ifndef HARDFORK_CORE_460_TIME
-#define HARDFORK_CORE_460_TIME (fc::time_point_sec( 1609372800 ) ) // 2020-12-31T00:00:00
+#define HARDFORK_CORE_460_TIME (fc::time_point_sec( 1596117300 )) // Thursday, July 30, 2020 13:55:00 UTC
 #endif

--- a/libraries/chain/hardfork.d/CORE_BSIP64.hf
+++ b/libraries/chain/hardfork.d/CORE_BSIP64.hf
@@ -1,4 +1,4 @@
 // bitshares BSIP 64 HTLC modifications
 #ifndef HARDFORK_CORE_BSIP64_TIME
-#define HARDFORK_CORE_BSIP64_TIME (fc::time_point_sec( 1600000000 ) ) // Sep 2020
+#define HARDFORK_CORE_BSIP64_TIME (fc::time_point_sec( 1596117300 )) // Thursday, July 30, 2020 13:55:00 UTC
 #endif

--- a/libraries/chain/hardfork.d/CORE_BSIP74.hf
+++ b/libraries/chain/hardfork.d/CORE_BSIP74.hf
@@ -1,4 +1,4 @@
 // bitshares-core BSIP 74 add margin call fee
 #ifndef HARDFORK_CORE_BSIP74_TIME
-#define HARDFORK_CORE_BSIP74_TIME (fc::time_point_sec( 1679955066 ) ) // Temporary date until actual hardfork date is set
+#define HARDFORK_CORE_BSIP74_TIME (fc::time_point_sec( 1596117300 )) // Thursday, July 30, 2020 13:55:00 UTC
 #endif

--- a/libraries/chain/hardfork.d/CORE_BSIP87.hf
+++ b/libraries/chain/hardfork.d/CORE_BSIP87.hf
@@ -1,4 +1,4 @@
 // bitshares-core BSIP 87: add force-settlement fee percentage:
 #ifndef HARDFORK_CORE_BSIP87_TIME
-#define HARDFORK_CORE_BSIP87_TIME (fc::time_point_sec( 1679955066 ) ) // Temporary date until actual hardfork date is set
+#define HARDFORK_CORE_BSIP87_TIME (fc::time_point_sec( 1596117300 )) // Thursday, July 30, 2020 13:55:00 UTC
 #endif

--- a/libraries/chain/hardfork.d/CORE_BSIP_87_74_COLLATFEE.hf
+++ b/libraries/chain/hardfork.d/CORE_BSIP_87_74_COLLATFEE.hf
@@ -3,5 +3,5 @@
 // HARDFORK_CORE_BSIP87_TIME or HARDFORK_CORE_BSIP74_TIME.
 // This hardfork check should be removable after the hardfork date passes.
 #ifndef HARDFORK_CORE_BSIP_87_74_COLLATFEE_TIME
-#define HARDFORK_CORE_BSIP_87_74_COLLATFEE_TIME (fc::time_point_sec( 1679955066 ) ) // Temporary date until actual hardfork date is set
+#define HARDFORK_CORE_BSIP_87_74_COLLATFEE_TIME (fc::time_point_sec( 1596117300 )) // Thu, July 30, 2020 13:55:00 UTC
 #endif


### PR DESCRIPTION
to Thursday, July 30, 2020 13:55:00 UTC (2020-07-30T13:55:00Z)