### PR TITLE
Add CLI commands get_account_name and get_asset_symbol

### DIFF
--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -98,10 +98,10 @@ class wallet_api
        * Each account can have multiple balances, one for each type of asset owned by that
        * account.  The returned list will only contain assets for which the account has a
        * nonzero balance
-       * @param id the name or id of the account whose balances you want
+       * @param account_name_or_id the name or id of the account whose balances you want
        * @returns a list of the given account's balances
        */
-      vector<asset>                     list_account_balances(const string& id);
+      vector<asset>                     list_account_balances(const string& account_name_or_id);
       /** Lists all assets registered on the blockchain.
        *
        * To list all assets, pass the empty string \c "" for the lowerbound to start
@@ -122,21 +122,21 @@ class wallet_api
        *
        * This returns a list of operation history objects, which describe activity on the account.
        *
-       * @param name the name or id of the account
+       * @param account_name_or_id the name or id of the account
        * @param limit the number of entries to return (starting from the most recent)
        * @returns a list of \c operation_history_objects
        */
-      vector<operation_detail>  get_account_history(string name, int limit)const;
+      vector<operation_detail>  get_account_history(string account_name_or_id, int limit)const;
 
       /** Returns the relative operations on the named account from start number.
        *
-       * @param name the name or id of the account
+       * @param account_name_or_id the name or id of the account
        * @param stop Sequence number of earliest operation.
        * @param limit the number of entries to return
        * @param start  the sequence number where to start looping back throw the history
        * @returns a list of \c operation_history_objects
        */
