### PR TITLE
Update license year and contributors list

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,19 +1,31 @@
 Alfredo Garcia <oxarbitrage@gmail.com> <oxarbitrage@gmail.com>
 Alfredo Garcia <oxarbitrage@gmail.com> <root@NC-PH-1346-07.web-hosting.com>
+Anonymous <you@example.com>
+Anton Autushka <antoninus.liberalis@gmail.com> <a.autushka@aetsoft.by>
+BrownBear <-> <->
 Christopher Sanborn <23085117+christophersanborn@users.noreply.github.com>
 Chronos <chronos.crypto@gmail.com>
+Dan Notestein <dan@syncad.com> <dan@syncad.com>
+Dan Notestein <dan@syncad.com> <syncad@syncad.com>
+Daniel Larimer <bytemaster@users.noreply.github.com> <dlarimer@gmail.com>
 Daniel Larimer <bytemaster@users.noreply.github.com> <dan.larimer@block.one>
 Daniel Larimer <bytemaster@users.noreply.github.com> <dan@bitshares.org>
 Daniel Larimer <bytemaster@users.noreply.github.com> <dan@invictus-innovations.com>
 Daniel Larimer <bytemaster@users.noreply.github.com> <dlarimer@invictus-innovations.com>
+Daniel Larimer <bytemaster@users.noreply.github.com> <dan@steemit.com>
+Daniel Larimer <bytemaster@users.noreply.github.com> <dan.larimer@8riverscapital.com>
 Eric Frias <efrias@syncad.com>
 Fabian Schuh <Fabian@chainsquad.com> <mail@xeroc.org>
 Fabian Schuh <Fabian@chainsquad.com> <xeroc@chainsquad.com>
 John M. Jones <jmjatlanta@gmail.com>
 Ken Code <ken@BitShares-Munich.de>
 Matias Romeo <matias.romeo@gmail.com>
+Michael Vandeberg <mvandeberg@users.noreply.github.com> <vandeberg@cryptonomex.com>
+Michael Vandeberg <mvandeberg@users.noreply.github.com> <vandeberg@steemit.com>
 Nathan Hourt <themodprobe@protonmail.com> <nat.hourt@gmail.com>
 Nathan Hourt <themodprobe@protonmail.com> <nathan@followmyvote.com>
+Nathan Hourt <themodprobe@protonmail.com> <nathan@bitshares.org>
+Nikolai Mushegian <nikolai.mushegian@gmail.com> <nmushegi@andrew.cmu.edu>
 OpenLedger <service.github@openledger.info> <service.github@openledger.info>
 OpenLedger <service.github@openledger.info> <42674402+OpenLedgerApp@users.noreply.github.com>
 Peter Conrad <conrad@quisquis.de> <cyrano@quisquis.de>
@@ -23,20 +35,26 @@ Roelandp <dnaleor@gmail.com>
 Ryan R. Fox <ryan@ryanrfox.com> <ryan@ryanrfox.com>
 Ryan R. Fox <ryan@ryanrfox.com> <ryanRfox@users.noreply.github.com>
 Sigve Kvalsvik <bitsharesblocks@gmail.com> <sigvekvalsvik@gmail.com>
-Valentine Zavgorodnev <i@valzav.com>
+Valentine Zavgorodnev <i@valzav.com> <i@valzav.com>
+Valentine Zavgorodnev <i@valzav.com> <vz@valzav.com>
 Valera Cogut <info@valeracogut.com> <valerakogut@gmail.com>
 Vikram Rajkumar <vikramrajkumar@users.noreply.github.com> <vikram@bitshares.org>
 Vikram Rajkumar <vikramrajkumar@users.noreply.github.com> <vikram@soledger.com>
+Vikram Rajkumar <vikramrajkumar@users.noreply.github.com> <vikramrajkumar1@gmail.com>
 William <tmfc@homtail.com> <jinwei@gmail.com>
 William <tmfc@homtail.com> <tmfc@homtail.com>
 Xiaodong Li <mantianyu@gmail.com> <cifer-lee@users.noreply.github.com>
 Xiaodong Li <mantianyu@gmail.com> <mantianyu@gmail.com>
 Xiaodong Li <mantianyu@gmail.com> <maintianyu@gmail.com>
 Xiaodong Li <mantianyu@gmail.com> <lixiaodongcifer@didichuxing.com>
