### PR TITLE
Fix cache for matrix in Github Actions

### DIFF
--- a/.github/workflows/build-and-test.mac.yml
+++ b/.github/workflows/build-and-test.mac.yml
@@ -31,13 +31,13 @@ jobs:
               -D OPENSSL_ROOT_DIR=/usr/local/opt/openssl \
               ..
     - name: Load Cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ccache
-        key: ccache-osx-${{ github.ref }}-${{ github.sha }}
+        key: ccache-${{ matrix.os }}-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
-          ccache-osx-${{ github.ref }}-
-          ccache-osx-
+          ccache-${{ matrix.os }}-${{ github.ref }}-
+          ccache-${{ matrix.os }}-
     - name: Build
       run: |
         export CCACHE_DIR="$GITHUB_WORKSPACE/ccache"

--- a/.github/workflows/build-and-test.ubuntu-debug.yml
+++ b/.github/workflows/build-and-test.ubuntu-debug.yml
@@ -71,13 +71,13 @@ jobs:
               ..
         popd
     - name: Load Cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ccache
-        key: ccache-debug-${{ github.ref }}-${{ github.sha }}
+        key: ccache-debug-${{ matrix.os }}-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
-          ccache-debug-${{ github.ref }}-
-          ccache-debug-
+          ccache-debug-${{ matrix.os }}-${{ github.ref }}-
+          ccache-debug-${{ matrix.os }}-
     - name: Build
       run: |
         export CCACHE_DIR="$GITHUB_WORKSPACE/ccache"

--- a/.github/workflows/build-and-test.ubuntu-release.yml
+++ b/.github/workflows/build-and-test.ubuntu-release.yml
@@ -57,13 +57,13 @@ jobs:
               ..
         popd
     - name: Load Cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ccache
-        key: ccache-release-${{ github.ref }}-${{ github.sha }}
+        key: ccache-release-${{ matrix.os }}-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
-          ccache-release-${{ github.ref }}-
-          ccache-release-
+          ccache-release-${{ matrix.os }}-${{ github.ref }}-
+          ccache-release-${{ matrix.os }}-
     - name: Build
       run: |
         export CCACHE_DIR="$GITHUB_WORKSPACE/ccache"


### PR DESCRIPTION
Each build environment should have its own cache. This PR does it.