### PR TITLE
Fix Github Autobuild for macOS

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -323,7 +323,7 @@ jobs:
         brew install autoconf automake libtool
         brew install ccache
         brew search boost
-        brew install boost@1.60
+        brew install bitshares/boost160/boost@1.60
     - uses: actions/checkout@v2
       with:
         submodules: recursive


### PR DESCRIPTION
As a temporary solution, install boost 1.60 from our own tap (https://github.com/bitshares/homebrew-boost160).

Fixes #2253.