### PR TITLE
Force TLSv1.2 or above when using libcurl

### DIFF
--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -38,7 +38,10 @@ class elasticsearch_plugin_impl
    public:
       elasticsearch_plugin_impl(elasticsearch_plugin& _plugin)
          : _self( _plugin )
-      {  curl = curl_easy_init(); }
+      {
+         curl = curl_easy_init();
+         curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
+      }
       virtual ~elasticsearch_plugin_impl();
 
       bool update_account_histories( const signed_block& b );

--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -653,6 +653,7 @@ graphene::utilities::ES elasticsearch_plugin::prepareHistoryQuery(string query)
 {
    CURL *curl;
    curl = curl_easy_init();
+   curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
 
    graphene::utilities::ES es;
    es.curl = curl;

--- a/libraries/plugins/es_objects/es_objects.cpp
+++ b/libraries/plugins/es_objects/es_objects.cpp
@@ -43,7 +43,10 @@ class es_objects_plugin_impl
    public:
       es_objects_plugin_impl(es_objects_plugin& _plugin)
          : _self( _plugin )
-      {  curl = curl_easy_init(); }
+      {
+         curl = curl_easy_init();
+         curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
+      }
       virtual ~es_objects_plugin_impl();
 
       bool index_database(const vector<object_id_type>& ids, std::string action);

--- a/tests/elasticsearch/main.cpp
+++ b/tests/elasticsearch/main.cpp
@@ -51,6 +51,7 @@ BOOST_AUTO_TEST_CASE(elasticsearch_account_history) {
 
       CURL *curl; // curl handler
       curl = curl_easy_init();
+      curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
 
       graphene::utilities::ES es;
       es.curl = curl;
@@ -140,6 +141,7 @@ BOOST_AUTO_TEST_CASE(elasticsearch_objects) {
 
       CURL *curl; // curl handler
       curl = curl_easy_init();
+      curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
 
       graphene::utilities::ES es;
       es.curl = curl;
@@ -195,6 +197,7 @@ BOOST_AUTO_TEST_CASE(elasticsearch_suite) {
 
       CURL *curl; // curl handler
       curl = curl_easy_init();
+      curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
 
       graphene::utilities::ES es;
       es.curl = curl;
@@ -221,6 +224,7 @@ BOOST_AUTO_TEST_CASE(elasticsearch_history_api) {
    try {
       CURL *curl; // curl handler
       curl = curl_easy_init();
+      curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
 
       graphene::utilities::ES es;
       es.curl = curl;


### PR DESCRIPTION
Fixes potential security issues.