### PR TITLE
Add liquidity pool statistics and new APIs

### DIFF
--- a/libraries/app/api.cpp
+++ b/libraries/app/api.cpp
@@ -546,6 +546,127 @@ namespace graphene { namespace app {
        return result;
     } FC_CAPTURE_AND_RETHROW( (asset_a)(asset_b)(bucket_seconds)(start)(end) ) }
 
+    vector<liquidity_pool_history_object> history_api::get_liquidity_pool_history(
+               liquidity_pool_id_type pool_id,
+               optional<fc::time_point_sec> start,
+               optional<fc::time_point_sec> stop,
+               optional<uint32_t> olimit,
+               optional<int64_t> operation_type )const
+    { try {
+       FC_ASSERT( _app.get_options().has_market_history_plugin, "Market history plugin is not enabled." );
+
+       uint32_t limit = olimit.valid() ? *olimit : 101;
+
+       const auto configured_limit = _app.get_options().api_limit_get_liquidity_pool_history;
+       FC_ASSERT( limit <= configured_limit,
+                  "limit can not be greater than ${configured_limit}",
+                  ("configured_limit", configured_limit) );
+
+       FC_ASSERT( _app.chain_database(), "Internal error: the chain database is not availalbe" );
+
+       const auto& db = *_app.chain_database();
+
+       vector<liquidity_pool_history_object> result;
+
+       if( limit == 0 || ( start.valid() && stop.valid() && *start <= *stop ) ) // empty result
+          return result;
+
+       const auto& hist_idx = db.get_index_type<liquidity_pool_history_index>();
+
+       if( operation_type.valid() ) // one operation type
+       {
+          const auto& idx = hist_idx.indices().get<by_pool_op_type_time>();
+          auto itr = start.valid() ? idx.lower_bound( boost::make_tuple( pool_id, *operation_type, *start ) )
+                                   : idx.lower_bound( boost::make_tuple( pool_id, *operation_type ) );
+          auto itr_stop = stop.valid() ? idx.upper_bound( boost::make_tuple( pool_id, *operation_type, *stop ) )
+                                       : idx.upper_bound( boost::make_tuple( pool_id, *operation_type ) );
+          while( itr != itr_stop && result.size() < limit )
+          {
+             result.push_back( *itr );
+             ++itr;
+          }
+       }
+       else // all operation types
+       {
+          const auto& idx = hist_idx.indices().get<by_pool_time>();
+          auto itr = start.valid() ? idx.lower_bound( boost::make_tuple( pool_id, *start ) )
+                                   : idx.lower_bound( pool_id );
+          auto itr_stop = stop.valid() ? idx.upper_bound( boost::make_tuple( pool_id, *stop ) )
+                                       : idx.upper_bound( pool_id );
+          while( itr != itr_stop && result.size() < limit )
+          {
+             result.push_back( *itr );
+             ++itr;
+          }
+       }
+
+       return result;
+
+    } FC_CAPTURE_AND_RETHROW( (pool_id)(start)(stop)(olimit)(operation_type) ) }
+
+    vector<liquidity_pool_history_object> history_api::get_liquidity_pool_history_by_sequence(
+               liquidity_pool_id_type pool_id,
+               optional<uint64_t> start,
+               optional<fc::time_point_sec> stop,
+               optional<uint32_t> olimit,
+               optional<int64_t> operation_type )const
+    { try {
+       FC_ASSERT( _app.get_options().has_market_history_plugin, "Market history plugin is not enabled." );
+
+       uint32_t limit = olimit.valid() ? *olimit : 101;
+
+       const auto configured_limit = _app.get_options().api_limit_get_liquidity_pool_history;
+       FC_ASSERT( limit <= configured_limit,
+                  "limit can not be greater than ${configured_limit}",
+                  ("configured_limit", configured_limit) );
+
+       FC_ASSERT( _app.chain_database(), "Internal error: the chain database is not availalbe" );
+
+       const auto& db = *_app.chain_database();
+
+       vector<liquidity_pool_history_object> result;
+
+       if( limit == 0 ) // empty result
+          return result;
+
+       const auto& hist_idx = db.get_index_type<liquidity_pool_history_index>();
+
+       if( operation_type.valid() ) // one operation type
+       {
+          const auto& idx = hist_idx.indices().get<by_pool_op_type_seq>();
+          const auto& idx_t = hist_idx.indices().get<by_pool_op_type_time>();
+          auto itr = start.valid() ? idx.lower_bound( boost::make_tuple( pool_id, *operation_type, *start ) )
+                                   : idx.lower_bound( boost::make_tuple( pool_id, *operation_type ) );
+          auto itr_temp = stop.valid() ? idx_t.upper_bound( boost::make_tuple( pool_id, *operation_type, *stop ) )
+                                       : idx_t.upper_bound( boost::make_tuple( pool_id, *operation_type ) );
+          auto itr_stop = ( itr_temp == idx_t.end() ? idx.end() : idx.iterator_to( *itr_temp ) );
+          while( itr != itr_stop && result.size() < limit )
+          {
+             result.push_back( *itr );
+             ++itr;
+          }
+       }
+       else // all operation types
+       {
+          const auto& idx = hist_idx.indices().get<by_pool_seq>();
+          const auto& idx_t = hist_idx.indices().get<by_pool_time>();
+          auto itr = start.valid() ? idx.lower_bound( boost::make_tuple( pool_id, *start ) )
+                                   : idx.lower_bound( pool_id );
+          auto itr_temp = stop.valid() ? idx_t.upper_bound( boost::make_tuple( pool_id, *stop ) )
+                                       : idx_t.upper_bound( pool_id );
+          auto itr_stop = ( itr_temp == idx_t.end() ? idx.end() : idx.iterator_to( *itr_temp ) );
+          while( itr != itr_stop && result.size() < limit )
+          {
+             result.push_back( *itr );
+             ++itr;
+          }
+       }
+
+       return result;
+
+    } FC_CAPTURE_AND_RETHROW( (pool_id)(start)(stop)(olimit)(operation_type) ) }
+
+
     crypto_api::crypto_api(){};
 
     commitment_type crypto_api::blind( const blind_factor_type& blind, uint64_t value )

