### PR TITLE
Fix two_node_network connection failure in app_test

### DIFF
--- a/tests/app/main.cpp
+++ b/tests/app/main.cpp
@@ -231,12 +231,12 @@ BOOST_AUTO_TEST_CASE( two_node_network )
 
       fc::configure_logging(logging_config);
 
+      // Start app1
+      BOOST_TEST_MESSAGE( "Creating and initializing app1" );
+
       auto port = fc::network::get_available_port();
       auto app1_p2p_endpoint_str = string("127.0.0.1:") + std::to_string(port);
       auto app2_seed_nodes_str = string("[\"") + app1_p2p_endpoint_str + "\"]";
-
-      // Start app1
-      BOOST_TEST_MESSAGE( "Creating and initializing app1" );
 
       fc::temp_directory app_dir( graphene::utilities::temp_directory_path() );
       auto genesis_file = create_genesis_file(app_dir);
@@ -252,7 +252,7 @@ BOOST_AUTO_TEST_CASE( two_node_network )
       cfg.emplace("genesis-json", boost::program_options::variable_value(genesis_file, false));
       cfg.emplace("seed-nodes", boost::program_options::variable_value(string("[]"), false));
       app1.initialize(app_dir.path(), cfg);
-      BOOST_TEST_MESSAGE( "Starting app1 and waiting 500 ms" );
+      BOOST_TEST_MESSAGE( "Starting app1 and waiting" );
       app1.startup();
 
       auto node_startup_wait_time = fc::seconds(15);

--- a/tests/app/main.cpp
+++ b/tests/app/main.cpp
@@ -235,6 +235,7 @@ BOOST_AUTO_TEST_CASE( two_node_network )
       BOOST_TEST_MESSAGE( "Creating and initializing app1" );
 
       fc::temp_directory app_dir( graphene::utilities::temp_directory_path() );
+      auto genesis_file = create_genesis_file(app_dir);
 
       graphene::app::application app1;
       app1.register_plugin< graphene::account_history::account_history_plugin>();
@@ -244,7 +245,7 @@ BOOST_AUTO_TEST_CASE( two_node_network )
       app1.startup_plugins();
       boost::program_options::variables_map cfg;
       cfg.emplace("p2p-endpoint", boost::program_options::variable_value(string("127.0.0.1:3939"), false));
-      cfg.emplace("genesis-json", boost::program_options::variable_value(create_genesis_file(app_dir), false));
+      cfg.emplace("genesis-json", boost::program_options::variable_value(genesis_file, false));
       cfg.emplace("seed-nodes", boost::program_options::variable_value(string("[]"), false));
       app1.initialize(app_dir.path(), cfg);
       BOOST_TEST_MESSAGE( "Starting app1 and waiting 500 ms" );
@@ -271,7 +272,7 @@ BOOST_AUTO_TEST_CASE( two_node_network )
       app2.startup_plugins();
       boost::program_options::variables_map cfg2;
       cfg2.emplace("p2p-endpoint", boost::program_options::variable_value(string("127.0.0.1:4040"), false));
-      cfg2.emplace("genesis-json", boost::program_options::variable_value(create_genesis_file(app_dir), false));
+      cfg2.emplace("genesis-json", boost::program_options::variable_value(genesis_file, false));
       cfg2.emplace("seed-nodes", boost::program_options::variable_value(string("[\"127.0.0.1:3939\"]"), false));
       app2.initialize(app2_dir.path(), cfg2);
 

--- a/tests/common/init_unit_test_suite.hpp
+++ b/tests/common/init_unit_test_suite.hpp
@@ -21,6 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#pragma once
+
 #include <cstdlib>
 #include <iostream>
 #include <boost/test/included/unit_test.hpp>

--- a/tests/common/utils.hpp
+++ b/tests/common/utils.hpp
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#pragma once
 
 #include <fc/thread/thread.hpp>
 #include <boost/test/included/unit_test.hpp>

--- a/tests/common/utils.hpp
+++ b/tests/common/utils.hpp
@@ -26,6 +26,19 @@
 #include <fc/thread/thread.hpp>
 #include <boost/test/included/unit_test.hpp>
 
+#ifdef _WIN32
+   #ifndef _WIN32_WINNT
+      #define _WIN32_WINNT 0x0501
+   #endif
+   #include <winsock2.h>
+   #include <ws2tcpip.h>
+#else
+   #include <sys/types.h>
+   #include <sys/socket.h>
+   #include <netinet/in.h>
+   #include <netinet/ip.h>
+#endif
+
 namespace fc {
 
    /** Waits for F() to return true before max_duration has passed.
@@ -38,4 +51,34 @@ namespace fc {
          fc::usleep(fc::milliseconds(100));
       BOOST_REQUIRE( f() );
    }
-}
+
+namespace network {
+   //////
+   /// @brief attempt to find an available port on localhost
+   /// @returns an available port number, or -1 on error
+   /////
+   int get_available_port()
+   {
+      struct sockaddr_in sin;
+      int socket_fd = socket(AF_INET, SOCK_STREAM, 0);
+      if (socket_fd == -1)
+         return -1;
+      sin.sin_family = AF_INET;
+      sin.sin_port = 0;
+      sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+      if (::bind(socket_fd, (struct sockaddr*)&sin, sizeof(struct sockaddr_in)) == -1)
+         return -1;
+      socklen_t len = sizeof(sin);
+      if (getsockname(socket_fd, (struct sockaddr *)&sin, &len) == -1)
+         return -1;
+   #ifdef _WIN32
+      closesocket(socket_fd);
+   #else
+      close(socket_fd);
+   #endif
+      return ntohs(sin.sin_port);
+   }
+
+} // namespace fc::network
+
+} // namespace fc


### PR DESCRIPTION
Fixes #39.

By the way, there is another issue in `app_test` that sometimes the transaction may fail to broadcast / propagate. Since it's hard to reproduce, it won't be fixed in this pull request if it didn't appear when testing. A new pull request will be needed when it appears again.