### PR TITLE
Fix Doxygen warnings, remove some unused code

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -758,7 +758,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = README.md doc/main.dox libraries
+INPUT                  = README.md libraries
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1558,7 +1558,7 @@ EXTRA_SEARCH_MAPPINGS  =
 # If the GENERATE_LATEX tag is set to YES, doxygen will generate LaTeX output.
 # The default value is: YES.
 
-GENERATE_LATEX         = YES
+GENERATE_LATEX         = NO
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of

--- a/libraries/app/application_impl.hxx
+++ b/libraries/app/application_impl.hxx
@@ -56,7 +56,9 @@ class application_impl : public net::node_delegate
       /**
        * @brief allows the application to validate an item prior to broadcasting to peers.
        *
+       * @param blk_msg the message which contains the block
        * @param sync_mode true if the message was fetched through the sync process, false during normal operation
+       * @param contained_transaction_message_ids container for the transactions to write back into
        * @returns true if this message caused the blockchain to switch forks, false if it did not
        *
        * @throws exception if error validating the item, otherwise the item is safe to broadcast on.

--- a/libraries/app/include/graphene/app/api.hpp
+++ b/libraries/app/include/graphene/app/api.hpp
@@ -127,14 +127,14 @@ namespace graphene { namespace app {
 
          /**
           * @brief Get operations relevant to the specificed account
-          * @param account_id_or_name The account ID or name whose history should be queried
+          * @param account_name_or_id The account name or ID whose history should be queried
           * @param stop ID of the earliest operation to retrieve
           * @param limit Maximum number of operations to retrieve (must not exceed 100)
           * @param start ID of the most recent operation to retrieve
           * @return A list of operations performed by account, ordered from most recent to oldest.
           */
          vector<operation_history_object> get_account_history(
-            const std::string account_id_or_name,
+            const std::string account_name_or_id,
             operation_history_id_type stop = operation_history_id_type(),
             unsigned limit = 100,
             operation_history_id_type start = operation_history_id_type()
@@ -142,7 +142,7 @@ namespace graphene { namespace app {
 
          /**
           * @brief Get operations relevant to the specified account filtering by operation type
-          * @param account_id_or_name The account ID or name whose history should be queried
+          * @param account_name_or_id The account name or ID whose history should be queried
           * @param operation_types The IDs of the operation we want to get operations in the account
           * ( 0 = transfer , 1 = limit order create, ...)
           * @param start the sequence number where to start looping back throw the history
@@ -150,7 +150,7 @@ namespace graphene { namespace app {
           * @return history_operation_detail
           */
          history_operation_detail get_account_history_by_operations(
-            const std::string account_id_or_name,
+            const std::string account_name_or_id,
             flat_set<uint16_t> operation_types,
             uint32_t start,
             unsigned limit
@@ -158,7 +158,7 @@ namespace graphene { namespace app {
 
          /**
           * @brief Get only asked operations relevant to the specified account
-          * @param account_id_or_name The account ID or name whose history should be queried
+          * @param account_name_or_id The account name or ID whose history should be queried
           * @param operation_type The type of the operation we want to get operations in the account
           * ( 0 = transfer , 1 = limit order create, ...)
           * @param stop ID of the earliest operation to retrieve
@@ -167,7 +167,7 @@ namespace graphene { namespace app {
           * @return A list of operations performed by account, ordered from most recent to oldest.
           */
          vector<operation_history_object> get_account_history_operations(
-            const std::string account_id_or_name,
+            const std::string account_name_or_id,
             int operation_type,
             operation_history_id_type start = operation_history_id_type(),
             operation_history_id_type stop = operation_history_id_type(),
@@ -178,7 +178,7 @@ namespace graphene { namespace app {
           * @brief Get operations relevant to the specified account referenced
           * by an event numbering specific to the account. The current number of operations
           * for the account can be found in the account statistics (or use 0 for start).
-          * @param account_id_or_name The account ID or name whose history should be queried
+          * @param account_name_or_id The account name or ID whose history should be queried
           * @param stop Sequence number of earliest operation. 0 is default and will
           * query 'limit' number of operations.
           * @param limit Maximum number of operations to retrieve (must not exceed 100)
@@ -186,7 +186,7 @@ namespace graphene { namespace app {
           * 0 is default, which will start querying from the most recent operation.
           * @return A list of operations performed by account, ordered from most recent to oldest.
           */
-         vector<operation_history_object> get_relative_account_history( const std::string account_id_or_name,
+         vector<operation_history_object> get_relative_account_history( const std::string account_name_or_id,
                                                                         uint64_t stop = 0,
                                                                         unsigned limit = 100,
                                                                         uint64_t start = 0) const;
@@ -562,8 +562,8 @@ namespace graphene { namespace app {
          /**
           * @brief Get grouped limit orders in given market.
           *
-          * @param base_asset ID or symbol of asset being sold
-          * @param quote_asset ID or symbol of asset being purchased
+          * @param base_asset symbol or ID of asset being sold
+          * @param quote_asset symbol or ID of asset being purchased
           * @param group Maximum price diff within each order group, have to be one of configured values
           * @param start Optional price to indicate the first order group to retrieve
           * @param limit Maximum number of order groups to retrieve (must not exceed 101)
@@ -593,12 +593,12 @@ namespace graphene { namespace app {
          /**
           * @brief Get all stored objects of an account in a particular catalog
           *
-          * @param account The account ID or name to get info from
+          * @param account_name_or_id The account name or ID to get info from
           * @param catalog Category classification. Each account can store multiple catalogs.
           *
           * @return The vector of objects of the account or empty
           */
-         vector<account_storage_object> get_storage_info(std::string account_id_or_name, std::string catalog)const;
+         vector<account_storage_object> get_storage_info(std::string account_name_or_id, std::string catalog)const;
 
    private:
          application& _app;

--- a/libraries/app/include/graphene/app/api_objects.hpp
+++ b/libraries/app/include/graphene/app/api_objects.hpp
@@ -191,18 +191,18 @@ FC_REFLECT( graphene::app::full_account,
             (more_data_available)
           )
 
-FC_REFLECT( graphene::app::order, (price)(quote)(base) );
-FC_REFLECT( graphene::app::order_book, (base)(quote)(bids)(asks) );
+FC_REFLECT( graphene::app::order, (price)(quote)(base) )
+FC_REFLECT( graphene::app::order_book, (base)(quote)(bids)(asks) )
 FC_REFLECT( graphene::app::market_ticker,
             (time)(base)(quote)(latest)(lowest_ask)(lowest_ask_base_size)(lowest_ask_quote_size)
-            (highest_bid)(highest_bid_base_size)(highest_bid_quote_size)(percent_change)(base_volume)(quote_volume)(mto_id) );
-FC_REFLECT( graphene::app::market_volume, (time)(base)(quote)(base_volume)(quote_volume) );
+            (highest_bid)(highest_bid_base_size)(highest_bid_quote_size)(percent_change)(base_volume)(quote_volume)(mto_id) )
+FC_REFLECT( graphene::app::market_volume, (time)(base)(quote)(base_volume)(quote_volume) )
 FC_REFLECT( graphene::app::market_trade, (sequence)(date)(price)(amount)(value)(type)
-            (side1_account_id)(side2_account_id));
+            (side1_account_id)(side2_account_id) )
 
 FC_REFLECT_DERIVED( graphene::app::extended_asset_object, (graphene::chain::asset_object),
-                    (total_in_collateral)(total_backing_collateral) );
+                    (total_in_collateral)(total_backing_collateral) )
 
 FC_REFLECT_DERIVED( graphene::app::extended_liquidity_pool_object, (graphene::chain::liquidity_pool_object),
-                    (statistics) );
+                    (statistics) )
 

--- a/libraries/app/include/graphene/app/plugin.hpp
+++ b/libraries/app/include/graphene/app/plugin.hpp
@@ -42,7 +42,7 @@ class abstract_plugin
        *
        * Plugins MUST supply a method initialize() which will be called early in the application startup. This method
        * should contain early setup code such as initializing variables, adding indexes to the database, registering
-       * callback methods from the database, adding APIs, etc., as well as applying any options in the @ref options map
+       * callback methods from the database, adding APIs, etc., as well as applying any options in the @p options map
        *
        * This method is called BEFORE the database is open, therefore any routines which require any chain state MUST
        * NOT be called by this method. These routines should be performed in startup() instead.
@@ -120,7 +120,7 @@ class plugin : public abstract_plugin
       application* _app = nullptr;
 };
 
-/// @group Some useful tools for boost::program_options arguments using vectors of JSON strings
+/// @ingroup Some useful tools for boost::program_options arguments using vectors of JSON strings
 /// @{
 template<typename T>
 T dejsonify(const string& s, uint32_t max_depth)

--- a/libraries/chain/include/graphene/chain/asset_object.hpp
+++ b/libraries/chain/include/graphene/chain/asset_object.hpp
@@ -34,7 +34,7 @@
  * A prediction market is a specialized BitAsset such that total debt and total collateral are always equal amounts
  * (although asset IDs differ). No margin calls or force settlements may be performed on a prediction market asset. A
  * prediction market is globally settled by the issuer after the event being predicted resolves, thus a prediction
- * market must always have the @ref global_settle permission enabled. The maximum price for global settlement or short
+ * market must always have the @c global_settle permission enabled. The maximum price for global settlement or short
  * sale of a prediction market asset is 1-to-1.
  */
 

--- a/libraries/chain/include/graphene/chain/database.hpp
+++ b/libraries/chain/include/graphene/chain/database.hpp
@@ -109,6 +109,7 @@ namespace graphene { namespace chain {
 
          /**
           * @brief Rebuild object graph from block history and open detabase
+          * @param data_dir the path to store the database
           *
           * This method may be called after or instead of @ref database::open, and will rebuild the object graph by
           * replaying blockchain history. When this method exits successfully, the database will be open.
@@ -117,6 +118,7 @@ namespace graphene { namespace chain {
 
          /**
           * @brief wipe Delete database from disk, and potentially the raw chain as well.
+          * @param data_dir the path to store the database
           * @param include_blocks If true, delete the raw chain as well as the database.
           *
           * Will close the database before wiping. Database will be closed when this function returns.
@@ -330,7 +332,7 @@ namespace graphene { namespace chain {
          void deposit_market_fee_vesting_balance(const account_id_type &account_id, const asset &delta);
         /**
           * @brief Retrieve a particular account's market fee vesting balance in a given asset
-          * @param owner Account whose balance should be retrieved
+          * @param account_id Account whose balance should be retrieved
           * @param asset_id ID of the asset to get balance in
           * @return owner's balance in asset
           */
@@ -370,7 +372,8 @@ namespace graphene { namespace chain {
 
          //////////////////// db_market.cpp ////////////////////
 
-         /// @{ @group Market Helpers
+         /// @ingroup Market Helpers
+         /// @{
          void globally_settle_asset( const asset_object& bitasset, const price& settle_price );
          void cancel_settle_order(const force_settlement_object& order, bool create_virtual_op = true);
          void cancel_limit_order(const limit_order_object& order, bool create_virtual_op = true, bool skip_cancel_fee = false);
@@ -387,7 +390,8 @@ namespace graphene { namespace chain {
       public:
          /**
           * @brief Process a new limit order through the markets
-          * @param order The new order to process
+          * @param new_order_object The new order to process
+          * @param allow_black_swan whether to allow a black swan event
           * @return true if order was completely filled; false otherwise
           *
           * This function takes a new limit order, and runs the markets attempting to match it with existing orders
@@ -685,24 +689,5 @@ namespace graphene { namespace chain {
          const witness_schedule_object*         _p_witness_schedule_obj    = nullptr;
          ///@}
    };
-
-   namespace detail
-   {
-       template<int... Is>
-       struct seq { };
-
-       template<int N, int... Is>
-       struct gen_seq : gen_seq<N - 1, N - 1, Is...> { };
-
-       template<int... Is>
-       struct gen_seq<0, Is...> : seq<Is...> { };
-
-       template<typename T, int... Is>
-       void for_each(T&& t, const account_object& a, seq<Is...>)
-       {
-           auto l = { (std::get<Is>(t)(a), 0)... };
-           (void)l;
-       }
-   }
 
 } }

--- a/libraries/chain/include/graphene/chain/withdraw_permission_object.hpp
+++ b/libraries/chain/include/graphene/chain/withdraw_permission_object.hpp
@@ -36,7 +36,8 @@ namespace graphene { namespace chain {
    * @brief Grants another account authority to withdraw a limited amount of funds per interval
    *
    * The primary purpose of this object is to enable recurring payments on the blockchain. An account which wishes to
-   * process a recurring payment may use a @ref withdraw_permission_claim_operation to reference an object of this type
+   * process a recurring payment may use a @ref graphene::protocol::withdraw_permission_claim_operation
+   * to reference an object of this type
    * and withdraw up to @ref withdrawal_limit from @ref withdraw_from_account. Only @ref authorized_account may do
    * this. Any number of withdrawals may be made so long as the total amount withdrawn per period does not exceed the
    * limit for any given period.

--- a/libraries/chain/include/graphene/chain/worker_object.hpp
+++ b/libraries/chain/include/graphene/chain/worker_object.hpp
@@ -48,8 +48,8 @@ class database;
   * To create a new worker type, define a my_new_worker_type struct with a pay_worker method which updates the
   * my_new_worker_type object and/or the database. Create a my_new_worker_type::initializer struct with an init
   * method and any data members necessary to create a new worker of this type. Reflect my_new_worker_type and
-  * my_new_worker_type::initializer into FC's type system, and add them to @ref worker_type and @ref
-  * worker_initializer respectively. Make sure the order of types in @ref worker_type and @ref worker_initializer
+  * my_new_worker_type::initializer into FC's type system, and add them to @ref worker_type and @c
+  * worker_initializer respectively. Make sure the order of types in @ref worker_type and @c worker_initializer
   * remains the same.
   * @{
   */

--- a/libraries/net/include/graphene/net/node.hpp
+++ b/libraries/net/include/graphene/net/node.hpp
@@ -71,7 +71,9 @@ namespace graphene { namespace net {
          /**
           *  @brief Called when a new block comes in from the network
           *
+          *  @param blk_msg the message which contains the block
           *  @param sync_mode true if the message was fetched through the sync process, false during normal operation
+          *  @param contained_transaction_message_ids container for the transactions to write back into
           *  @returns true if this message caused the blockchain to switch forks, false if it did not
           *
           *  @throws exception if error validating the item, otherwise the item is

--- a/libraries/net/include/graphene/net/peer_connection.hpp
+++ b/libraries/net/include/graphene/net/peer_connection.hpp
@@ -339,4 +339,4 @@ FC_REFLECT_ENUM(graphene::net::peer_connection::connection_negotiation_status, (
                                                                           (closing)
                                                                           (closed) )
 
-FC_REFLECT( graphene::net::peer_connection::timestamped_item_id, (item)(timestamp));
+FC_REFLECT( graphene::net::peer_connection::timestamped_item_id, (item)(timestamp) )

--- a/libraries/protocol/account.cpp
+++ b/libraries/protocol/account.cpp
@@ -29,20 +29,24 @@ namespace graphene { namespace protocol {
 
 /**
  * Names must comply with the following grammar (RFC 1035):
+ * @code
  * <domain> ::= <subdomain> | " "
  * <subdomain> ::= <label> | <subdomain> "." <label>
  * <label> ::= <letter> [ [ <ldh-str> ] <let-dig> ]
  * <ldh-str> ::= <let-dig-hyp> | <let-dig-hyp> <ldh-str>
  * <let-dig-hyp> ::= <let-dig> | "-"
  * <let-dig> ::= <letter> | <digit>
+ * @endcode
  *
  * Which is equivalent to the following:
  *
+ * @code
  * <domain> ::= <subdomain> | " "
  * <subdomain> ::= <label> ("." <label>)*
  * <label> ::= <letter> [ [ <let-dig-hyp>+ ] <let-dig> ]
  * <let-dig-hyp> ::= <let-dig> | "-"
  * <let-dig> ::= <letter> | <digit>
+ * @endcode
  *
  * I.e. a valid name consists of a dot-separated sequence
  * of one or more labels consisting of the following rules:

--- a/libraries/protocol/include/graphene/protocol/account.hpp
+++ b/libraries/protocol/include/graphene/protocol/account.hpp
@@ -129,8 +129,9 @@ namespace graphene { namespace protocol {
     * @ingroup operations
     * @brief Update an existing account
     *
-    * This operation is used to update an existing account. It can be used to update the authorities, or adjust the options on the account.
-    * See @ref account_object::options for the options which may be updated.
+    * This operation is used to update an existing account. It can be used to update the authorities,
+    * or adjust the options on the account.
+    * See @ref graphene::chain::account_object::options for the options which may be updated.
     */
    struct account_update_operation : public base_operation
    {

--- a/libraries/protocol/include/graphene/protocol/asset_ops.hpp
+++ b/libraries/protocol/include/graphene/protocol/asset_ops.hpp
@@ -174,10 +174,9 @@ namespace graphene { namespace protocol {
       /// ID is not known at the time this operation is created, create this price as though the new asset has instance
       /// ID 1, and the chain will overwrite it with the new asset's ID.
       asset_options              common_options;
-      /// Options only available for BitAssets. MUST be non-null if and only if the @ref market_issued flag is set in
-      /// common_options.flags
+      /// Options only available for BitAssets. MUST be non-null if and only if the asset is market-issued.
       optional<bitasset_options> bitasset_opts;
-      /// For BitAssets, set this to true if the asset implements a @ref prediction_market; false otherwise
+      /// For BitAssets, set this to true if the asset implements a prediction market; false otherwise
       bool is_prediction_market = false;
       extensions_type extensions;
 
@@ -201,7 +200,7 @@ namespace graphene { namespace protocol {
       struct fee_parameters_type { uint64_t fee = 500 * GRAPHENE_BLOCKCHAIN_PRECISION; };
 
       asset           fee;
-      account_id_type issuer; ///< must equal @ref asset_to_settle->issuer
+      account_id_type issuer; ///< must equal issuer of @ref asset_to_settle
       asset_id_type   asset_to_settle;
       price           settle_price;
       extensions_type extensions;
@@ -345,7 +344,8 @@ namespace graphene { namespace protocol {
     * options an an existing BitAsset.
     *
     * @pre @ref issuer MUST be an existing account and MUST match asset_object::issuer on @ref asset_to_update
-    * @pre @ref asset_to_update MUST be a BitAsset, i.e. @ref asset_object::is_market_issued() returns true
+    * @pre @ref asset_to_update MUST be a BitAsset, i.e. @ref graphene::chain::asset_object::is_market_issued()
+    *                           returns true
     * @pre @ref fee MUST be nonnegative, and @ref issuer MUST have a sufficient balance to pay it
     * @pre @ref new_options SHALL be internally consistent, as verified by @ref validate()
     * @post @ref asset_to_update will have BitAsset-specific options matching those of new_options
@@ -374,7 +374,8 @@ namespace graphene { namespace protocol {
     *
     * @pre @ref issuer MUST be an existing account, and MUST match asset_object::issuer on @ref asset_to_update
     * @pre @ref issuer MUST NOT be the committee account
-    * @pre @ref asset_to_update MUST be a BitAsset, i.e. @ref asset_object::is_market_issued() returns true
+    * @pre @ref asset_to_update MUST be a BitAsset, i.e. @ref graphene::chain::asset_object::is_market_issued()
+    *                           returns true
     * @pre @ref fee MUST be nonnegative, and @ref issuer MUST have a sufficient balance to pay it
     * @pre Cardinality of @ref new_feed_producers MUST NOT exceed @ref chain_parameters::maximum_asset_feed_publishers
     * @post @ref asset_to_update will have a set of feed producers matching @ref new_feed_producers
@@ -676,7 +677,7 @@ FC_REFLECT( graphene::protocol::asset_issue_operation,
 FC_REFLECT( graphene::protocol::asset_reserve_operation,
             (fee)(payer)(amount_to_reserve)(extensions) )
 
-FC_REFLECT( graphene::protocol::asset_fund_fee_pool_operation, (fee)(from_account)(asset_id)(amount)(extensions) );
+FC_REFLECT( graphene::protocol::asset_fund_fee_pool_operation, (fee)(from_account)(asset_id)(amount)(extensions) )
 
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::protocol::asset_options )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::protocol::bitasset_options::ext )

--- a/libraries/protocol/include/graphene/protocol/balance.hpp
+++ b/libraries/protocol/include/graphene/protocol/balance.hpp
@@ -29,10 +29,12 @@
 namespace graphene { namespace protocol { 
 
    /**
-    * @brief Claim a balance in a @ref balance_object
+    * @brief Claim a balance in a @ref graphene::chain::balance_object
     *
-    * This operation is used to claim the balance in a given @ref balance_object. If the balance object contains a
-    * vesting balance, @ref total_claimed must not exceed @ref balance_object::available at the time of evaluation. If
+    * This operation is used to claim the balance in a given @ref graphene::chain::balance_object.
+    * If the balance object contains a
+    * vesting balance, @ref total_claimed must not exceed @ref graphene::chain::balance_object::available
+    * at the time of evaluation. If
     * the object contains a non-vesting balance, @ref total_claimed must be the full balance of the object.
     */
    struct balance_claim_operation : public base_operation

--- a/libraries/protocol/include/graphene/protocol/base.hpp
+++ b/libraries/protocol/include/graphene/protocol/base.hpp
@@ -78,7 +78,7 @@ namespace graphene { namespace protocol {
     *
     *    Each operation contains enough information to enumerate all accounts for which the
     *    operation should apear in its account history.  This principle enables us to easily
-    *    define and enforce the @balance_calculation. This is superset of the @ref defined_authority
+    *    define and enforce the @ref balance_calculation. This is superset of the @ref defined_authority
     *
     *  @{
     */

--- a/libraries/protocol/include/graphene/protocol/chain_parameters.hpp
+++ b/libraries/protocol/include/graphene/protocol/chain_parameters.hpp
@@ -97,10 +97,12 @@ namespace graphene { namespace protocol {
       chain_parameters& operator=(const chain_parameters& other);
       chain_parameters& operator=(chain_parameters&& other);
 
-      /// If @ref market_fee_network_percent is valid, return the value it contains, otherwise return 0
+      /// If @c market_fee_network_percent in @ref extensions is valid, return the value it contains,
+      /// otherwise return 0
       uint16_t get_market_fee_network_percent() const;
 
-      /// If @ref maker_fee_discount_percent is valid, return the value it contains, otherwise return 0
+      /// If @c maker_fee_discount_percent in @ref extensions is valid, return the value it contains,
+      /// otherwise return 0
       uint16_t get_maker_fee_discount_percent() const;
 
       private:

--- a/libraries/protocol/include/graphene/protocol/committee_member.hpp
+++ b/libraries/protocol/include/graphene/protocol/committee_member.hpp
@@ -104,7 +104,7 @@ FC_REFLECT( graphene::protocol::committee_member_create_operation,
             (fee)(committee_member_account)(url) )
 FC_REFLECT( graphene::protocol::committee_member_update_operation,
             (fee)(committee_member)(committee_member_account)(new_url) )
-FC_REFLECT( graphene::protocol::committee_member_update_global_parameters_operation, (fee)(new_parameters) );
+FC_REFLECT( graphene::protocol::committee_member_update_global_parameters_operation, (fee)(new_parameters) )
 
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::protocol::committee_member_create_operation::fee_parameters_type )
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::protocol::committee_member_update_operation::fee_parameters_type )

--- a/libraries/protocol/include/graphene/protocol/confidential.hpp
+++ b/libraries/protocol/include/graphene/protocol/confidential.hpp
@@ -266,7 +266,7 @@ FC_REFLECT( graphene::protocol::stealth_confirmation,
             (one_time_key)(to)(encrypted_memo) )
 
 FC_REFLECT( graphene::protocol::stealth_confirmation::memo_data,
-            (from)(amount)(blinding_factor)(commitment)(check) );
+            (from)(amount)(blinding_factor)(commitment)(check) )
 
 FC_REFLECT( graphene::protocol::blind_memo,
             (from)(amount)(message)(check) )

--- a/libraries/protocol/include/graphene/protocol/operations.hpp
+++ b/libraries/protocol/include/graphene/protocol/operations.hpp
@@ -123,7 +123,7 @@ namespace graphene { namespace protocol {
     *  Appends required authorites to the result vector.  The authorities appended are not the
     *  same as those returned by get_required_auth 
     *
-    *  @return a set of required authorities for @ref op
+    *  @return a set of required authorities for @p op
     */
    void operation_get_required_authorities( const operation& op,
                                             flat_set<account_id_type>& active,

--- a/libraries/protocol/include/graphene/protocol/transaction.hpp
+++ b/libraries/protocol/include/graphene/protocol/transaction.hpp
@@ -56,8 +56,9 @@ namespace graphene { namespace protocol {
     * probably have a longer re-org window to ensure their transaction can still go through in the event of a momentary
     * disruption in service.
     *
-    * @note It is not recommended to set the @ref ref_block_num, @ref ref_block_prefix, and @ref expiration
-    * fields manually. Call the appropriate overload of @ref set_expiration instead.
+    * @note It is not recommended to set the @ref transaction::ref_block_num, @ref transaction::ref_block_prefix,
+    * and @ref transaction::expiration
+    * fields manually. Call the appropriate overload of @ref transaction::set_expiration instead.
     *
     * @{
     */
@@ -70,8 +71,7 @@ namespace graphene { namespace protocol {
    public:
       virtual ~transaction() = default;
       /**
-       * Least significant 16 bits from the reference block number. If @ref relative_expiration is zero, this field
-       * must be zero as well.
+       * Least significant 16 bits from the reference block number.
        */
       uint16_t           ref_block_num    = 0;
       /**
@@ -146,7 +146,7 @@ namespace graphene { namespace protocol {
 
       /**
        *  The purpose of this method is to identify some subset of
-       *  @ref available_keys that will produce sufficient signatures
+       *  @p available_keys that will produce sufficient signatures
        *  for a transaction.  The result is not always a minimal set of
        *  signatures, but any non-minimal result will still pass
        *  validation.
@@ -204,12 +204,12 @@ namespace graphene { namespace protocol {
        * @brief Extract public keys from signatures with given chain ID.
        * @param chain_id A chain ID
        * @return Public keys
-       * @note If @ref signees is empty, E.G. when it's the first time calling
+       * @note If @ref _signees is empty, E.G. when it's the first time calling
        *       this function for the signed transaction, public keys will be
        *       extracted with given chain ID, and be stored into the mutable
-       *       @ref signees field, then @ref signees will be returned;
-       *       otherwise, the @ref chain_id parameter will be ignored, and
-       *       @ref signees will be returned directly.
+       *       @ref _signees field, then @ref _signees will be returned;
+       *       otherwise, the @p chain_id parameter will be ignored, and
+       *       @ref _signees will be returned directly.
        */
       virtual const flat_set<public_key_type>& get_signature_keys( const chain_id_type& chain_id )const;
 
@@ -273,7 +273,7 @@ namespace graphene { namespace protocol {
                           bool ignore_custom_operation_required_auths,
                           uint32_t max_recursion = GRAPHENE_MAX_SIG_CHECK_DEPTH,
                           bool allow_committee = false,
-                          const flat_set<account_id_type>& active_aprovals = flat_set<account_id_type>(),
+                          const flat_set<account_id_type>& active_approvals = flat_set<account_id_type>(),
                           const flat_set<account_id_type>& owner_approvals = flat_set<account_id_type>() );
 
    /**
@@ -305,7 +305,7 @@ namespace graphene { namespace protocol {
 } } // graphene::protocol
 
 FC_REFLECT( graphene::protocol::transaction, (ref_block_num)(ref_block_prefix)(expiration)(operations)(extensions) )
-// Note: not reflecting signees field for backward compatibility; in addition, it should not be in p2p messages
+// Note: not reflecting _signees field for backward compatibility; in addition, it should not be in p2p messages
 FC_REFLECT_DERIVED( graphene::protocol::signed_transaction, (graphene::protocol::transaction), (signatures) )
 FC_REFLECT_DERIVED( graphene::protocol::precomputable_transaction, (graphene::protocol::signed_transaction), )
 FC_REFLECT_DERIVED( graphene::protocol::processed_transaction, (graphene::protocol::precomputable_transaction), (operation_results) )

--- a/libraries/protocol/include/graphene/protocol/withdraw_permission.hpp
+++ b/libraries/protocol/include/graphene/protocol/withdraw_permission.hpp
@@ -26,7 +26,7 @@
 #include <graphene/protocol/asset.hpp>
 #include <graphene/protocol/memo.hpp>
 
-namespace graphene { namespace protocol { 
+namespace graphene { namespace protocol {
 
    /**
     * @brief Create a new withdrawal permission
@@ -119,8 +119,8 @@ namespace graphene { namespace protocol {
     */
    struct withdraw_permission_claim_operation : public base_operation
    {
-      struct fee_parameters_type { 
-         uint64_t fee = 20*GRAPHENE_BLOCKCHAIN_PRECISION; 
+      struct fee_parameters_type {
+         uint64_t fee = 20*GRAPHENE_BLOCKCHAIN_PRECISION;
          uint32_t price_per_kbyte = 10;
       };
 
@@ -173,12 +173,17 @@ FC_REFLECT( graphene::protocol::withdraw_permission_update_operation::fee_parame
 FC_REFLECT( graphene::protocol::withdraw_permission_claim_operation::fee_parameters_type, (fee)(price_per_kbyte) )
 FC_REFLECT( graphene::protocol::withdraw_permission_delete_operation::fee_parameters_type, (fee) )
 
-FC_REFLECT( graphene::protocol::withdraw_permission_create_operation, (fee)(withdraw_from_account)(authorized_account)
+FC_REFLECT( graphene::protocol::withdraw_permission_create_operation,
+            (fee)(withdraw_from_account)(authorized_account)
             (withdrawal_limit)(withdrawal_period_sec)(periods_until_expiration)(period_start_time) )
-FC_REFLECT( graphene::protocol::withdraw_permission_update_operation, (fee)(withdraw_from_account)(authorized_account)
-            (permission_to_update)(withdrawal_limit)(withdrawal_period_sec)(period_start_time)(periods_until_expiration) )
-FC_REFLECT( graphene::protocol::withdraw_permission_claim_operation, (fee)(withdraw_permission)(withdraw_from_account)(withdraw_to_account)(amount_to_withdraw)(memo) );
-FC_REFLECT( graphene::protocol::withdraw_permission_delete_operation, (fee)(withdraw_from_account)(authorized_account)
+FC_REFLECT( graphene::protocol::withdraw_permission_update_operation,
+            (fee)(withdraw_from_account)(authorized_account)
+            (permission_to_update)(withdrawal_limit)(withdrawal_period_sec)
+            (period_start_time)(periods_until_expiration) )
+FC_REFLECT( graphene::protocol::withdraw_permission_claim_operation,
+            (fee)(withdraw_permission)(withdraw_from_account)(withdraw_to_account)(amount_to_withdraw)(memo) )
+FC_REFLECT( graphene::protocol::withdraw_permission_delete_operation,
+            (fee)(withdraw_from_account)(authorized_account)
             (withdrawal_permission) )
 
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::protocol::withdraw_permission_create_operation::fee_parameters_type )

--- a/libraries/protocol/include/graphene/protocol/worker.hpp
+++ b/libraries/protocol/include/graphene/protocol/worker.hpp
@@ -33,7 +33,8 @@ namespace graphene { namespace protocol {
     *
     * BitShares blockchains allow the creation of special "workers" which are elected positions paid by the blockchain
     * for services they provide. There may be several types of workers, and the semantics of how and when they are paid
-    * are defined by the @ref worker_type_enum enumeration. All workers are elected by core stakeholder approval, by
+    * are defined by the @ref graphene::chain::worker_type enumeration.
+    * All workers are elected by core stakeholder approval, by
     * voting for or against them.
     *
     * Workers are paid from the blockchain's daily budget if their total approval (votes for - votes against) is


### PR DESCRIPTION
PR for #2213.

Bumped FC with https://github.com/bitshares/bitshares-fc/pull/223 .

NOTE:
Item(s) unable to fix so far:
* ```warning: documented symbol `graphene::chain::decltype' was not declared or defined``` on several files
  * see https://sourceforge.net/p/doxygen/mailman/message/36304025/ - Doxygen doesn’t support decltype() yet 
* ```warning: no uniquely matching class member found for (some methods in some template classes)```, E.G.
```
libraries/fc/include/fc/fwd_impl.hpp:128: warning: no uniquely matching class member found for
  template < T, S, A >
  T & fc::fwd< T, S, A >::operator=(fc::fwd< T, S, A > &&u)
Possible candidates:
  'template < U >
  T & fc::fwd< T, S, Align >::operator=(U &&u)' at line 31 of file /home/ubuntu/bitshares-core-dev/libraries/fc/include/fc/fwd.hpp
  T & fc::fwd< T, S, Align >::operator=(fwd &&u)' at line 33 of file /home/ubuntu/bitshares-core-dev/libraries/fc/include/fc/fwd.hpp
  T & fc::fwd< T, S, Align >::operator=(const fwd &u)' at line 34 of file /home/ubuntu/bitshares-core-dev/libraries/fc/include/fc/fwd.hpp
```
* ```libraries/fc/include/fc/thread/parallel.hpp:91: warning: argument 'desc' of command @param is not found in the argument list of fc::do_parallel(Functor &&f, const char *desc FC_TASK_NAME_DEFAULT_ARG) ->-> fc::future< decltype(f())> ``` (and some other files), and `parameter 'FC_TASK_NAME_DEFAULT_ARG'` is "not documented"
  * Doxygen thinks `FC_TASK_NAME_DEFAULT_ARG` is the argument
* `README.md:6: warning: Unexpected html tag <img> found within <a href=...> context`
  * The section will be removed from the generated HTML file anyway