### PR TITLE
Split sonar-scanning into 3 steps, and fix macOS build for Github Autobuild

### DIFF
--- a/.github/workflows/build-and-test.mac.yml
+++ b/.github/workflows/build-and-test.mac.yml
@@ -12,8 +12,7 @@ jobs:
       run: |
         brew install autoconf automake libtool
         brew install ccache
-        brew search boost
-        brew install bitshares/boost160/boost@1.60
+        brew install bitshares/boost/boost@1.69
     - uses: actions/checkout@v2
       with:
         submodules: recursive
@@ -24,7 +23,7 @@ jobs:
         cmake -D CMAKE_BUILD_TYPE=Release \
               -D CMAKE_C_COMPILER_LAUNCHER=ccache \
               -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
-              -D BOOST_ROOT=/usr/local/opt/boost@1.60 \
+              -D BOOST_ROOT=/usr/local/opt/boost@1.69 \
               -D OPENSSL_ROOT_DIR=/usr/local/opt/openssl \
               ..
     - name: Load Cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,5 @@ jobs:
       script: ./programs/build_helpers/scan_with_sonar_step_1
     - stage: scan with sonar, step 2
       script: ./programs/build_helpers/scan_with_sonar_step_2
+    - stage: scan with sonar, step 3
+      script: ./programs/build_helpers/scan_with_sonar_step_3

--- a/programs/build_helpers/build_and_test
+++ b/programs/build_helpers/build_and_test
@@ -8,8 +8,8 @@ programs/build_helpers/buildstep cmake 5 "cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE
 programs/build_helpers/buildstep make.some.targets 2400 "make -j 2 witness_node cli_wallet chain_test cli_test js_operation_serializer get_dev_key network_mapper"
 programs/build_helpers/buildstep make.others 600 "make"
 set -o pipefail
-programs/build_helpers/buildstep run.chain_test 600 "libraries/fc/tests/run-parallel-tests.sh tests/chain_test -l message"
-programs/build_helpers/buildstep run.cli_test 180 "libraries/fc/tests/run-parallel-tests.sh tests/cli_test -l message"
+programs/build_helpers/buildstep run.chain_test 300 "libraries/fc/tests/run-parallel-tests.sh tests/chain_test -l message"
+programs/build_helpers/buildstep run.cli_test 120 "libraries/fc/tests/run-parallel-tests.sh tests/cli_test -l message"
 programs/build_helpers/buildstep end 0
 ccache -s
 

--- a/programs/build_helpers/scan_with_sonar_step_1
+++ b/programs/build_helpers/scan_with_sonar_step_1
@@ -12,7 +12,7 @@ du -hs sonar_cache
 # The first pass, skip some files. This will remove the skipped files from the cache, but is an acceptable trade-off
 programs/build_helpers/buildstep prepare.sonar.part1 1 "cp sonar-project.properties sonar-project.properties.bak; sed -i '/sonar\.exclusions=/d;s/#sonar\.exclusions.part1/sonar.exclusions/' sonar-project.properties"
 programs/build_helpers/buildstep run.sonar.part1 1500 "which sonar-scanner && sonar-scanner"
-programs/build_helpers/buildstep prepare.sonar.full 1 "cp sonar-project.properties.bak sonar-project.properties"
+programs/build_helpers/buildstep post.sonar.part1 1 "cp sonar-project.properties.bak sonar-project.properties"
 du -hs sonar_cache
 programs/build_helpers/buildstep end 0
 ccache -s

--- a/programs/build_helpers/scan_with_sonar_step_3
+++ b/programs/build_helpers/scan_with_sonar_step_3
@@ -7,17 +7,19 @@ programs/build_helpers/buildstep Prepare 1 "sed -i '/tests/d' libraries/fc/CMake
 programs/build_helpers/buildstep cmake 5 "cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS=--coverage -DCMAKE_CXX_FLAGS=--coverage -DBoost_USE_STATIC_LIBS=OFF -DCMAKE_CXX_OUTPUT_EXTENSION_REPLACE=ON ."
 programs/build_helpers/buildstep make.programs 1800 "programs/build_helpers/make_with_sonar bw-output -j 2 witness_node cli_wallet js_operation_serializer get_dev_key network_mapper app_test chain_test cli_test"
 set -o pipefail
+programs/build_helpers/buildstep run.chain_test 300 "libraries/fc/tests/run-parallel-tests.sh tests/chain_test -l message"
+programs/build_helpers/buildstep run.cli_test 120 "libraries/fc/tests/run-parallel-tests.sh tests/cli_test -l message"
+programs/build_helpers/buildstep run.app_test 120 "tests/app_test -l message"
 programs/build_helpers/buildstep prepare.sonar 20 "find libraries/[acdenptuw]*/CMakeFiles/*.dir programs/[cdgjsw]*/CMakeFiles/*.dir -type d -print | while read d; do gcov -o \"\$d\" \"\${d/CMakeFiles*.dir//}\"/*.cpp; done >/dev/null; programs/build_helpers/set_sonar_branch sonar-project.properties"
 du -hs sonar_cache
-# The first pass, skip some files. This will remove the skipped files from the cache, but is an acceptable trade-off
-programs/build_helpers/buildstep prepare.sonar.part1 1 "cp sonar-project.properties sonar-project.properties.bak; sed -i '/sonar\.exclusions=/d;s/#sonar\.exclusions.part1/sonar.exclusions/' sonar-project.properties"
-programs/build_helpers/buildstep run.sonar.part1 1500 "which sonar-scanner && sonar-scanner"
-programs/build_helpers/buildstep post.sonar.part1 1 "cp sonar-project.properties.bak sonar-project.properties"
-du -hs sonar_cache
-# The second pass, scan more files
+# The first pass is skipped here.
+# The second pass, scan some files.
 programs/build_helpers/buildstep prepare.sonar.part2 1 "cp sonar-project.properties sonar-project.properties.bak; sed -i '/sonar\.exclusions=/d;s/#sonar\.exclusions.part2/sonar.exclusions/' sonar-project.properties"
 programs/build_helpers/buildstep run.sonar.part2 1200 "which sonar-scanner && sonar-scanner"
 programs/build_helpers/buildstep post.sonar.part2 1 "cp sonar-project.properties.bak sonar-project.properties"
+du -hs sonar_cache
+# The third pass, scan all files
+programs/build_helpers/buildstep run.sonar.full 1200 "which sonar-scanner && sonar-scanner"
 du -hs sonar_cache
 programs/build_helpers/buildstep end 0
 ccache -s

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,6 +9,7 @@ sonar.links.scm=https://github.com/bitshares/bitshares-core/tree/master
 sonar.tests=tests
 # Used by the `build_and_test` script for the first pass when building with Travis CI, to skip some files
 #sonar.exclusions.part1=programs/build_helper/**/*,libraries/fc/**/*,libraries/egenesis/egenesis_full.cpp,libraries/chain/**/*.cpp,libraries/protocol/**/*.cpp
+#sonar.exclusions.part2=programs/build_helper/**/*,libraries/fc/**/*,libraries/egenesis/egenesis_full.cpp,libraries/chain/**/*.cpp
 sonar.exclusions=programs/build_helper/**/*,libraries/fc/**/*,libraries/egenesis/egenesis_full.cpp
 sonar.sources=libraries,programs
 sonar.cfamily.build-wrapper-output=bw-output


### PR DESCRIPTION
Fix Travis CI timeout issue occurred on https://github.com/bitshares/bitshares-core/pull/2297. Follow-up of https://github.com/bitshares/bitshares-core/pull/2294.

Fix macOS build for Github Autobuild by using boost 1.69.