### PR TITLE
Add database API to query for liquidity pools by any one asset in the pool

### DIFF
--- a/libraries/app/database_api_impl.hxx
+++ b/libraries/app/database_api_impl.hxx
@@ -153,6 +153,11 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
             optional<uint32_t> limit = 101,
             optional<liquidity_pool_id_type> start_id = optional<liquidity_pool_id_type>(),
             optional<bool> with_statistics = false )const;
+      vector<extended_liquidity_pool_object> get_liquidity_pools_by_one_asset(
+            std::string asset_symbol_or_id,
+            optional<uint32_t> limit = 101,
+            optional<liquidity_pool_id_type> start_id = optional<liquidity_pool_id_type>(),
+            optional<bool> with_statistics = false )const;
       vector<extended_liquidity_pool_object> get_liquidity_pools_by_both_assets(
             std::string asset_symbol_or_id_a,
             std::string asset_symbol_or_id_b,
@@ -465,6 +470,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       const application_options* _app_options = nullptr;
 
       const graphene::api_helper_indexes::amount_in_collateral_index* amount_in_collateral_index;
+      const graphene::api_helper_indexes::asset_in_liquidity_pools_index* asset_in_liquidity_pools_index;
 };
 
 } } // graphene::app

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -692,6 +692,26 @@ class database_api
             optional<bool> with_statistics = false )const;
 
       /**
+       * @brief Get a list of liquidity pools by the symbol or ID of one asset in the pool
+       * @param asset_symbol_or_id symbol name or ID of the asset
+       * @param limit  The limitation of items each query can fetch, not greater than a configured value
+       * @param start_id  Start liquidity pool id, fetch pools whose IDs are greater than or equal to this ID
+       * @param with_statistics Whether to return statistics
+       * @return The liquidity pools
+       *
+       * @note
+       * 1. if @p asset_symbol_or_id cannot be tied to an asset, an error will be returned
+       * 2. @p limit can be omitted or be null, if so the default value 101 will be used
+       * 3. @p start_id can be omitted or be null, if so the api will return the "first page" of pools
+       * 4. can only omit one or more arguments in the end of the list, but not one or more in the middle
+       */
+      vector<extended_liquidity_pool_object> get_liquidity_pools_by_one_asset(
+            std::string asset_symbol_or_id,
+            optional<uint32_t> limit = 101,
+            optional<liquidity_pool_id_type> start_id = optional<liquidity_pool_id_type>(),
+            optional<bool> with_statistics = false )const;
+
+      /**
        * @brief Get a list of liquidity pools by the symbols or IDs of the two assets in the pool
        * @param asset_symbol_or_id_a symbol name or ID of one asset
        * @param asset_symbol_or_id_b symbol name or ID of the other asset
@@ -1179,6 +1199,7 @@ FC_API(graphene::app::database_api,
    (list_liquidity_pools)
    (get_liquidity_pools_by_asset_a)
    (get_liquidity_pools_by_asset_b)
+   (get_liquidity_pools_by_one_asset)
    (get_liquidity_pools_by_both_assets)
    (get_liquidity_pools)
    (get_liquidity_pools_by_share_asset)


### PR DESCRIPTION
This PR adds a new database API which is more friendly than the old `get_liquidity_pools_by_asset_a` and `get_liquidity_pools_by_asset_b` API pair:

* `get_liquidity_pools_by_one_asset( asset, limit, start_pool_id, with_statistics )`

The `api_helper_indexes` plugin is required for this API.

Resolves https://github.com/bitshares/bitshares-core/issues/2356.