--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -326,11 +326,15 @@ void application_impl::set_api_limit() {
    if(_options->count("api-limit-get-withdraw-permissions-by-recipient")) {
       _app_options.api_limit_get_withdraw_permissions_by_recipient = _options->at("api-limit-get-withdraw-permissions-by-recipient").as<uint64_t>();
    }
-   if(_options->count("api-limit-get-liquidity-pools")) {
+   if(_options->count("api-limit-get-tickets") > 0) {
+      _app_options.api_limit_get_tickets = _options->at("api-limit-get-tickets").as<uint64_t>();
+   }
+   if(_options->count("api-limit-get-liquidity-pools") > 0) {
       _app_options.api_limit_get_liquidity_pools = _options->at("api-limit-get-liquidity-pools").as<uint64_t>();
    }
-   if(_options->count("api-limit-get-tickets")) {
-      _app_options.api_limit_get_tickets = _options->at("api-limit-get-tickets").as<uint64_t>();
+   if(_options->count("api-limit-get-liquidity-pool-history") > 0) {
+      _app_options.api_limit_get_liquidity_pool_history =
+            _options->at("api-limit-get-liquidity-pool-history").as<uint64_t>();
    }
 }
 
@@ -1060,10 +1064,12 @@ void application::set_program_options(boost::program_options::options_descriptio
           "For database_api_impl::get_withdraw_permissions_by_giver to set max limit value")
          ("api-limit-get-withdraw-permissions-by-recipient",boost::program_options::value<uint64_t>()->default_value(101),
           "For database_api_impl::get_withdraw_permissions_by_recipient to set max limit value")
-         ("api-limit-get-liquidity-pools",boost::program_options::value<uint64_t>()->default_value(101),
-          "For database_api_impl::get_liquidity_pools_* to set max limit value")
-         ("api-limit-get-tickets",boost::program_options::value<uint64_t>()->default_value(101),
-          "For database_api_impl::get_tickets_* to set max limit value")
+         ("api-limit-get-tickets", boost::program_options::value<uint64_t>()->default_value(101),
+          "Set maximum limit value for database APIs which query for tickets")
+         ("api-limit-get-liquidity-pools", boost::program_options::value<uint64_t>()->default_value(101),
+          "Set maximum limit value for database APIs which query for liquidity pools")
+         ("api-limit-get-liquidity-pool-history", boost::program_options::value<uint64_t>()->default_value(101),
+          "Set maximum limit value for APIs which query for history of liquidity pools")
          ;
    command_line_options.add(configuration_file_options);
    command_line_options.add_options()

--- a/libraries/app/application_impl.hxx
+++ b/libraries/app/application_impl.hxx
@@ -41,6 +41,7 @@ class application_impl : public net::node_delegate
       void set_dbg_init_key( graphene::chain::genesis_state_type& genesis, const std::string& init_key );
       void set_api_limit();
 
+      void initialize();
       void startup();
 
       fc::optional< api_access_info > get_api_access_info(const string& username)const;
@@ -179,6 +180,9 @@ class application_impl : public net::node_delegate
       virtual void error_encountered(const std::string& message, const fc::oexception& error) override;
 
       uint8_t get_current_block_interval_in_seconds() const override;
+
+      /// Returns whether a plugin is enabled
+      bool is_plugin_enabled(const string& name) const;
 
       application* _self;
 

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -1721,18 +1721,21 @@ vector<market_trade> database_api_impl::get_trade_history_by_sequence(
 //                                                                  //
 //////////////////////////////////////////////////////////////////////
 
-vector<liquidity_pool_object> database_api::list_liquidity_pools(
+vector<extended_liquidity_pool_object> database_api::list_liquidity_pools(
             optional<uint32_t> limit,
-            optional<liquidity_pool_id_type> start_id )const
+            optional<liquidity_pool_id_type> start_id,
+            optional<bool> with_statistics )const
 {
    return my->list_liquidity_pools(
             limit,
-            start_id );
+            start_id,
+            with_statistics );
 }
 
-vector<liquidity_pool_object> database_api_impl::list_liquidity_pools(
+vector<extended_liquidity_pool_object> database_api_impl::list_liquidity_pools(
             optional<uint32_t> olimit,
-            optional<liquidity_pool_id_type> ostart_id )const
+            optional<liquidity_pool_id_type> ostart_id,
+            optional<bool> with_statistics )const
 {
    uint32_t limit = olimit.valid() ? *olimit : 101;
 
@@ -1742,7 +1745,9 @@ vector<liquidity_pool_object> database_api_impl::list_liquidity_pools(
               "limit can not be greater than ${configured_limit}",
               ("configured_limit", configured_limit) );
 
-   vector<liquidity_pool_object> results;
+   bool with_stats = ( with_statistics.valid() && *with_statistics );
+
+   vector<extended_liquidity_pool_object> results;
 
    liquidity_pool_id_type start_id = ostart_id.valid() ? *ostart_id : liquidity_pool_id_type();
 
@@ -1754,74 +1759,85 @@ vector<liquidity_pool_object> database_api_impl::list_liquidity_pools(
    uint32_t count = 0;
    for ( ; lower_itr != upper_itr && count < limit; ++lower_itr, ++count)
    {
-      results.emplace_back( *lower_itr );
+      results.emplace_back( extend_liquidity_pool( *lower_itr, with_stats ) );
    }
 
    return results;
 }
 
-vector<liquidity_pool_object> database_api::get_liquidity_pools_by_asset_a(
+vector<extended_liquidity_pool_object> database_api::get_liquidity_pools_by_asset_a(
             std::string asset_symbol_or_id,
             optional<uint32_t> limit,
-            optional<liquidity_pool_id_type> start_id )const
+            optional<liquidity_pool_id_type> start_id,
+            optional<bool> with_statistics )const
 {
    return my->get_liquidity_pools_by_asset_a(
             asset_symbol_or_id,
             limit,
-            start_id );
+            start_id,
+            with_statistics );
 }
 
-vector<liquidity_pool_object> database_api_impl::get_liquidity_pools_by_asset_a(
+vector<extended_liquidity_pool_object> database_api_impl::get_liquidity_pools_by_asset_a(
             std::string asset_symbol_or_id,
             optional<uint32_t> limit,
-            optional<liquidity_pool_id_type> start_id )const
+            optional<liquidity_pool_id_type> start_id,
+            optional<bool> with_statistics )const
 {
    return get_liquidity_pools_by_asset_x<by_asset_a>(
             asset_symbol_or_id,
             limit,
-            start_id );
+            start_id,
+            with_statistics );
 }
 
-vector<liquidity_pool_object> database_api::get_liquidity_pools_by_asset_b(
+vector<extended_liquidity_pool_object> database_api::get_liquidity_pools_by_asset_b(
             std::string asset_symbol_or_id,
             optional<uint32_t> limit,
-            optional<liquidity_pool_id_type> start_id )const
+            optional<liquidity_pool_id_type> start_id,
+            optional<bool> with_statistics )const
 {
    return my->get_liquidity_pools_by_asset_b(
             asset_symbol_or_id,
             limit,
-            start_id );
+            start_id,
+            with_statistics );
 }
 
-vector<liquidity_pool_object> database_api_impl::get_liquidity_pools_by_asset_b(
+vector<extended_liquidity_pool_object> database_api_impl::get_liquidity_pools_by_asset_b(
             std::string asset_symbol_or_id,
             optional<uint32_t> limit,
-            optional<liquidity_pool_id_type> start_id )const
+            optional<liquidity_pool_id_type> start_id,
+            optional<bool> with_statistics )const
 {
    return get_liquidity_pools_by_asset_x<by_asset_b>(
             asset_symbol_or_id,
             limit,
-            start_id );
+            start_id,
+            with_statistics );
 }
 
-vector<liquidity_pool_object> database_api::get_liquidity_pools_by_both_assets(
+vector<extended_liquidity_pool_object> database_api::get_liquidity_pools_by_both_assets(
             std::string asset_symbol_or_id_a,
             std::string asset_symbol_or_id_b,
             optional<uint32_t> limit,
-            optional<liquidity_pool_id_type> start_id )const
+            optional<liquidity_pool_id_type> start_id,
+            optional<bool> with_statistics )const
 {
    return my->get_liquidity_pools_by_both_assets(
             asset_symbol_or_id_a,
             asset_symbol_or_id_b,
             limit,
-            start_id );
+            start_id,
+            with_statistics );
 }
 
