### PR TITLE
Use boost 1.69 for Github Autobuild macOS build

### DIFF
--- a/.github/workflows/build-and-test.mac.yml
+++ b/.github/workflows/build-and-test.mac.yml
@@ -12,8 +12,7 @@ jobs:
       run: |
         brew install autoconf automake libtool
         brew install ccache
-        brew search boost
-        brew install bitshares/boost160/boost@1.60
+        brew install bitshares/boost/boost@1.69
     - uses: actions/checkout@v2
       with:
         submodules: recursive
@@ -24,7 +23,7 @@ jobs:
         cmake -D CMAKE_BUILD_TYPE=Release \
               -D CMAKE_C_COMPILER_LAUNCHER=ccache \
               -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
-              -D BOOST_ROOT=/usr/local/opt/boost@1.60 \
+              -D BOOST_ROOT=/usr/local/opt/boost@1.69 \
               -D OPENSSL_ROOT_DIR=/usr/local/opt/openssl \
               ..
     - name: Load Cache


### PR DESCRIPTION
Fix macOS build (https://github.com/bitshares/bitshares-core/runs/1338299889?check_suite_focus=true).