+Yuvaraj Gogoi <yuvarajgogoi@gmail.com> <yuvarajgogoi@gmail.com>
 abitmore <abitmore@users.noreply.github.com>
 albert <393259066@qq.com> <393259066@qq.com>
 albert <393259066@qq.com> <zhuliting@gxb.io>
+batmaninpink <batmaninpink@users.noreply.github.com> <batmaninpink@>
 bitcube <root@seed.cubeconnex.com>
 btcinshares <btcinshares@protonmail.com> <33876675+btcinshares@users.noreply.github.com>
 crazybits <crazybit.github@gmail.com> <crazybit.github@gmail.com>
 crazybits <crazybit.github@gmail.com> <crazybits@users.noreply.github.com>
+theoreticalbts <theoreticalbts@users.noreply.github.com> <drltc@users.noreply.github.com>
+theoreticalbts <theoreticalbts@users.noreply.github.com> <theoreticalbts@users.noreply.github.com>

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -26,7 +26,7 @@ Sigve Kvalsvik <bitsharesblocks@gmail.com>
 albert <393259066@qq.com>
 Ryan R. Fox <ryan@ryanrfox.com>
 Valentine Zavgorodnev <i@valzav.com>
-Michael Vandeberg <vandeberg@cryptonomex.com>
+Michael Vandeberg <mvandeberg@users.noreply.github.com>
 James Calfee <james@jcalfee.info>
 Alexey Frolov <alexey.frolov@aetsoft.by>
 syalon <hanomirin@foxmail.com>
@@ -34,7 +34,7 @@ takaaki7 <nakama67006700@gmail.com>
 Nicolas Wack <wackou@gmail.com>
 Taconator <TheTaconator@users.noreply.github.com>
 Qi Xing <cwyyprog@163.com>
-Anton Autushka <a.autushka@aetsoft.by>
+Anton Autushka <antoninus.liberalis@gmail.com>
 Chronos <chronos.crypto@gmail.com>
 Wei Yang <richard.weiyang@gmail.com>
 Zapata <marco.tessari@gmail.com>
@@ -45,11 +45,11 @@ Tengfei Niu <spartucus@users.noreply.github.com>
 Tiago Peralta <tperalta82@gmail.com>
 ioBanker <37595908+ioBanker@users.noreply.github.com>
 Karl Semich <0xloem@gmail.com>
-Michael Vandeberg <vandeberg@steemit.com>
 SahkanDesertHawk <panasiuki@gmail.com>
 Scott Howard <showard314@gmail.com>
 Tydus <Tydus@Tydus.org>
 William <tmfc@homtail.com>
+bangzi1001 <36911788+bangzi1001@users.noreply.github.com>
 d.yakovitsky <d.yakovitsky@aetsoft.by>
 ddylko <ddylko@ddylkoPC>
 iHashFury <iPerky@users.noreply.github.com>
@@ -69,12 +69,13 @@ Ken Code <ken@BitShares-Munich.de>
 Krzysztof Szumny <krzysztof.szumny@stxnext.pl>
 Paul Brossier <piem@piem.org>
 Roelandp <dnaleor@gmail.com>
+Semen Martynov <semen.martynov@gmail.com>
 Thomas Freedman <thom@ozarkholler.com>
 Troglodactyl <troglodactyl@gmail.com>
 VoR0220 <catalanor0220@gmail.com>
 alt <pch957@163.com>
-bangzi1001 <36911788+bangzi1001@users.noreply.github.com>
 bitcube <root@seed.cubeconnex.com>
 lafona <lafona@protonmail.com>
 liondani <liondani@gmx.com>
 lososeg <ya.lososeg@gmail.com>
+xiao93 <42384581+xiao93@users.noreply.github.com>

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 Copyright (c) 2015-2016 Cryptonomex Inc. <contact@cryptonomex.com>
-Copyright (c) 2015-2020 contributors, see CONTRIBUTORS.txt
+Copyright (c) 2015-2021 contributors, see CONTRIBUTORS.txt
 
 The MIT License
 


### PR DESCRIPTION
Also bumped FC to include https://github.com/bitshares/bitshares-fc/pull/225.

Note: the contributors list may need to be updated again before the final release.