-     vector<operation_detail>  get_relative_account_history( string name, uint32_t stop,
+     vector<operation_detail>  get_relative_account_history( string account_name_or_id, uint32_t stop,
                                                              int limit, uint32_t start )const;
 
       /**
@@ -152,8 +152,8 @@ class wallet_api
 
       /**
        * @brief Get OHLCV data of a trading pair in a time range
-       * @param symbol name or ID of the base asset
-       * @param symbol2 name or ID of the quote asset
+       * @param symbol symbol or ID of the base asset
+       * @param symbol2 symbol or ID of the quote asset
        * @param bucket length of each time bucket in seconds.
        * @param start the start of a time range, E.G. "2018-01-01T00:00:00"
        * @param end the end of the time range
@@ -198,11 +198,11 @@ class wallet_api
 
       /**
        * @brief Get call orders (aka margin positions) for a given asset
-       * @param a symbol name or ID of the debt asset
+       * @param asset_symbol_or_id symbol or ID of the debt asset
        * @param limit Maximum number of orders to retrieve
        * @return The call orders, ordered from earliest to be called to latest
        */
-      vector<call_order_object>         get_call_orders(string a, uint32_t limit)const;
+      vector<call_order_object>         get_call_orders(string asset_symbol_or_id, uint32_t limit)const;
 
       /**
        * @brief Get forced settlement orders in a given asset
@@ -214,12 +214,13 @@ class wallet_api
 
       /** Returns the collateral_bid object for the given MPA
        *
-       * @param asset the name or id of the asset
+       * @param asset_symbol_or_id the symbol or id of the asset
        * @param limit the number of entries to return
        * @param start the sequence number where to start looping back throw the history
        * @returns a list of \c collateral_bid_objects
        */
-      vector<collateral_bid_object> get_collateral_bids(string asset, uint32_t limit = 100, uint32_t start = 0)const;
+      vector<collateral_bid_object> get_collateral_bids(string asset_symbol_or_id, uint32_t limit = 100,
+                                                        uint32_t start = 0)const;
 
       /** Returns the block chain's slowly-changing settings.
        * This object contains all of the properties of the blockchain that are fixed
@@ -233,14 +234,14 @@ class wallet_api
       /**
        * Get operations relevant to the specified account filtering by operation type, with transaction id
        *
-       * @param name the name or id of the account, whose history shoulde be queried
+       * @param account_name_or_id the name or id of the account, whose history shoulde be queried
        * @param operation_types The IDs of the operation we want to get operations in the account
        *                        ( 0 = transfer , 1 = limit order create, ...)
        * @param start the sequence number where to start looping back throw the history
        * @param limit the max number of entries to return (from start number)
        * @returns account_history_operation_detail
        */
-      account_history_operation_detail get_account_history_by_operations( string name,
+      account_history_operation_detail get_account_history_by_operations( string account_name_or_id,
                                                                           flat_set<uint16_t> operation_types,
                                                                           uint32_t start, int limit);
 
@@ -260,18 +261,18 @@ class wallet_api
       account_object                    get_account(string account_name_or_id) const;
 
       /** Returns information about the given asset.
-       * @param asset_name_or_id the symbol or id of the asset in question
+       * @param asset_symbol_or_id the symbol or id of the asset in question
        * @returns the information about the asset stored in the block chain
        */
-      extended_asset_object             get_asset(string asset_name_or_id) const;
+      extended_asset_object             get_asset(string asset_symbol_or_id) const;
 
       /** Returns the BitAsset-specific data for a given asset.
        * Market-issued assets's behavior are determined both by their "BitAsset Data" and
        * their basic asset data, as returned by \c get_asset().
-       * @param asset_name_or_id the symbol or id of the BitAsset in question
+       * @param asset_symbol_or_id the symbol or id of the BitAsset in question
        * @returns the BitAsset-specific data for this asset
        */
-      asset_bitasset_data_object        get_bitasset_data(string asset_name_or_id)const;
+      asset_bitasset_data_object        get_bitasset_data(string asset_symbol_or_id)const;
 
       /**
        * Returns information about the given HTLC object.
@@ -286,12 +287,35 @@ class wallet_api
        */
       account_id_type                   get_account_id(string account_name_or_id) const;
 
+      /** Lookup the name of an account.
+       * @param account_name_or_id the name or ID of the account to look up
+       * @returns the name of the account
+       */
+      string                            get_account_name(string account_name_or_id) const
+      { return get_account( account_name_or_id ).name; }
+
       /**
-       * Lookup the id of a named asset.
-       * @param asset_name_or_id the symbol or ID of an asset to look up
+       * Lookup the id of an asset.
+       * @param asset_symbol_or_id the symbol or ID of an asset to look up
        * @returns the id of the given asset
        */
-      asset_id_type                     get_asset_id(string asset_name_or_id) const;
+      asset_id_type                     get_asset_id(string asset_symbol_or_id) const;
+
+      /**
+       * Lookup the symbol of an asset.
+       * @param asset_symbol_or_id the symbol or ID of an asset to look up
+       * @returns the symbol of the given asset
+       */
+      string                            get_asset_symbol(string asset_symbol_or_id) const
+      { return get_asset( asset_symbol_or_id ).symbol; }
+
+      /**
+       * Lookup the symbol of an asset. Synonym of @ref get_asset_symbol.
+       * @param asset_symbol_or_id the symbol or ID of an asset to look up
+       * @returns the symbol of the given asset
+       */
+      string                            get_asset_name(string asset_symbol_or_id) const
+      { return get_asset_symbol( asset_symbol_or_id ); }
 
       /**
        * Returns the blockchain object corresponding to the given id.
@@ -354,7 +378,7 @@ class wallet_api
        *
        * Calculate and update fees for the operations in a transaction builder.
        * @param handle handle of the transaction builder
-       * @param fee_asset name or ID of an asset that to be used to pay fees
+       * @param fee_asset symbol or ID of an asset that to be used to pay fees
        * @return total fees
        */
       asset set_fees_on_builder_transaction(transaction_handle_type handle, string fee_asset = GRAPHENE_SYMBOL);
@@ -694,11 +718,11 @@ class wallet_api
        *  Upgrades an account to prime status.
        *  This makes the account holder a 'lifetime member'.
        *
-       * @param name the name or id of the account to upgrade
+       * @param account_name_or_id the name or id of the account to upgrade
        * @param broadcast true to broadcast the transaction on the network
        * @returns the signed transaction upgrading the account
        */
-      signed_transaction upgrade_account(string name, bool broadcast);
+      signed_transaction upgrade_account(string account_name_or_id, bool broadcast);
 
       /** Creates a new account and registers it on the blockchain.
        *
@@ -708,9 +732,11 @@ class wallet_api
        * @see register_account()
        *
        * @param brain_key the brain key used for generating the account's private keys
-       * @param account_name the name of the account, must be unique on the blockchain.  Shorter names
-       *                     are more expensive to register; the rules are still in flux, but in general
-       *                     names of more than 8 characters with at least one digit will be cheap.
+       * @param account_name the name of the account, must be unique on the blockchain.
+       *                     Names with only latin letters and at least one vowel are
+       *                     premium names and expensive to register;
+       *                     names with only consonants, or at least with a digit, a dot or
+       *                     a minus sign are cheap.
        * @param registrar_account the account which will pay the fee to register the user
        * @param referrer_account the account who is acting as a referrer, and may receive a
        *                         portion of the user's transaction fees.  This can be the
@@ -728,7 +754,7 @@ class wallet_api
        * @param from the name or id of the account sending the funds
        * @param to the name or id of the account receiving the funds
        * @param amount the amount to send (in nominal units -- to send half of a BTS, specify 0.5)
-       * @param asset_symbol the symbol or id of the asset to send
+       * @param asset_symbol_or_id the symbol or id of the asset to send
        * @param memo a memo to attach to the transaction.  The memo will be encrypted in the
        *             transaction and readable for the receiver.  There is no length limit
        *             other than the limit imposed by maximum transaction size, but transaction
@@ -739,7 +765,7 @@ class wallet_api
       signed_transaction transfer(string from,
                                   string to,
                                   string amount,
-                                  string asset_symbol,
+                                  string asset_symbol_or_id,
                                   string memo,
                                   bool broadcast = false);
 
@@ -749,7 +775,7 @@ class wallet_api
        * @param from the name or id of the account sending the funds
        * @param to the name or id of the account receiving the funds
        * @param amount the amount to send (in nominal units -- to send half of a BTS, specify 0.5)
-       * @param asset_symbol the symbol or id of the asset to send
+       * @param asset_symbol_or_id the symbol or id of the asset to send
        * @param memo a memo to attach to the transaction.  The memo will be encrypted in the
        *             transaction and readable for the receiver.  There is no length limit
        *             other than the limit imposed by maximum transaction size, but transaction
@@ -759,9 +785,9 @@ class wallet_api
       pair<transaction_id_type,signed_transaction> transfer2(string from,
                                                              string to,
                                                              string amount,
-                                                             string asset_symbol,
+                                                             string asset_symbol_or_id,
                                                              string memo ) {
-         auto trx = transfer( from, to, amount, asset_symbol, memo, true );
+         auto trx = transfer( from, to, amount, asset_symbol_or_id, memo, true );
          return std::make_pair(trx.id(),trx);
       }
 
@@ -899,33 +925,33 @@ class wallet_api
       blind_receipt receive_blind_transfer( string confirmation_receipt, string opt_from, string opt_memo );
 
       /**
-       * Transfers a public balance from \c from_account_id_or_name to one or more blinded balances using a
+       * Transfers a public balance from \c from_account_name_or_id to one or more blinded balances using a
        * stealth transfer.
-       * @param from_account_id_or_name ID or name of an account to transfer from
-       * @param asset_symbol symbol or ID of the asset to be transferred
+       * @param from_account_name_or_id name or ID of an account to transfer from
+       * @param asset_symbol_or_id symbol or ID of the asset to be transferred
        * @param to_amounts map from key or label to amount
        * @param broadcast true to broadcast the transaction on the network
        * @return a blind confirmation
        */
-      blind_confirmation transfer_to_blind( string from_account_id_or_name,
-                                            string asset_symbol,
+      blind_confirmation transfer_to_blind( string from_account_name_or_id,
+                                            string asset_symbol_or_id,
                                             vector<pair<string, string>> to_amounts,
                                             bool broadcast = false );
 
       /**
        * Transfers funds from a set of blinded balances to a public account balance.
        * @param from_blind_account_key_or_label a public key in Base58 format or a label to transfer from
-       * @param to_account_id_or_name ID or name of an account to transfer to
+       * @param to_account_name_or_id name or ID of an account to transfer to
        * @param amount the amount to be transferred
-       * @param asset_symbol symbol or ID of the asset to be transferred
+       * @param asset_symbol_or_id symbol or ID of the asset to be transferred
        * @param broadcast true to broadcast the transaction on the network
        * @return a blind confirmation
        */
       blind_confirmation transfer_from_blind(
                                             string from_blind_account_key_or_label,
-                                            string to_account_id_or_name,
+                                            string to_account_name_or_id,
                                             string amount,
-                                            string asset_symbol,
+                                            string asset_symbol_or_id,
                                             bool broadcast = false );
 
       /**
@@ -933,14 +959,14 @@ class wallet_api
        * @param from_key_or_label a public key in Base58 format or a label to transfer from
        * @param to_key_or_label a public key in Base58 format or a label to transfer to
        * @param amount the amount to be transferred
-       * @param symbol symbol or ID of the asset to be transferred
+       * @param symbol_or_id symbol or ID of the asset to be transferred
        * @param broadcast true to broadcast the transaction on the network
        * @return a blind confirmation
        */
       blind_confirmation blind_transfer( string from_key_or_label,
                                          string to_key_or_label,
                                          string amount,
-                                         string symbol,
+                                         string symbol_or_id,
                                          bool broadcast = false );
 
       /** Place a limit order attempting to sell one asset for another.
@@ -948,8 +974,8 @@ class wallet_api
        * Buying and selling are the same operation on BitShares; if you want to buy BTS
        * with USD, you should sell USD for BTS.
        *
-       * The blockchain will attempt to sell the \c symbol_to_sell for as
-       * much \c symbol_to_receive as possible, as long as the price is at
+       * The blockchain will attempt to sell the \c symbol_or_id_to_sell for as
+       * much \c symbol_or_id_to_receive as possible, as long as the price is at
        * least \c min_to_receive / \c amount_to_sell.
        *
        * In addition to the transaction fees, market fees will apply as specified
@@ -968,10 +994,10 @@ class wallet_api
        * @param seller_account the account providing the asset being sold, and which will
        *                       receive the proceeds of the sale.
        * @param amount_to_sell the amount of the asset being sold to sell (in nominal units)
-       * @param symbol_to_sell the name or id of the asset to sell
+       * @param symbol_or_id_to_sell the symbol or id of the asset to sell
        * @param min_to_receive the minimum amount you are willing to receive in return for
        *                       selling the entire amount_to_sell
-       * @param symbol_to_receive the name or id of the asset you wish to receive
+       * @param symbol_or_id_to_receive the symbol or id of the asset you wish to receive
        * @param timeout_sec if the order does not fill immediately, this is the length of
        *                    time the order will remain on the order books before it is
        *                    cancelled and the un-spent funds are returned to the seller's
@@ -985,9 +1011,9 @@ class wallet_api
        */
       signed_transaction sell_asset(string seller_account,
                                     string amount_to_sell,
-                                    string   symbol_to_sell,
+                                    string symbol_or_id_to_sell,
                                     string min_to_receive,
-                                    string   symbol_to_receive,
+                                    string symbol_or_id_to_receive,
                                     uint32_t timeout_sec = 0,
                                     bool     fill_or_kill = false,
                                     bool     broadcast = false);
@@ -996,27 +1022,27 @@ class wallet_api
        *
        * This is the first step in shorting an asset.  Call \c sell_asset() to complete the short.
        *
-       * @param borrower_name the name or id of the account associated with the transaction.
+       * @param borrower the name or id of the account associated with the transaction.
        * @param amount_to_borrow the amount of the asset being borrowed.  Make this value
        *                         negative to pay back debt.
-       * @param asset_symbol the symbol or id of the asset being borrowed.
+       * @param asset_symbol_or_id the symbol or id of the asset being borrowed.
        * @param amount_of_collateral the amount of the backing asset to add to your collateral
        *        position.  Make this negative to claim back some of your collateral.
        *        The backing asset is defined in the \c bitasset_options for the asset being borrowed.
        * @param broadcast true to broadcast the transaction on the network
        * @returns the signed transaction borrowing the asset
        */
-      signed_transaction borrow_asset(string borrower_name, string amount_to_borrow, string asset_symbol,
+      signed_transaction borrow_asset(string borrower, string amount_to_borrow, string asset_symbol_or_id,
                                       string amount_of_collateral, bool broadcast = false);
 
       /** Borrow an asset or update the debt/collateral ratio for the loan, with additional options.
        *
        * This is the first step in shorting an asset.  Call \c sell_asset() to complete the short.
        *
-       * @param borrower_name the name or id of the account associated with the transaction.
+       * @param borrower the name or id of the account associated with the transaction.
        * @param amount_to_borrow the amount of the asset being borrowed.  Make this value
        *                         negative to pay back debt.
-       * @param asset_symbol the symbol or id of the asset being borrowed.
+       * @param asset_symbol_or_id the symbol or id of the asset being borrowed.
        * @param amount_of_collateral the amount of the backing asset to add to your collateral
        *        position.  Make this negative to claim back some of your collateral.
        *        The backing asset is defined in the \c bitasset_options for the asset being borrowed.
@@ -1024,7 +1050,7 @@ class wallet_api
        * @param broadcast true to broadcast the transaction on the network
        * @returns the signed transaction borrowing the asset
        */
-      signed_transaction borrow_asset_ext( string borrower_name, string amount_to_borrow, string asset_symbol,
+      signed_transaction borrow_asset_ext( string borrower, string amount_to_borrow, string asset_symbol_or_id,
                                            string amount_of_collateral,
                                            call_order_update_operation::extensions_type extensions,
                                            bool broadcast = false );
@@ -1066,17 +1092,17 @@ class wallet_api
                                       fc::optional<bitasset_options> bitasset_opts,
                                       bool broadcast = false);
 
-      /** Issue new shares of an asset.
+      /** Create the specified amount of the specified asset and credit into the specified account.
        *
-       * @param to_account the name or id of the account to receive the new shares
+       * @param to_account the name or id of the account to receive the new supply
        * @param amount the amount to issue, in nominal units
-       * @param symbol the ticker symbol of the asset to issue
+       * @param symbol_or_id the ticker symbol or id of the asset to issue
        * @param memo a memo to include in the transaction, readable by the recipient
        * @param broadcast true to broadcast the transaction on the network
-       * @returns the signed transaction issuing the new shares
+       * @returns the signed transaction issuing the new supply
        */
       signed_transaction issue_asset(string to_account, string amount,
-                                     string symbol,
+                                     string symbol_or_id,
                                      string memo,
                                      bool broadcast = false);
 
@@ -1088,7 +1114,7 @@ class wallet_api
        * @note This operation cannot be used to update BitAsset-specific options. For these options,
        * \c update_bitasset() instead.
        *
-       * @param symbol the name or id of the asset to update
+       * @param symbol_or_id the symbol or id of the asset to update
        * @param new_issuer if changing the asset's issuer, the name or id of the new issuer.
        *                   null if you wish to remain the issuer of the asset
        * @param new_options the new asset_options object, which will entirely replace the existing
@@ -1096,7 +1122,7 @@ class wallet_api
        * @param broadcast true to broadcast the transaction on the network
        * @returns the signed transaction updating the asset
        */
-      signed_transaction update_asset(string symbol,
+      signed_transaction update_asset(string symbol_or_id,
                                       optional<string> new_issuer,
                                       asset_options new_options,
                                       bool broadcast = false);
@@ -1107,12 +1133,12 @@ class wallet_api
        *
        * @note This operation requires the owner key to be available in the wallet.
        *
-       * @param symbol the name or id of the asset to update
+       * @param symbol_or_id the symbol or id of the asset to update
        * @param new_issuer if changing the asset's issuer, the name or id of the new issuer.
        * @param broadcast true to broadcast the transaction on the network
        * @returns the signed transaction updating the asset
        */
-      signed_transaction update_asset_issuer(string symbol,
+      signed_transaction update_asset_issuer(string symbol_or_id,
                                              string new_issuer,
                                              bool broadcast = false);
 
@@ -1123,13 +1149,13 @@ class wallet_api
        *
        * @see update_asset()
        *
-       * @param symbol the name or id of the asset to update, which must be a market-issued asset
+       * @param symbol_or_id the symbol or id of the asset to update, which must be a market-issued asset
        * @param new_options the new bitasset_options object, which will entirely replace the existing
        *                    options.
        * @param broadcast true to broadcast the transaction on the network
        * @returns the signed transaction updating the bitasset
        */
-      signed_transaction update_bitasset(string symbol,
+      signed_transaction update_bitasset(string symbol_or_id,
                                          bitasset_options new_options,
                                          bool broadcast = false);
 
@@ -1137,13 +1163,13 @@ class wallet_api
        *
        * BitAssets have price feeds selected by taking the median values of recommendations from a set of feed producers.
        * This command is used to specify which accounts may produce feeds for a given BitAsset.
-       * @param symbol the name or id of the asset to update
+       * @param symbol_or_id the symbol or id of the asset to update
        * @param new_feed_producers a list of account names or ids which are authorized to produce feeds for the asset.
        *                           this list will completely replace the existing list
        * @param broadcast true to broadcast the transaction on the network
        * @returns the signed transaction updating the bitasset's feed producers
        */
-      signed_transaction update_asset_feed_producers(string symbol,
+      signed_transaction update_asset_feed_producers(string symbol_or_id,
                                                      flat_set<string> new_feed_producers,
                                                      bool broadcast = false);
 
@@ -1162,13 +1188,13 @@ class wallet_api
        * its collateral.
        *
        * @param publishing_account the account publishing the price feed
-       * @param symbol the name or id of the asset whose feed we're publishing
+       * @param symbol_or_id the symbol or id of the asset whose feed we're publishing
        * @param feed the price_feed object containing the three prices making up the feed
        * @param broadcast true to broadcast the transaction on the network
        * @returns the signed transaction updating the price feed for the given asset
        */
       signed_transaction publish_asset_feed(string publishing_account,
-                                            string symbol,
+                                            string symbol_or_id,
                                             price_feed feed,
                                             bool broadcast = false);
 
@@ -1181,13 +1207,13 @@ class wallet_api
        * This command allows anyone to deposit the core asset into this fee pool.
        *
        * @param from the name or id of the account sending the core asset
-       * @param symbol the name or id of the asset whose fee pool you wish to fund
+       * @param symbol_or_id the symbol or id of the asset whose fee pool you wish to fund
        * @param amount the amount of the core asset to deposit
        * @param broadcast true to broadcast the transaction on the network
        * @returns the signed transaction funding the fee pool
        */
       signed_transaction fund_asset_fee_pool(string from,
-                                             string symbol,
+                                             string symbol_or_id,
                                              string amount,
                                              bool broadcast = false);
 
@@ -1199,33 +1225,33 @@ class wallet_api
        *
        * This command allows the issuer to withdraw those funds from the fee pool.
        *
-       * @param symbol the name or id of the asset whose fee pool you wish to claim
+       * @param symbol_or_id the symbol or id of the asset whose fee pool you wish to claim
        * @param amount the amount of the core asset to withdraw
        * @param broadcast true to broadcast the transaction on the network
        * @returns the signed transaction claiming from the fee pool
        */
-      signed_transaction claim_asset_fee_pool(string symbol,
+      signed_transaction claim_asset_fee_pool(string symbol_or_id,
                                               string amount,
                                               bool broadcast = false);
 
-      /** Burns an amount of given asset.
+      /** Burns an amount of given asset to its reserve pool.
        *
        * This command burns an amount of given asset to reduce the amount in circulation.
        * @note you cannot burn market-issued assets.
        * @param from the account containing the asset you wish to burn
        * @param amount the amount to burn, in nominal units
-       * @param symbol the name or id of the asset to burn
+       * @param symbol_or_id the symbol or id of the asset to burn
        * @param broadcast true to broadcast the transaction on the network
        * @returns the signed transaction burning the asset
        */
       signed_transaction reserve_asset(string from,
                                     string amount,
-                                    string symbol,
+                                    string symbol_or_id,
                                     bool broadcast = false);
 
       /** Forces a global settling of the given asset (black swan or prediction markets).
        *
-       * In order to use this operation, asset_to_settle must have the global_settle flag set
+       * In order to use this operation, asset_to_settle must have the \c global_settle permission set
        *
        * When this operation is executed all open margin positions are called at the settle price.
        * A pool will be formed containing the collateral got from the margin positions.
@@ -1235,12 +1261,12 @@ class wallet_api
        *
        * @note this operation is used only by the asset issuer.
        *
-       * @param symbol the name or id of the asset to globally settle
+       * @param symbol_or_id the symbol or id of the asset to globally settle
        * @param settle_price the price at which to settle
        * @param broadcast true to broadcast the transaction on the network
        * @returns the signed transaction settling the named asset
        */
-      signed_transaction global_settle_asset(string symbol,
+      signed_transaction global_settle_asset(string symbol_or_id,
                                              price settle_price,
                                              bool broadcast = false);
 
@@ -1254,17 +1280,17 @@ class wallet_api
        * will be based on the feed price for the market-issued asset being settled.
        * The exact settlement price will be the
        * feed price at the time of settlement with an offset in favor of the margin position, where the offset is a
-       * blockchain parameter set in the global_property_object.
+       * blockchain parameter set in the asset's bitasset options.
        *
        * @param account_to_settle the name or id of the account owning the asset
-       * @param amount_to_settle the amount of the named asset to schedule for settlement
-       * @param symbol the name or id of the asset to settle
+       * @param amount_to_settle the amount of the asset to schedule for settlement
+       * @param symbol_or_id the symbol or id of the asset to settle
        * @param broadcast true to broadcast the transaction on the network
        * @returns the signed transaction settling the named asset
        */
       signed_transaction settle_asset(string account_to_settle,
                                       string amount_to_settle,
-                                      string symbol,
+                                      string symbol_or_id,
                                       bool broadcast = false);
 
       /** Creates or updates a bid on an MPA after global settlement.
@@ -1274,16 +1300,16 @@ class wallet_api
        * the debt and the settlement fund, see BSIP-0018. Updating an existing
        * bid to cover 0 debt will delete the bid.
        *
-       * @param bidder_name the name or id of the account making the bid
+       * @param bidder the name or id of the account making the bid
        * @param debt_amount the amount of debt of the named asset to bid for
-       * @param debt_symbol the name or id of the MPA to bid for
+       * @param debt_symbol_or_id the symbol or id of the MPA to bid for
        * @param additional_collateral the amount of additional collateral to bid
        *        for taking over debt_amount. The asset type of this amount is
-       *        determined automatically from debt_symbol.
+       *        determined automatically from \c debt_symbol_or_id.
        * @param broadcast true to broadcast the transaction on the network
        * @returns the signed transaction creating/updating the bid
        */
-      signed_transaction bid_collateral(string bidder_name, string debt_amount, string debt_symbol,
+      signed_transaction bid_collateral(string bidder, string debt_amount, string debt_symbol_or_id,
                                         string additional_collateral, bool broadcast = false);
 
       /** Whitelist and blacklist accounts, primarily for transacting in whitelisted assets.
@@ -1441,7 +1467,7 @@ class wallet_api
        * @param source The account that will reserve the funds (and pay the fee)
        * @param destination The account that will receive the funds if the preimage is presented
        * @param amount the amount of the asset that is to be traded
-       * @param asset_symbol The asset that is to be traded
+       * @param asset_symbol_or_id The asset that is to be traded
        * @param hash_algorithm the algorithm used to generate the hash from the preimage. Can be RIPEMD160, SHA1 or SHA256.
        * @param preimage_hash the hash of the preimage
        * @param preimage_size the size of the preimage in bytes
@@ -1450,7 +1476,7 @@ class wallet_api
        * @param broadcast true if you wish to broadcast the transaction
        * @return the signed transaction
        */
-      signed_transaction htlc_create( string source, string destination, string amount, string asset_symbol,
+      signed_transaction htlc_create( string source, string destination, string amount, string asset_symbol_or_id,
             string hash_algorithm, const std::string& preimage_hash, uint32_t preimage_size,
             const uint32_t claim_period_seconds, const std::string& memo, bool broadcast = false );
 
@@ -1490,28 +1516,28 @@ class wallet_api
        *
        * @param witness_name The account name of the witness, also accepts account ID or vesting balance ID type.
        * @param amount The amount to withdraw.
-       * @param asset_symbol The symbol of the asset to withdraw.
+       * @param asset_symbol_or_id The symbol or id of the asset to withdraw.
        * @param broadcast true if you wish to broadcast the transaction
        * @return the signed transaction
        */
       signed_transaction withdraw_vesting(
          string witness_name,
          string amount,
-         string asset_symbol,
+         string asset_symbol_or_id,
          bool broadcast = false);
 
       /** Vote for a given committee_member.
        *
        * An account can publish a list of all committee_members they approve of.  This
        * command allows you to add or remove committee_members from this list.
-       * Each account's vote is weighted according to the number of shares of the
-       * core asset owned by that account at the time the votes are tallied.
+       * Each account's vote is weighted according to the number of voting stake
+       * owned by that account at the time the votes are tallied.
        *
        * @note you cannot vote against a committee_member, you can only vote for the committee_member
        *       or not vote for the committee_member.
        *
-       * @param voting_account the name or id of the account who is voting with their shares
-       * @param committee_member the name or id of the committee_member' owner account
+       * @param voting_account the name or id of the account who is voting with their stake
+       * @param committee_member the name or id of the committee_member's owner account
        * @param approve true if you wish to vote in favor of that committee_member, false to
        *                remove your vote in favor of that committee_member
        * @param broadcast true if you wish to broadcast the transaction
@@ -1526,13 +1552,13 @@ class wallet_api
        *
        * An account can publish a list of all witnesses they approve of.  This
        * command allows you to add or remove witnesses from this list.
-       * Each account's vote is weighted according to the number of shares of the
-       * core asset owned by that account at the time the votes are tallied.
+       * Each account's vote is weighted according to the number of voting stake
+       * owned by that account at the time the votes are tallied.
        *
        * @note you cannot vote against a witness, you can only vote for the witness
        *       or not vote for the witness.
        *
-       * @param voting_account the name or id of the account who is voting with their shares
+       * @param voting_account the name or id of the account who is voting with their stake
        * @param witness the name or id of the witness' owner account
        * @param approve true if you wish to vote in favor of that witness, false to
        *                remove your vote in favor of that witness
@@ -1556,8 +1582,8 @@ class wallet_api
        * This setting can be changed at any time.
        *
        * @param account_to_modify the name or id of the account to update
-       * @param voting_account the name or id of an account authorized to vote account_to_modify's shares,
-       *                       or null to vote your own shares
+       * @param voting_account the name or id of an account authorized to vote account_to_modify's stake,
+       *                       or null to vote your own stake
        *
        * @param broadcast true if you wish to broadcast the transaction
        * @return the signed transaction changing your vote proxy settings
@@ -1701,8 +1727,8 @@ class wallet_api
 
       /**
        * Returns the order book for the market base:quote.
-       * @param base symbol name or ID of the base asset
-       * @param quote symbol name or ID of the quote asset
+       * @param base symbol or ID of the base asset
+       * @param quote symbol or ID of the quote asset
        * @param limit depth of the order book to retrieve, for bids and asks each, capped at 50
        * @return Order book of the market
        */
@@ -1757,7 +1783,7 @@ class wallet_api
        * Each account can optionally add random information in the form of a key-value map
        * to be retrieved by any interested party.
        *
-       * @param account The account ID or name that we are adding additional information to.
+       * @param account The account name or ID that we are adding additional information to.
        * @param catalog The name of the catalog the operation will insert data to.
        * @param remove true if you want to remove stuff from a catalog.
        * @param key_values The map to be inserted/removed to/from the catalog
@@ -1773,7 +1799,7 @@ class wallet_api
        *
        * Storage data added to the map with @ref account_store_map will be returned.
        *
-       * @param account Account ID or name to get contact data from.
+       * @param account Account name or ID to get stored data from.
        * @param catalog The catalog to retrieve.
        *
        * @return An \c account_storage_object or empty.
@@ -1836,6 +1862,9 @@ FC_API( graphene::wallet::wallet_api,
         (publish_asset_feed)
         (issue_asset)
         (get_asset)
+        (get_asset_id)
+        (get_asset_name)
+        (get_asset_symbol)
         (get_bitasset_data)
         (fund_asset_fee_pool)
         (claim_asset_fee_pool)
@@ -1864,6 +1893,7 @@ FC_API( graphene::wallet::wallet_api,
         (set_desired_witness_and_committee_member_count)
         (get_account)
         (get_account_id)
+        (get_account_name)
         (get_block)
         (get_account_count)
         (get_account_history)


### PR DESCRIPTION
Add some CLI commands for convenience.
*  get_account_name (account_name_or_id)
*  get_asset_symbol (asset_symbol_or_id)
*  get_asset_name (asset_symbol_or_id)
  Note: this is a synonym of `get_asset_symbol`.

Add missing reflection for
* get_asset_id (asset_symbol_or_id)

Update some in-code docs for CLI commands.