### PR TITLE
Add more database APIs for liquidity pools

### DIFF
--- a/libraries/app/database_api_impl.hxx
+++ b/libraries/app/database_api_impl.hxx
@@ -139,6 +139,9 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
                                                                         unsigned limit = 100 )const;
 
       // Liquidity pools
+      vector<liquidity_pool_object> list_liquidity_pools(
+            optional<uint32_t> limit = 101,
+            optional<liquidity_pool_id_type> start_id = optional<liquidity_pool_id_type>() )const;
       vector<liquidity_pool_object> get_liquidity_pools_by_asset_a(
             std::string asset_symbol_or_id,
             optional<uint32_t> limit = 101,

--- a/libraries/app/database_api_impl.hxx
+++ b/libraries/app/database_api_impl.hxx
@@ -158,6 +158,10 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       vector<optional<liquidity_pool_object>> get_liquidity_pools_by_share_asset(
             const vector<std::string>& asset_symbols_or_ids,
             optional<bool> subscribe = optional<bool>() )const;
+      vector<liquidity_pool_object> get_liquidity_pools_by_owner(
+            std::string account_name_or_id,
+            optional<uint32_t> limit = 101,
+            optional<asset_id_type> start_id = optional<asset_id_type>() )const;
 
       // Witnesses
       vector<optional<witness_object>> get_witnesses(const vector<witness_id_type>& witness_ids)const;

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -632,6 +632,21 @@ class database_api
       /////////////////////
 
       /**
+       * @brief Get a list of liquidity pools
+       * @param limit  The limitation of items each query can fetch, not greater than a configured value
+       * @param start_id  Start liquidity pool id, fetch pools whose IDs are greater than or equal to this ID
+       * @return The liquidity pools
+       *
+       * @note
+       * 1. @p limit can be omitted or be null, if so the default value 101 will be used
+       * 2. @p start_id can be omitted or be null, if so the api will return the "first page" of pools
+       * 3. can only omit one or more arguments in the end of the list, but not one or more in the middle
+       */
+      vector<liquidity_pool_object> list_liquidity_pools(
+            optional<uint32_t> limit = 101,
+            optional<liquidity_pool_id_type> start_id = optional<liquidity_pool_id_type>() )const;
+
+      /**
        * @brief Get a list of liquidity pools by the symbol or ID of the first asset in the pool
        * @param asset_symbol_or_id symbol name or ID of the asset
        * @param limit  The limitation of items each query can fetch, not greater than a configured value
@@ -1074,6 +1089,7 @@ FC_API(graphene::app::database_api,
    (get_trade_history_by_sequence)
 
    // Liquidity pools
+   (list_liquidity_pools)
    (get_liquidity_pools_by_asset_a)
    (get_liquidity_pools_by_asset_b)
    (get_liquidity_pools_by_both_assets)

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -718,6 +718,24 @@ class database_api
             const vector<std::string>& asset_symbols_or_ids,
             optional<bool> subscribe = optional<bool>() )const;
 
+      /**
+       * @brief Get a list of liquidity pools by the name or ID of the owner account
+       * @param account_name_or_id name or ID of the owner account
+       * @param limit  The limitation of items each query can fetch, not greater than a configured value
+       * @param start_id  Start share asset id, fetch pools whose share asset IDs are greater than or equal to this ID
+       * @return The liquidity pools
+       *
+       * @note
+       * 1. if @p account_name_or_id cannot be tied to an account, an error will be returned
+       * 2. @p limit can be omitted or be null, if so the default value 101 will be used
+       * 3. @p start_id can be omitted or be null, if so the api will return the "first page" of pools
+       * 4. can only omit one or more arguments in the end of the list, but not one or more in the middle
+       */
+      vector<liquidity_pool_object> get_liquidity_pools_by_owner(
+            std::string account_name_or_id,
+            optional<uint32_t> limit = 101,
+            optional<asset_id_type> start_id = optional<asset_id_type>() )const;
+
       ///////////////
       // Witnesses //
       ///////////////
@@ -1094,6 +1112,7 @@ FC_API(graphene::app::database_api,
    (get_liquidity_pools_by_asset_b)
    (get_liquidity_pools_by_both_assets)
    (get_liquidity_pools_by_share_asset)
+   (get_liquidity_pools_by_owner)
 
    // Witnesses
    (get_witnesses)


### PR DESCRIPTION
Add following APIs:
* list_liquidity_pools( limit, start_id )
* get_liquidity_pools_by_owner( account, limit, start_asset_id )

Fixes #2284, fixes #2286 .