### PR TITLE
Update README to use the Travis-CI.com badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ BitShares Core
 
 [Build Status](https://travis-ci.com/bitshares/bitshares-core/branches):
 
-`master` | `develop` | `hardfork` | `testnet` | `bitshares-fc` 
+`master` | `develop` | `hardfork` | `testnet` | `bitshares-fc`
  --- | --- | --- | --- | ---
- [![](https://travis-ci.com/bitshares/bitshares-core.svg?branch=master)](https://travis-ci.com/bitshares/bitshares-core) | [![](https://travis-ci.com/bitshares/bitshares-core.svg?branch=develop)](https://travis-ci.com/bitshares/bitshares-core) | [![](https://travis-ci.com/bitshares/bitshares-core.svg?branch=hardfork)](https://travis-ci.com/bitshares/bitshares-core) | [![](https://travis-ci.com/bitshares/bitshares-core.svg?branch=testnet)](https://travis-ci.com/bitshares/bitshares-core) | [![](https://travis-ci.com/bitshares/bitshares-fc.svg?branch=master)](https://travis-ci.com/bitshares/bitshares-fc) 
+ [![](https://travis-ci.com/bitshares/bitshares-core.svg?branch=master)](https://travis-ci.com/bitshares/bitshares-core) | [![](https://travis-ci.com/bitshares/bitshares-core.svg?branch=develop)](https://travis-ci.com/bitshares/bitshares-core) | [![](https://travis-ci.com/bitshares/bitshares-core.svg?branch=hardfork)](https://travis-ci.com/bitshares/bitshares-core) | [![](https://travis-ci.com/bitshares/bitshares-core.svg?branch=testnet)](https://travis-ci.com/bitshares/bitshares-core) | [![](https://travis-ci.com/bitshares/bitshares-fc.svg?branch=master)](https://travis-ci.com/bitshares/bitshares-fc)
  [![](https://github.com/bitshares/bitshares-core/workflows/Github%20Autobuild/badge.svg?branch=master)](https://github.com/bitshares/bitshares-core/actions?query=branch%3Amaster) | [![](https://github.com/bitshares/bitshares-core/workflows/Github%20Autobuild/badge.svg?branch=develop)](https://github.com/bitshares/bitshares-core/actions?query=branch%3Adevelop) | [![](https://github.com/bitshares/bitshares-core/workflows/Github%20Autobuild/badge.svg?branch=hardfork)](https://github.com/bitshares/bitshares-core/actions?query=branch%3Ahardfork) | [![](https://github.com/bitshares/bitshares-core/workflows/Github%20Autobuild/badge.svg?branch=testnet)](https://github.com/bitshares/bitshares-core/actions?query=branch%3Atestnet) | [![](https://github.com/bitshares/bitshares-fc/workflows/Github%20Autobuild/badge.svg?branch=master)](https://github.com/bitshares/bitshares-fc/actions?query=branch%3Amaster)
 
 * [Getting Started](#getting-started)
@@ -30,7 +30,7 @@ Build instructions and additional documentation are available in the
 
 ### Build
 
-We recommend building on Ubuntu 16.04 LTS (64-bit) 
+We recommend building on Ubuntu 16.04 LTS (64-bit)
 
 **Build Dependencies:**
 
@@ -66,7 +66,7 @@ We recommend building on Ubuntu 16.04 LTS (64-bit)
   * Windows (various versions, Visual Studio and MinGW)
   * OpenBSD (various versions)
 
-* BitShares requires [Boost](http://www.boost.org/) libraries to build, supports version `1.58` to `1.69`.
+* BitShares requires [Boost](https://www.boost.org/) libraries to build, supports version `1.58` to `1.69`.
 Newer versions may work, but have not been tested.
 If your system came pre-installed with a version of Boost libraries that you do not wish to use, you may
 manually build your preferred version and use it with BitShares by specifying it on the CMake command line.
@@ -171,7 +171,7 @@ Use `gethelp <COMMAND>` to see more info about individual commands. E.G.
 
     >>> gethelp get_order_book
 
-The definition of all commands is available in the 
+The definition of all commands is available in the
 [wallet.hpp](https://github.com/bitshares/bitshares-core/blob/master/libraries/wallet/include/graphene/wallet/wallet.hpp) souce code file.
 Corresponding documentation can be found in the [Doxygen documentation](https://doxygen.bitshares.org/classgraphene_1_1wallet_1_1wallet__api.html).
 
@@ -327,7 +327,7 @@ FAQ
 - Is there a way to access methods which require login over HTTP?
 
     Yes. Most of the methods can be accessed by specifying the API name instead of an API ID. If an API is protected by a username and a password, it can be accessed by using *basic access authentication*. Please check the ["Accessing restrictable node API's"](#accessing-restrictable-node-apis) section for more info.
-    
+
     However, HTTP is not really designed for "server push" notifications, and we would have to figure out a way to queue notifications for a polling client. Websockets solves this problem. If you need to access the stateful methods, use Websockets.
 
 - What is the meaning of `a.b.c` numbers?
@@ -370,7 +370,7 @@ FAQ
     less fine if your `witness_node` allows the general public to control which p2p nodes it's
     connecting to.  Therefore the API to add p2p connections needs to be set up with proper access
     controls.
- 
+
 License
 -------
 BitShares Core is under the MIT license. See [LICENSE](https://github.com/bitshares/bitshares-core/blob/master/LICENSE.txt)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 BitShares Core
 ==============
 
-[Build Status](https://travis-ci.org/bitshares/bitshares-core/branches):
+[Build Status](https://travis-ci.com/bitshares/bitshares-core/branches):
 
 `master` | `develop` | `hardfork` | `testnet` | `bitshares-fc` 
  --- | --- | --- | --- | ---
- [![](https://travis-ci.org/bitshares/bitshares-core.svg?branch=master)](https://travis-ci.org/bitshares/bitshares-core) | [![](https://travis-ci.org/bitshares/bitshares-core.svg?branch=develop)](https://travis-ci.org/bitshares/bitshares-core) | [![](https://travis-ci.org/bitshares/bitshares-core.svg?branch=hardfork)](https://travis-ci.org/bitshares/bitshares-core) | [![](https://travis-ci.org/bitshares/bitshares-core.svg?branch=testnet)](https://travis-ci.org/bitshares/bitshares-core) | [![](https://travis-ci.org/bitshares/bitshares-fc.svg?branch=master)](https://travis-ci.org/bitshares/bitshares-fc) 
+ [![](https://travis-ci.com/bitshares/bitshares-core.svg?branch=master)](https://travis-ci.com/bitshares/bitshares-core) | [![](https://travis-ci.com/bitshares/bitshares-core.svg?branch=develop)](https://travis-ci.com/bitshares/bitshares-core) | [![](https://travis-ci.com/bitshares/bitshares-core.svg?branch=hardfork)](https://travis-ci.com/bitshares/bitshares-core) | [![](https://travis-ci.com/bitshares/bitshares-core.svg?branch=testnet)](https://travis-ci.com/bitshares/bitshares-core) | [![](https://travis-ci.com/bitshares/bitshares-fc.svg?branch=master)](https://travis-ci.com/bitshares/bitshares-fc) 
  [![](https://github.com/bitshares/bitshares-core/workflows/Github%20Autobuild/badge.svg?branch=master)](https://github.com/bitshares/bitshares-core/actions?query=branch%3Amaster) | [![](https://github.com/bitshares/bitshares-core/workflows/Github%20Autobuild/badge.svg?branch=develop)](https://github.com/bitshares/bitshares-core/actions?query=branch%3Adevelop) | [![](https://github.com/bitshares/bitshares-core/workflows/Github%20Autobuild/badge.svg?branch=hardfork)](https://github.com/bitshares/bitshares-core/actions?query=branch%3Ahardfork) | [![](https://github.com/bitshares/bitshares-core/workflows/Github%20Autobuild/badge.svg?branch=testnet)](https://github.com/bitshares/bitshares-core/actions?query=branch%3Atestnet) | [![](https://github.com/bitshares/bitshares-fc/workflows/Github%20Autobuild/badge.svg?branch=master)](https://github.com/bitshares/bitshares-fc/actions?query=branch%3Amaster)
 
 * [Getting Started](#getting-started)


### PR DESCRIPTION
Note: the migration has been done except the badges. PR for #2312.

TODO: bump FC to include https://github.com/bitshares/bitshares-fc/pull/213.