### PR TITLE
Reduce the allowable range of negative latency

### DIFF
--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -571,7 +571,7 @@ bool application_impl::handle_block(const graphene::net::block_message& blk_msg,
            ("w",witness_account.name)
            ("i",last_irr)("d",blk_msg.block.block_num()-last_irr) );
    }
-   GRAPHENE_ASSERT( latency.count()/1000 > -5000,
+   GRAPHENE_ASSERT( latency.count()/1000 > -2500, // 2.5 seconds
                     graphene::net::block_timestamp_in_future_exception,
                     "Rejecting block with timestamp in the future", );
 

--- a/tests/app/main.cpp
+++ b/tests/app/main.cpp
@@ -336,6 +336,11 @@ BOOST_AUTO_TEST_CASE( two_node_network )
       BOOST_TEST_MESSAGE( "Generating block on db2" );
       fc::ecc::private_key committee_key = fc::ecc::private_key::regenerate(fc::sha256::hash(string("nathan")));
 
+      // the other node will reject the block if its timestamp is in the future, so we wait
+      fc::wait_for( BROADCAST_WAIT_TIME, [db2] () {
+         return db2->get_slot_time(1) <= fc::time_point::now();
+      });
+
       auto block_1 = db2->generate_block(
          db2->get_slot_time(1),
          db2->get_scheduled_witness(1),


### PR DESCRIPTION
Without this patch, when a block producer's system clock runs >= 3 seconds faster, the innocent block producers will miss blocks.

This patch makes the misconfigured block producers but not the innocents miss blocks.