-vector<liquidity_pool_object> database_api_impl::get_liquidity_pools_by_both_assets(
+vector<extended_liquidity_pool_object> database_api_impl::get_liquidity_pools_by_both_assets(
             std::string asset_symbol_or_id_a,
             std::string asset_symbol_or_id_b,
             optional<uint32_t> olimit,
-            optional<liquidity_pool_id_type> ostart_id )const
+            optional<liquidity_pool_id_type> ostart_id,
+            optional<bool> with_statistics )const
 {
    uint32_t limit = olimit.valid() ? *olimit : 101;
 
@@ -1831,7 +1847,9 @@ vector<liquidity_pool_object> database_api_impl::get_liquidity_pools_by_both_ass
               "limit can not be greater than ${configured_limit}",
               ("configured_limit", configured_limit) );
 
-   vector<liquidity_pool_object> results;
+   bool with_stats = ( with_statistics.valid() && *with_statistics );
+
+   vector<extended_liquidity_pool_object> results;
 
    asset_id_type asset_id_a = get_asset_from_string(asset_symbol_or_id_a)->id;
    asset_id_type asset_id_b = get_asset_from_string(asset_symbol_or_id_b)->id;
@@ -1848,24 +1866,73 @@ vector<liquidity_pool_object> database_api_impl::get_liquidity_pools_by_both_ass
    uint32_t count = 0;
    for ( ; lower_itr != upper_itr && count < limit; ++lower_itr, ++count)
    {
-      results.emplace_back( *lower_itr );
+      results.emplace_back( extend_liquidity_pool( *lower_itr, with_stats ) );
    }
 
    return results;
 }
 
-vector<optional<liquidity_pool_object>> database_api::get_liquidity_pools_by_share_asset(
+vector<optional<extended_liquidity_pool_object>> database_api::get_liquidity_pools(
+            const vector<liquidity_pool_id_type>& ids,
+            optional<bool> subscribe,
+            optional<bool> with_statistics )const
+{
+   return my->get_liquidity_pools(
+            ids,
+            subscribe,
+            with_statistics );
+}
+
+vector<optional<extended_liquidity_pool_object>> database_api_impl::get_liquidity_pools(
+            const vector<liquidity_pool_id_type>& ids,
+            optional<bool> subscribe,
+            optional<bool> with_statistics )const
+{
+   FC_ASSERT( _app_options, "Internal error" );
+   const auto configured_limit = _app_options->api_limit_get_liquidity_pools;
+   FC_ASSERT( ids.size() <= configured_limit,
+              "size of the querying list can not be greater than ${configured_limit}",
+              ("configured_limit", configured_limit) );
+
+   bool with_stats = ( with_statistics.valid() && *with_statistics );
+
+   bool to_subscribe = get_whether_to_subscribe( subscribe );
+   vector<optional<extended_liquidity_pool_object>> result; result.reserve(ids.size());
+   std::transform(ids.begin(), ids.end(), std::back_inserter(result),
+                  [this,to_subscribe,with_stats](liquidity_pool_id_type id)
+                     -> optional<extended_liquidity_pool_object> {
+
+      if(auto o = _db.find(id))
+      {
+         auto ext_obj = extend_liquidity_pool( *o, with_stats );
+         if( to_subscribe )
+         {
+            subscribe_to_item( id );
+            if( ext_obj.statistics.valid() )
+               subscribe_to_item( ext_obj.statistics->id );
+         }
+         return ext_obj;
+      }
+      return {};
+   });
+   return result;
+}
+
+vector<optional<extended_liquidity_pool_object>> database_api::get_liquidity_pools_by_share_asset(
             const vector<std::string>& asset_symbols_or_ids,
-            optional<bool> subscribe )const
+            optional<bool> subscribe,
+            optional<bool> with_statistics )const
 {
    return my->get_liquidity_pools_by_share_asset(
             asset_symbols_or_ids,
-            subscribe );
+            subscribe,
+            with_statistics );
 }
 
-vector<optional<liquidity_pool_object>> database_api_impl::get_liquidity_pools_by_share_asset(
+vector<optional<extended_liquidity_pool_object>> database_api_impl::get_liquidity_pools_by_share_asset(
             const vector<std::string>& asset_symbols_or_ids,
-            optional<bool> subscribe )const
+            optional<bool> subscribe,
+            optional<bool> with_statistics )const
 {
    FC_ASSERT( _app_options, "Internal error" );
    const auto configured_limit = _app_options->api_limit_get_liquidity_pools;
@@ -1873,37 +1940,47 @@ vector<optional<liquidity_pool_object>> database_api_impl::get_liquidity_pools_b
               "size of the querying list can not be greater than ${configured_limit}",
               ("configured_limit", configured_limit) );
 
+   bool with_stats = ( with_statistics.valid() && *with_statistics );
+
    bool to_subscribe = get_whether_to_subscribe( subscribe );
-   vector<optional<liquidity_pool_object>> result; result.reserve(asset_symbols_or_ids.size());
+   vector<optional<extended_liquidity_pool_object>> result; result.reserve(asset_symbols_or_ids.size());
    std::transform(asset_symbols_or_ids.begin(), asset_symbols_or_ids.end(), std::back_inserter(result),
-                  [this,to_subscribe](std::string id_or_name) -> optional<liquidity_pool_object> {
+                  [this,to_subscribe,with_stats](std::string id_or_name) -> optional<extended_liquidity_pool_object> {
 
       const asset_object* asset_obj = get_asset_from_string( id_or_name, false );
       if( asset_obj == nullptr || !asset_obj->is_liquidity_pool_share_asset() )
          return {};
       const liquidity_pool_object& lp_obj = (*asset_obj->for_liquidity_pool)(_db);
+      auto ext_obj = extend_liquidity_pool( lp_obj, with_stats );
       if( to_subscribe )
+      {
          subscribe_to_item( lp_obj.id );
-      return lp_obj;
+         if( ext_obj.statistics.valid() )
+            subscribe_to_item( ext_obj.statistics->id );
+      }
+      return ext_obj;
    });
    return result;
 }
 
-vector<liquidity_pool_object> database_api::get_liquidity_pools_by_owner(
+vector<extended_liquidity_pool_object> database_api::get_liquidity_pools_by_owner(
             std::string account_name_or_id,
             optional<uint32_t> limit,
-            optional<asset_id_type> start_id )const
+            optional<asset_id_type> start_id,
+            optional<bool> with_statistics )const
 {
    return my->get_liquidity_pools_by_owner(
             account_name_or_id,
             limit,
-            start_id );
+            start_id,
+            with_statistics );
 }
 
-vector<liquidity_pool_object> database_api_impl::get_liquidity_pools_by_owner(
+vector<extended_liquidity_pool_object> database_api_impl::get_liquidity_pools_by_owner(
             std::string account_name_or_id,
             optional<uint32_t> olimit,
-            optional<asset_id_type> ostart_id )const
+            optional<asset_id_type> ostart_id,
+            optional<bool> with_statistics )const
 {
    uint32_t limit = olimit.valid() ? *olimit : 101;
 
@@ -1913,7 +1990,9 @@ vector<liquidity_pool_object> database_api_impl::get_liquidity_pools_by_owner(
               "limit can not be greater than ${configured_limit}",
               ("configured_limit", configured_limit) );
 
-   vector<liquidity_pool_object> results;
+   bool with_stats = ( with_statistics.valid() && *with_statistics );
+
+   vector<extended_liquidity_pool_object> results;
 
    account_id_type owner = get_account_from_string(account_name_or_id)->id;
 
@@ -1931,7 +2010,7 @@ vector<liquidity_pool_object> database_api_impl::get_liquidity_pools_by_owner(
       const asset_object& asset_obj = *lower_itr;
       if( !asset_obj.is_liquidity_pool_share_asset() ) // TODO improve performance
          continue;
-      results.emplace_back( (*asset_obj.for_liquidity_pool)(_db) );
+      results.emplace_back( extend_liquidity_pool( (*asset_obj.for_liquidity_pool)(_db), with_stats ) );
       ++count;
    }
 

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -1756,8 +1756,7 @@ vector<extended_liquidity_pool_object> database_api_impl::list_liquidity_pools(
    auto upper_itr = idx.end();
 
    results.reserve( limit );
-   uint32_t count = 0;
-   for ( ; lower_itr != upper_itr && count < limit; ++lower_itr, ++count)
+   for ( ; lower_itr != upper_itr && results.size() < limit; ++lower_itr )
    {
       results.emplace_back( extend_liquidity_pool( *lower_itr, with_stats ) );
    }
@@ -1863,8 +1862,7 @@ vector<extended_liquidity_pool_object> database_api_impl::get_liquidity_pools_by
    auto upper_itr = idx.upper_bound( std::make_tuple( asset_id_a, asset_id_b ) );
 
    results.reserve( limit );
-   uint32_t count = 0;
-   for ( ; lower_itr != upper_itr && count < limit; ++lower_itr, ++count)
+   for ( ; lower_itr != upper_itr && results.size() < limit; ++lower_itr )
    {
       results.emplace_back( extend_liquidity_pool( *lower_itr, with_stats ) );
    }
@@ -2004,14 +2002,12 @@ vector<extended_liquidity_pool_object> database_api_impl::get_liquidity_pools_by
    auto upper_itr = idx.upper_bound( owner );
 
    results.reserve( limit );
-   uint32_t count = 0;
-   for ( ; lower_itr != upper_itr && count < limit; ++lower_itr )
+   for ( ; lower_itr != upper_itr && results.size() < limit; ++lower_itr )
    {
       const asset_object& asset_obj = *lower_itr;
       if( !asset_obj.is_liquidity_pool_share_asset() ) // TODO improve performance
          continue;
       results.emplace_back( extend_liquidity_pool( (*asset_obj.for_liquidity_pool)(_db), with_stats ) );
-      ++count;
    }
 
    return results;

--- a/libraries/app/database_api_impl.hxx
+++ b/libraries/app/database_api_impl.hxx
@@ -331,8 +331,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
          auto upper_itr = idx.upper_bound( asset_id );
 
          results.reserve( limit );
-         uint32_t count = 0;
-         for ( ; lower_itr != upper_itr && count < limit; ++lower_itr, ++count)
+         for ( ; lower_itr != upper_itr && results.size() < limit; ++lower_itr )
          {
             results.emplace_back( extend_liquidity_pool( *lower_itr, with_stats ) );
          }

--- a/libraries/app/include/graphene/app/api.hpp
+++ b/libraries/app/include/graphene/app/api.hpp
@@ -220,6 +220,65 @@ namespace graphene { namespace app {
           * it means this API server supports OHLCV data aggregated in 5-minute buckets.
           */
          flat_set<uint32_t> get_market_history_buckets()const;
+
+         /**
+          * @brief Get history of a liquidity pool
+          * @param pool_id ID of the liquidity pool to query
+          * @param start A UNIX timestamp. Optional.
+          *              If specified, only the operations occurred not later than this time will be returned.
+          * @param stop  A UNIX timestamp. Optional.
+          *              If specified, only the operations occurred later than this time will be returned.
+          * @param limit Maximum quantity of operations in the history to retrieve.
+          *              Optional. If not specified, at most 101 records will be returned.
+          * @param operation_type Optional. If specified, only the operations whose type is the specified type
+          *                       will be returned. Otherwise all operations will be returned.
+          * @return operation history of the liquidity pool, ordered by time, most recent first.
+          *
+          * @note
+          * 1. The time must be UTC. The range is (stop, start].
+          * 2. In case when there are more than 100 operations occurred in the same second, this API only returns
+          *    the most recent records, the rest records can be retrieved with the
+          *    @ref get_liquidity_pool_history_by_sequence API.
+          * 3. List of operation type code: 59-creation, 60-deletion, 61-deposit, 62-withdrawal, 63-exchange.
+          * 4. Can only omit one or more arguments in the end of the list, but not one or more in the middle.
+          *    If need to not specify an individual argument, can specify \c null in the place.
+          */
+         vector<liquidity_pool_history_object> get_liquidity_pool_history(
+               liquidity_pool_id_type pool_id,
+               optional<fc::time_point_sec> start = optional<fc::time_point_sec>(),
+               optional<fc::time_point_sec> stop = optional<fc::time_point_sec>(),
+               optional<uint32_t> limit = 101,
+               optional<int64_t> operation_type = optional<int64_t>() )const;
+
+         /**
+          * @brief Get history of a liquidity pool
+          * @param pool_id ID of the liquidity pool to query
+          * @param start An Integer. Optional.
+          *              If specified, only the operations whose sequences are not greater than this will be returned.
+          * @param stop  A UNIX timestamp. Optional.
+          *              If specified, only operations occurred later than this time will be returned.
+          * @param limit Maximum quantity of operations in the history to retrieve.
+          *              Optional. If not specified, at most 101 records will be returned.
+          * @param operation_type Optional. If specified, only the operations whose type is the specified type
+          *                       will be returned. Otherwise all operations will be returned.
+          * @return operation history of the liquidity pool, ordered by time, most recent first.
+          *
+          * @note
+          * 1. The time must be UTC. The range is (stop, start].
+          * 2. In case when there are more than 100 operations occurred in the same second, this API only returns
+          *    the most recent records, the rest records can be retrieved with the
+          *    @ref get_liquidity_pool_history_by_sequence API.
+          * 3. List of operation type code: 59-creation, 60-deletion, 61-deposit, 62-withdrawal, 63-exchange.
+          * 4. Can only omit one or more arguments in the end of the list, but not one or more in the middle.
+          *    If need to not specify an individual argument, can specify \c null in the place.
+          */
+         vector<liquidity_pool_history_object> get_liquidity_pool_history_by_sequence(
+               liquidity_pool_id_type pool_id,
+               optional<uint64_t> start = optional<uint64_t>(),
+               optional<fc::time_point_sec> stop = optional<fc::time_point_sec>(),
+               optional<uint32_t> limit = 101,
+               optional<int64_t> operation_type = optional<int64_t>() )const;
+
       private:
            application& _app;
            graphene::app::database_api database_api;
@@ -645,6 +704,8 @@ FC_API(graphene::app::history_api,
        (get_fill_order_history)
        (get_market_history)
        (get_market_history_buckets)
+       (get_liquidity_pool_history)
+       (get_liquidity_pool_history_by_sequence)
      )
 FC_API(graphene::app::block_api,
        (get_blocks)

--- a/libraries/app/include/graphene/app/api_objects.hpp
+++ b/libraries/app/include/graphene/app/api_objects.hpp
@@ -30,6 +30,7 @@
 #include <graphene/chain/proposal_object.hpp>
 #include <graphene/chain/withdraw_permission_object.hpp>
 #include <graphene/chain/htlc_object.hpp>
+#include <graphene/chain/liquidity_pool_object.hpp>
 
 #include <graphene/api_helper_indexes/api_helper_indexes.hpp>
 #include <graphene/market_history/market_history_plugin.hpp>
@@ -152,6 +153,15 @@ namespace graphene { namespace app {
       optional<share_type> total_backing_collateral;
    };
 
+   struct extended_liquidity_pool_object : liquidity_pool_object
+   {
+      extended_liquidity_pool_object() {}
+      explicit extended_liquidity_pool_object( const liquidity_pool_object& o ) : liquidity_pool_object( o ) {}
+      explicit extended_liquidity_pool_object( liquidity_pool_object&& o ) : liquidity_pool_object( std::move(o) ) {}
+
+      optional<liquidity_pool_ticker_object> statistics;
+   };
+
 } }
 
 FC_REFLECT( graphene::app::more_data,
@@ -193,4 +203,6 @@ FC_REFLECT( graphene::app::market_trade, (sequence)(date)(price)(amount)(value)(
 FC_REFLECT_DERIVED( graphene::app::extended_asset_object, (graphene::chain::asset_object),
                     (total_in_collateral)(total_backing_collateral) );
 
+FC_REFLECT_DERIVED( graphene::app::extended_liquidity_pool_object, (graphene::chain::liquidity_pool_object),
+                    (statistics) );
 

--- a/libraries/app/include/graphene/app/application.hpp
+++ b/libraries/app/include/graphene/app/application.hpp
@@ -72,8 +72,9 @@ namespace graphene { namespace app {
          uint64_t api_limit_get_trade_history_by_sequence = 100;
          uint64_t api_limit_get_withdraw_permissions_by_giver = 101;
          uint64_t api_limit_get_withdraw_permissions_by_recipient = 101;
-         uint64_t api_limit_get_liquidity_pools = 101;
          uint64_t api_limit_get_tickets = 101;
+         uint64_t api_limit_get_liquidity_pools = 101;
+         uint64_t api_limit_get_liquidity_pool_history = 101;
    };
 
    class application

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -120,6 +120,7 @@ class database_api
        * - lookup_accounts
        * - get_full_accounts
        * - get_htlc
+       * - get_liquidity_pools
        * - get_liquidity_pools_by_share_asset
        *
        * Note: auto-subscription is enabled by default
@@ -637,6 +638,7 @@ class database_api
        * @brief Get a list of liquidity pools
        * @param limit  The limitation of items each query can fetch, not greater than a configured value
        * @param start_id  Start liquidity pool id, fetch pools whose IDs are greater than or equal to this ID
+       * @param with_statistics Whether to return statistics
        * @return The liquidity pools
        *
        * @note
@@ -644,15 +646,17 @@ class database_api
        * 2. @p start_id can be omitted or be null, if so the api will return the "first page" of pools
        * 3. can only omit one or more arguments in the end of the list, but not one or more in the middle
        */
-      vector<liquidity_pool_object> list_liquidity_pools(
+      vector<extended_liquidity_pool_object> list_liquidity_pools(
             optional<uint32_t> limit = 101,
-            optional<liquidity_pool_id_type> start_id = optional<liquidity_pool_id_type>() )const;
+            optional<liquidity_pool_id_type> start_id = optional<liquidity_pool_id_type>(),
+            optional<bool> with_statistics = false )const;
 
       /**
        * @brief Get a list of liquidity pools by the symbol or ID of the first asset in the pool
        * @param asset_symbol_or_id symbol name or ID of the asset
        * @param limit  The limitation of items each query can fetch, not greater than a configured value
        * @param start_id  Start liquidity pool id, fetch pools whose IDs are greater than or equal to this ID
+       * @param with_statistics Whether to return statistics
        * @return The liquidity pools
        *
        * @note
@@ -661,16 +665,18 @@ class database_api
        * 3. @p start_id can be omitted or be null, if so the api will return the "first page" of pools
        * 4. can only omit one or more arguments in the end of the list, but not one or more in the middle
        */
-      vector<liquidity_pool_object> get_liquidity_pools_by_asset_a(
+      vector<extended_liquidity_pool_object> get_liquidity_pools_by_asset_a(
             std::string asset_symbol_or_id,
             optional<uint32_t> limit = 101,
-            optional<liquidity_pool_id_type> start_id = optional<liquidity_pool_id_type>() )const;
+            optional<liquidity_pool_id_type> start_id = optional<liquidity_pool_id_type>(),
+            optional<bool> with_statistics = false )const;
 
       /**
        * @brief Get a list of liquidity pools by the symbol or ID of the second asset in the pool
        * @param asset_symbol_or_id symbol name or ID of the asset
        * @param limit  The limitation of items each query can fetch, not greater than a configured value
        * @param start_id  Start liquidity pool id, fetch pools whose IDs are greater than or equal to this ID
+       * @param with_statistics Whether to return statistics
        * @return The liquidity pools
        *
        * @note
@@ -679,10 +685,11 @@ class database_api
        * 3. @p start_id can be omitted or be null, if so the api will return the "first page" of pools
        * 4. can only omit one or more arguments in the end of the list, but not one or more in the middle
        */
-      vector<liquidity_pool_object> get_liquidity_pools_by_asset_b(
+      vector<extended_liquidity_pool_object> get_liquidity_pools_by_asset_b(
             std::string asset_symbol_or_id,
             optional<uint32_t> limit = 101,
-            optional<liquidity_pool_id_type> start_id = optional<liquidity_pool_id_type>() )const;
+            optional<liquidity_pool_id_type> start_id = optional<liquidity_pool_id_type>(),
+            optional<bool> with_statistics = false )const;
 
       /**
        * @brief Get a list of liquidity pools by the symbols or IDs of the two assets in the pool
@@ -690,6 +697,7 @@ class database_api
        * @param asset_symbol_or_id_b symbol name or ID of the other asset
        * @param limit  The limitation of items each query can fetch, not greater than a configured value
        * @param start_id  Start liquidity pool id, fetch pools whose IDs are greater than or equal to this ID
+       * @param with_statistics Whether to return statistics
        * @return The liquidity pools
        *
        * @note
@@ -699,11 +707,29 @@ class database_api
        * 3. @p start_id can be omitted or be null, if so the api will return the "first page" of pools
        * 4. can only omit one or more arguments in the end of the list, but not one or more in the middle
        */
-      vector<liquidity_pool_object> get_liquidity_pools_by_both_assets(
+      vector<extended_liquidity_pool_object> get_liquidity_pools_by_both_assets(
             std::string asset_symbol_or_id_a,
             std::string asset_symbol_or_id_b,
             optional<uint32_t> limit = 101,
-            optional<liquidity_pool_id_type> start_id = optional<liquidity_pool_id_type>() )const;
+            optional<liquidity_pool_id_type> start_id = optional<liquidity_pool_id_type>(),
+            optional<bool> with_statistics = false )const;
+
+      /**
+       * @brief Get a list of liquidity pools by their IDs
+       * @param ids IDs of the liquidity pools
+       * @param subscribe @a true to subscribe to the queried objects; @a false to not subscribe;
+       *                  @a null to subscribe or not subscribe according to current auto-subscription setting
+       *                  (see @ref set_auto_subscription)
+       * @param with_statistics Whether to return statistics
+       * @return The liquidity pools
+       *
+       * @note if an ID in the list can not be found,
+       *       the corresponding data in the returned list is null.
+       */
+      vector<optional<extended_liquidity_pool_object>> get_liquidity_pools(
+            const vector<liquidity_pool_id_type>& ids,
+            optional<bool> subscribe = optional<bool>(),
+            optional<bool> with_statistics = false )const;
 
       /**
        * @brief Get a list of liquidity pools by their share asset symbols or IDs
@@ -711,20 +737,23 @@ class database_api
        * @param subscribe @a true to subscribe to the queried objects; @a false to not subscribe;
        *                  @a null to subscribe or not subscribe according to current auto-subscription setting
        *                  (see @ref set_auto_subscription)
+       * @param with_statistics Whether to return statistics
        * @return The liquidity pools that the assets are for
        *
        * @note if an asset in the list can not be found or is not a share asset of any liquidity pool,
        *       the corresponding data in the returned list is null.
        */
-      vector<optional<liquidity_pool_object>> get_liquidity_pools_by_share_asset(
+      vector<optional<extended_liquidity_pool_object>> get_liquidity_pools_by_share_asset(
             const vector<std::string>& asset_symbols_or_ids,
-            optional<bool> subscribe = optional<bool>() )const;
+            optional<bool> subscribe = optional<bool>(),
+            optional<bool> with_statistics = false )const;
 
       /**
        * @brief Get a list of liquidity pools by the name or ID of the owner account
        * @param account_name_or_id name or ID of the owner account
        * @param limit  The limitation of items each query can fetch, not greater than a configured value
        * @param start_id  Start share asset id, fetch pools whose share asset IDs are greater than or equal to this ID
+       * @param with_statistics Whether to return statistics
        * @return The liquidity pools
        *
        * @note
@@ -733,10 +762,11 @@ class database_api
        * 3. @p start_id can be omitted or be null, if so the api will return the "first page" of pools
        * 4. can only omit one or more arguments in the end of the list, but not one or more in the middle
        */
-      vector<liquidity_pool_object> get_liquidity_pools_by_owner(
+      vector<extended_liquidity_pool_object> get_liquidity_pools_by_owner(
             std::string account_name_or_id,
             optional<uint32_t> limit = 101,
-            optional<asset_id_type> start_id = optional<asset_id_type>() )const;
+            optional<asset_id_type> start_id = optional<asset_id_type>(),
+            optional<bool> with_statistics = false )const;
 
       ///////////////
       // Witnesses //
@@ -1150,6 +1180,7 @@ FC_API(graphene::app::database_api,
    (get_liquidity_pools_by_asset_a)
    (get_liquidity_pools_by_asset_b)
    (get_liquidity_pools_by_both_assets)
+   (get_liquidity_pools)
    (get_liquidity_pools_by_share_asset)
    (get_liquidity_pools_by_owner)
 

--- a/libraries/chain/include/graphene/chain/liquidity_pool_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/liquidity_pool_evaluator.hpp
@@ -82,6 +82,8 @@ namespace graphene { namespace chain {
          const asset_dynamic_data_object* _share_asset_dyn_data = nullptr;
          asset _pool_pays_a;
          asset _pool_pays_b;
+         asset _fee_a;
+         asset _fee_b;
    };
 
    class liquidity_pool_exchange_evaluator : public evaluator<liquidity_pool_exchange_evaluator>
@@ -100,6 +102,7 @@ namespace graphene { namespace chain {
          asset _account_receives;
          asset _maker_market_fee;
          asset _taker_market_fee;
+         asset _pool_taker_fee;
    };
 
 } } // graphene::chain

--- a/libraries/chain/include/graphene/chain/liquidity_pool_object.hpp
+++ b/libraries/chain/include/graphene/chain/liquidity_pool_object.hpp
@@ -107,6 +107,15 @@ typedef generic_index<liquidity_pool_object, liquidity_pool_multi_index_type> li
 
 MAP_OBJECT_ID_TO_TYPE( graphene::chain::liquidity_pool_object )
 
-FC_REFLECT_TYPENAME( graphene::chain::liquidity_pool_object )
+FC_REFLECT_DERIVED( graphene::chain::liquidity_pool_object, (graphene::db::object),
+                    (asset_a)
+                    (asset_b)
+                    (balance_a)
+                    (balance_b)
+                    (share_asset)
+                    (taker_fee_percent)
+                    (withdrawal_fee_percent)
+                    (virtual_value)
+                  )
 
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::chain::liquidity_pool_object )

--- a/libraries/chain/liquidity_pool_evaluator.cpp
+++ b/libraries/chain/liquidity_pool_evaluator.cpp
@@ -241,6 +241,8 @@ void_result liquidity_pool_withdraw_evaluator::do_evaluate(const liquidity_pool_
    {
       _pool_pays_a = asset( _pool->balance_a, _pool->asset_a );
       _pool_pays_b = asset( _pool->balance_b, _pool->asset_b );
+      _fee_a = asset( 0, _pool->asset_a );
+      _fee_b = asset( 0, _pool->asset_b );
    }
    else
    {
@@ -258,6 +260,8 @@ void_result liquidity_pool_withdraw_evaluator::do_evaluate(const liquidity_pool_
       FC_ASSERT( a128 > 0 || b128 > 0, "Aborting due to zero outcome" );
       _pool_pays_a = asset( static_cast<int64_t>( a128 ), _pool->asset_a );
       _pool_pays_b = asset( static_cast<int64_t>( b128 ), _pool->asset_b );
+      _fee_a = asset( static_cast<int64_t>( fee_a ), _pool->asset_a );
+      _fee_b = asset( static_cast<int64_t>( fee_b ), _pool->asset_b );
    }
 
    return void_result();
@@ -292,6 +296,8 @@ generic_exchange_operation_result liquidity_pool_withdraw_evaluator::do_apply(
    result.paid.emplace_back( op.share_amount );
    result.received.emplace_back( _pool_pays_a );
    result.received.emplace_back( _pool_pays_b );
+   result.fees.emplace_back( _fee_a );
+   result.fees.emplace_back( _fee_b );
 
    return result;
 } FC_CAPTURE_AND_RETHROW( (op) ) }
@@ -354,6 +360,8 @@ void_result liquidity_pool_exchange_evaluator::do_evaluate(const liquidity_pool_
 
    FC_ASSERT( _account_receives.amount >= op.min_to_receive.amount, "Unable to exchange at expected price" );
 
+   _pool_taker_fee = asset( static_cast<int64_t>( pool_taker_fee ), op.min_to_receive.asset_id );
+
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (op) ) }
 
@@ -396,6 +404,7 @@ generic_exchange_operation_result liquidity_pool_exchange_evaluator::do_apply(
    result.received.emplace_back( _account_receives );
    result.fees.emplace_back( _maker_market_fee );
    result.fees.emplace_back( _taker_market_fee );
+   result.fees.emplace_back( _pool_taker_fee );
 
    return result;
 } FC_CAPTURE_AND_RETHROW( (op) ) }

--- a/libraries/chain/small_objects.cpp
+++ b/libraries/chain/small_objects.cpp
@@ -200,17 +200,6 @@ FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::custom_authority_object, (graph
                                (account)(enabled)(valid_from)(valid_to)(operation_type)
                                (auth)(restrictions)(restriction_counter) )
 
-FC_REFLECT_DERIVED_NO_TYPENAME( graphene::chain::liquidity_pool_object, (graphene::db::object),
-                    (asset_a)
-                    (asset_b)
-                    (balance_a)
-                    (balance_b)
-                    (share_asset)
-                    (taker_fee_percent)
-                    (withdrawal_fee_percent)
-                    (virtual_value)
-                  )
-
 
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::chain::balance_object )
 GRAPHENE_IMPLEMENT_EXTERNAL_SERIALIZATION( graphene::chain::block_summary_object )

--- a/libraries/plugins/market_history/include/graphene/market_history/market_history_plugin.hpp
+++ b/libraries/plugins/market_history/include/graphene/market_history/market_history_plugin.hpp
@@ -236,6 +236,8 @@ struct liquidity_pool_history_object : public abstract_object<liquidity_pool_his
 
 struct by_pool_seq;
 struct by_pool_time;
+struct by_pool_op_type_seq;
+struct by_pool_op_type_time;
 
 typedef multi_index_container<
    liquidity_pool_history_object,
@@ -259,6 +261,32 @@ typedef multi_index_container<
          >,
          composite_key_compare<
             std::less< liquidity_pool_id_type >,
+            std::greater< time_point_sec >,
+            std::greater< uint64_t >
+         >
+      >,
+      ordered_unique< tag<by_pool_op_type_seq>,
+         composite_key< liquidity_pool_history_object,
+            member<liquidity_pool_history_object, liquidity_pool_id_type, &liquidity_pool_history_object::pool>,
+            member<liquidity_pool_history_object, int64_t, &liquidity_pool_history_object::op_type>,
+            member<liquidity_pool_history_object, uint64_t, &liquidity_pool_history_object::sequence>
+         >,
+         composite_key_compare<
+            std::less< liquidity_pool_id_type >,
+            std::less< int64_t >,
+            std::greater< uint64_t >
+         >
+      >,
+      ordered_unique< tag<by_pool_op_type_time>,
+         composite_key< liquidity_pool_history_object,
+            member<liquidity_pool_history_object, liquidity_pool_id_type, &liquidity_pool_history_object::pool>,
+            member<liquidity_pool_history_object, int64_t, &liquidity_pool_history_object::op_type>,
+            member<liquidity_pool_history_object, time_point_sec, &liquidity_pool_history_object::time>,
+            member<liquidity_pool_history_object, uint64_t, &liquidity_pool_history_object::sequence>
+         >,
+         composite_key_compare<
+            std::less< liquidity_pool_id_type >,
+            std::less< int64_t >,
             std::greater< time_point_sec >,
             std::greater< uint64_t >
          >

--- a/tests/common/database_fixture.hpp
+++ b/tests/common/database_fixture.hpp
@@ -458,7 +458,6 @@ struct database_fixture {
 
    vector< operation_history_object > get_operation_history( account_id_type account_id )const;
    vector< graphene::market_history::order_history_object > get_market_order_history( asset_id_type a, asset_id_type b )const;
-   bool validation_current_test_name_for_setting_api_limit( const string& current_test_name )const;
 
    /****
     * @brief return htlc fee parameters

--- a/tests/tests/api_limit_tests.cpp
+++ b/tests/tests/api_limit_tests.cpp
@@ -42,7 +42,9 @@ BOOST_AUTO_TEST_CASE( api_limit_get_key_references ){
    vector< public_key_type >  numbered_key_id;
    numbered_private_keys.reserve( num_keys );
 
-   graphene::app::database_api db_api1( db, &( app.get_options() ));
+   graphene::app::application_options opt1 = app.get_options();
+   opt1.has_api_helper_indexes_plugin = false;
+   graphene::app::database_api db_api1( db, &opt1 );
    BOOST_CHECK_THROW( db_api1.get_key_references(numbered_key_id), fc::exception );
 
    graphene::app::application_options opt = app.get_options();

--- a/tests/tests/liquidity_pool_tests.cpp
+++ b/tests/tests/liquidity_pool_tests.cpp
@@ -669,6 +669,20 @@ BOOST_AUTO_TEST_CASE( deposit_withdrawal_test )
 
       generate_block();
 
+      graphene::market_history::liquidity_pool_ticker_id_type ticker_id( lp_id.instance );
+      const auto& ticker = db.get< graphene::market_history::liquidity_pool_ticker_object >( ticker_id );
+      BOOST_CHECK_EQUAL( ticker._24h_deposit_count, 7u );
+      BOOST_CHECK_EQUAL( ticker.total_deposit_count, 7u );
+      BOOST_CHECK_EQUAL( ticker._24h_withdrawal_count, 2u );
+      BOOST_CHECK_EQUAL( ticker.total_withdrawal_count, 2u );
+
+      generate_blocks( db.head_block_time() + fc::days(2) );
+
+      BOOST_CHECK_EQUAL( ticker._24h_deposit_count, 0u );
+      BOOST_CHECK_EQUAL( ticker.total_deposit_count, 7u );
+      BOOST_CHECK_EQUAL( ticker._24h_withdrawal_count, 0u );
+      BOOST_CHECK_EQUAL( ticker.total_withdrawal_count, 2u );
+
    } catch (fc::exception& e) {
       edump((e.to_detail_string()));
       throw;
@@ -899,6 +913,21 @@ BOOST_AUTO_TEST_CASE( exchange_test )
 
       // Generates a block
       generate_block();
+      BOOST_CHECK_EQUAL( eur_id(db).dynamic_data(db).accumulated_fees.value, expected_accumulated_fees_eur );
+
+      graphene::market_history::liquidity_pool_ticker_id_type ticker_id( lp_id.instance );
+      const auto& ticker = db.get< graphene::market_history::liquidity_pool_ticker_object >( ticker_id );
+      BOOST_CHECK_EQUAL( ticker._24h_exchange_a2b_count, 1u );
+      BOOST_CHECK_EQUAL( ticker.total_exchange_a2b_count, 1u );
+      BOOST_CHECK_EQUAL( ticker._24h_exchange_b2a_count, 1u );
+      BOOST_CHECK_EQUAL( ticker.total_exchange_b2a_count, 1u );
+
+      generate_blocks( db.head_block_time() + fc::days(2) );
+
+      BOOST_CHECK_EQUAL( ticker._24h_exchange_a2b_count, 0u );
+      BOOST_CHECK_EQUAL( ticker.total_exchange_a2b_count, 1u );
+      BOOST_CHECK_EQUAL( ticker._24h_exchange_b2a_count, 0u );
+      BOOST_CHECK_EQUAL( ticker.total_exchange_b2a_count, 1u );
 
    } catch (fc::exception& e) {
       edump((e.to_detail_string()));

--- a/tests/tests/liquidity_pool_tests.cpp
+++ b/tests/tests/liquidity_pool_tests.cpp
@@ -513,7 +513,9 @@ BOOST_AUTO_TEST_CASE( deposit_withdrawal_test )
       BOOST_REQUIRE_EQUAL( result.received.size(), 2u );
       BOOST_CHECK( result.received.front() == asset( -new_a, eur_id ) );
       BOOST_CHECK( result.received.back() == asset( -new_b, usd_id ) );
-      BOOST_REQUIRE_EQUAL( result.fees.size(), 0u );
+      BOOST_REQUIRE_EQUAL( result.fees.size(), 2u );
+      BOOST_CHECK( result.fees.front() == asset( 2, eur_id ) );
+      BOOST_CHECK( result.fees.back() == asset( 2, usd_id ) );
 
       expected_pool_balance_a += new_a; // 25789 - 68 = 25721
       expected_pool_balance_b += new_b; // 30946 - 83 = 30863
@@ -549,7 +551,9 @@ BOOST_AUTO_TEST_CASE( deposit_withdrawal_test )
       BOOST_REQUIRE_EQUAL( result.received.size(), 2u );
       BOOST_CHECK( result.received.front() == asset( -new_a, eur_id ) );
       BOOST_CHECK( result.received.back() == asset( -new_b, usd_id ) );
-      BOOST_REQUIRE_EQUAL( result.fees.size(), 0u );
+      BOOST_REQUIRE_EQUAL( result.fees.size(), 2u );
+      BOOST_CHECK( result.fees.front() == asset( 0, eur_id ) );
+      BOOST_CHECK( result.fees.back() == asset( 0, usd_id ) );
 
       expected_pool_balance_a = 0;
       expected_pool_balance_b = 0;
@@ -816,6 +820,7 @@ BOOST_AUTO_TEST_CASE( exchange_test )
       int64_t delta_a = 998; // 1000 - 2
       // tmp_delta = 1200 - round_up( 1000 * 1200 / (1000+998) ) = 1200 - 601 = 599
       int64_t delta_b = -588; // - ( 599 - round_down(599 * 2%) ) = - ( 599 - 11 ) = -588
+      int64_t pool_taker_fee = 11;
       int64_t taker_fee = 4; // 588 * 0.8%, usd
       int64_t ted_receives = 584; // 588 - 4
 
@@ -830,9 +835,10 @@ BOOST_AUTO_TEST_CASE( exchange_test )
       BOOST_CHECK( result.paid.front() == asset( 1000, eur_id ) );
       BOOST_REQUIRE_EQUAL( result.received.size(), 1u );
       BOOST_CHECK( result.received.front() == asset( ted_receives, usd_id ) );
-      BOOST_REQUIRE_EQUAL( result.fees.size(), 2u );
+      BOOST_REQUIRE_EQUAL( result.fees.size(), 3u );
       BOOST_CHECK( result.fees.front() == asset( maker_fee, eur_id ) );
-      BOOST_CHECK( result.fees.back() == asset( taker_fee, usd_id ) );
+      BOOST_CHECK( result.fees.at(1) == asset( taker_fee, usd_id ) );
+      BOOST_CHECK( result.fees.back() == asset( pool_taker_fee, usd_id ) );
 
       expected_pool_balance_a += delta_a; // 1000 + 998 = 1998
       expected_pool_balance_b += delta_b; // 1200 - 588 = 612
@@ -855,6 +861,7 @@ BOOST_AUTO_TEST_CASE( exchange_test )
       delta_b = 997; // 1000 - 3
       // tmp_delta = 1998 - round_up( 1998 * 612 / (612+997) ) = 1998 - 760 = 1238
       delta_a = -1214; // - ( 1238 - round_down(1238 * 2%) ) = - ( 1238 - 24 ) = -1214
+      pool_taker_fee = 24;
       taker_fee = 6; // 1214 * 0.5%, eur
       ted_receives = 1208; // 1214 - 6
 
@@ -869,9 +876,10 @@ BOOST_AUTO_TEST_CASE( exchange_test )
       BOOST_CHECK( result.paid.front() == asset( 1000, usd_id ) );
       BOOST_REQUIRE_EQUAL( result.received.size(), 1u );
       BOOST_CHECK( result.received.front() == asset( ted_receives, eur_id ) );
-      BOOST_REQUIRE_EQUAL( result.fees.size(), 2u );
+      BOOST_REQUIRE_EQUAL( result.fees.size(), 3u );
       BOOST_CHECK( result.fees.front() == asset( maker_fee, usd_id ) );
-      BOOST_CHECK( result.fees.back() == asset( taker_fee, eur_id ) );
+      BOOST_CHECK( result.fees.at(1) == asset( taker_fee, eur_id ) );
+      BOOST_CHECK( result.fees.back() == asset( pool_taker_fee, eur_id ) );
 
       expected_pool_balance_a += delta_a; // 1998 - 1214 = 784
       expected_pool_balance_b += delta_b; // 612 + 997 = 1609

--- a/tests/tests/liquidity_pool_tests.cpp
+++ b/tests/tests/liquidity_pool_tests.cpp
@@ -940,7 +940,6 @@ BOOST_AUTO_TEST_CASE( liquidity_pool_exchange_test )
       BOOST_REQUIRE( pools.front()->statistics.valid() );
       BOOST_CHECK( pools.front()->statistics->id == ticker_id );
       BOOST_CHECK_EQUAL( pools.front()->statistics->_24h_exchange_a2b_count, 1u );
-      BOOST_CHECK_EQUAL( pools.front()->statistics->_24h_exchange_a2b_count, 1u );
       BOOST_CHECK_EQUAL( pools.front()->statistics->total_exchange_a2b_count, 1u );
       BOOST_CHECK_EQUAL( pools.front()->statistics->_24h_exchange_b2a_count, 1u );
       BOOST_CHECK_EQUAL( pools.front()->statistics->total_exchange_b2a_count, 1u );

--- a/tests/tests/liquidity_pool_tests.cpp
+++ b/tests/tests/liquidity_pool_tests.cpp
@@ -924,6 +924,27 @@ BOOST_AUTO_TEST_CASE( liquidity_pool_exchange_test )
       BOOST_CHECK_EQUAL( ticker._24h_exchange_b2a_count, 1u );
       BOOST_CHECK_EQUAL( ticker.total_exchange_b2a_count, 1u );
 
+      // Check database API
+      graphene::app::database_api db_api( db, &( app.get_options() ) );
+
+      // get pool without statistics
+      auto pools = db_api.get_liquidity_pools( { lp_id } );
+      BOOST_REQUIRE_EQUAL( pools.size(), 1u );
+      BOOST_REQUIRE( pools.front().valid() );
+      BOOST_CHECK( !pools.front()->statistics.valid() );
+
+      // get pool with statistics
+      pools = db_api.get_liquidity_pools( { lp_id }, {}, true );
+      BOOST_REQUIRE_EQUAL( pools.size(), 1u );
+      BOOST_REQUIRE( pools.front().valid() );
+      BOOST_REQUIRE( pools.front()->statistics.valid() );
+      BOOST_CHECK( pools.front()->statistics->id == ticker_id );
+      BOOST_CHECK_EQUAL( pools.front()->statistics->_24h_exchange_a2b_count, 1u );
+      BOOST_CHECK_EQUAL( pools.front()->statistics->_24h_exchange_a2b_count, 1u );
+      BOOST_CHECK_EQUAL( pools.front()->statistics->total_exchange_a2b_count, 1u );
+      BOOST_CHECK_EQUAL( pools.front()->statistics->_24h_exchange_b2a_count, 1u );
+      BOOST_CHECK_EQUAL( pools.front()->statistics->total_exchange_b2a_count, 1u );
+
       generate_blocks( db.head_block_time() + fc::days(2) );
 
       BOOST_CHECK_EQUAL( ticker._24h_exchange_a2b_count, 0u );


### PR DESCRIPTION
For issue #2280.

* Added some liquidity pool statistics in market history plugin
* Extended existing liquidity pool APIs with an optional `with_statistics` parameter
  * `list_liquidity_pools( limit, start_pool_id, with_statistics ) `
  * `get_liquidity_pools_by_asset_a( asset, limit, start_pool_id, with_statistics )`
  * `get_liquidity_pools_by_asset_b( asset, limit, start_pool_id, with_statistics )`
  * `get_liquidity_pools_by_both_assets( asset_a, asset_b, limit, start_pool_id, with_statistics )`
  * `get_liquidity_pools_by_share_asset( assets_vector, subscribe, with_statistics )`
  * `get_liquidity_pools_by_owner( account, limit, start_share_asset_id, with_statistics )`
* Added a new database API
  * `get_liquidity_pools( pool_IDs, subscribe, with_statistics )`
* Added history APIs
  * `history_api::get_liquidity_pool_history( pool_id, start_time, stop_time, limit, operation_type )`
  * `history_api::get_liquidity_pool_history_by_sequence( pool_id, start_sequence, stop_time, limit, operation_type )`
