### PR TITLE
Prettify more operations in account history in CLI

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -126,6 +126,9 @@ jobs:
         libraries/fc/tests/run-parallel-tests.sh _build/tests/chain_test -l test_suite
         _build/tests/cli_test -l test_suite
         df -h
+        echo "Cleanup"
+        rm -rf /tmp/graphene*
+        df -h
     - name: Prepare for scanning with SonarScanner
       run: |
         mkdir -p sonar_cache

--- a/libraries/wallet/operation_printer.cpp
+++ b/libraries/wallet/operation_printer.cpp
@@ -238,6 +238,50 @@ std::string operation_printer::operator()(const asset_settle_operation& op) cons
    return "";
 }
 
+std::string operation_printer::operator()(const asset_fund_fee_pool_operation& op) const
+{
+   out << "Fund " << format_asset(op.amount) << " into asset fee pool of "
+       << wallet.get_asset(op.asset_id).symbol;
+   print_fee(op.fee);
+   print_result();
+   return "";
+}
+
+std::string operation_printer::operator()(const asset_claim_pool_operation& op) const
+{
+   out << "Claim " << format_asset(op.amount_to_claim) << " from asset fee pool of "
+       << wallet.get_asset(op.asset_id).symbol;
+   print_fee(op.fee);
+   print_result();
+   return "";
+}
+
+std::string operation_printer::operator()(const asset_update_feed_producers_operation& op) const
+{
+   out << "Update price feed producers of asset " << wallet.get_asset(op.asset_to_update).symbol
+       << " to ";
+   vector<string> accounts;
+   accounts.reserve( op.new_feed_producers.size() );
+   for( const auto& account_id : op.new_feed_producers )
+   {
+      accounts.push_back( wallet.get_account( account_id ).name );
+   }
+   out << fc::json::to_string(accounts);
+   print_fee(op.fee);
+   print_result();
+   return "";
+}
+
+std::string operation_printer::operator()(const asset_publish_feed_operation& op) const
+{
+   // TODO prettify the price
+   out << "Publish price feed " << format_asset(op.feed.settlement_price.base)
+       << " / " << format_asset(op.feed.settlement_price.quote);
+   print_fee(op.fee);
+   print_result();
+   return "";
+}
+
 std::string operation_printer::operator()(const call_order_update_operation& op) const
 {
    out << "Adjust debt position with delta debt amount " << format_asset(op.delta_debt)

--- a/libraries/wallet/operation_printer.hpp
+++ b/libraries/wallet/operation_printer.hpp
@@ -99,6 +99,10 @@ public:
    std::string operator()(const graphene::protocol::asset_create_operation& op)const;
    std::string operator()(const graphene::protocol::asset_update_operation& op)const;
    std::string operator()(const graphene::protocol::asset_update_bitasset_operation& op)const;
+   std::string operator()(const graphene::protocol::asset_update_feed_producers_operation& op)const;
+   std::string operator()(const graphene::protocol::asset_publish_feed_operation& op)const;
+   std::string operator()(const graphene::protocol::asset_fund_fee_pool_operation& op)const;
+   std::string operator()(const graphene::protocol::asset_claim_pool_operation& op)const;
    std::string operator()(const graphene::protocol::asset_issue_operation& op)const;
    std::string operator()(const graphene::protocol::asset_reserve_operation& op)const;
    std::string operator()(const graphene::protocol::asset_settle_operation& op)const;

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -468,8 +468,47 @@ BOOST_FIXTURE_TEST_CASE( mpa_tests, cli_fixture )
       {
          BOOST_FAIL("Unknown exception creating BOBCOIN");
       }
+      BOOST_CHECK(generate_block(app1));
+
+      auto check_nathan_last_history = [&]( string keyword ) {
+         auto history = con.wallet_api_ptr->get_relative_account_history("nathan", 0, 1, 0);
+         BOOST_REQUIRE_GT( history.size(), 0 );
+         BOOST_CHECK( history[0].description.find( keyword ) != string::npos );
+      };
+
+      check_nathan_last_history( "Create BitAsset" );
+      check_nathan_last_history( "BOBCOIN" );
 
       auto bobcoin = con.wallet_api_ptr->get_asset("BOBCOIN");
+      {
+         // Update asset
+         BOOST_TEST_MESSAGE("Update asset");
+         auto options = bobcoin.options;
+         BOOST_CHECK_EQUAL( options.max_supply.value, 1000000 );
+         options.max_supply = 2000000;
+         con.wallet_api_ptr->update_asset("BOBCOIN", {}, options, true);
+         // Check
+         bobcoin = con.wallet_api_ptr->get_asset("BOBCOIN");
+         BOOST_CHECK_EQUAL( bobcoin.options.max_supply.value, 2000000 );
+      }
+      BOOST_CHECK(generate_block(app1));
+      check_nathan_last_history( "Update asset" );
+
+      auto bitbobcoin = con.wallet_api_ptr->get_bitasset_data("BOBCOIN");
+      {
+         // Update bitasset
+         BOOST_TEST_MESSAGE("Update bitasset");
+         auto bitoptions = bitbobcoin.options;
+         BOOST_CHECK_EQUAL( bitoptions.feed_lifetime_sec, uint32_t(GRAPHENE_DEFAULT_PRICE_FEED_LIFETIME) );
+         bitoptions.feed_lifetime_sec = 3600u;
+         con.wallet_api_ptr->update_bitasset("BOBCOIN", bitoptions, true);
+         // Check
+         bitbobcoin = con.wallet_api_ptr->get_bitasset_data("BOBCOIN");
+         BOOST_CHECK_EQUAL( bitbobcoin.options.feed_lifetime_sec, 3600u );
+      }
+      BOOST_CHECK(generate_block(app1));
+      check_nathan_last_history( "Update bitasset" );
+
       {
          // Play with asset fee pool
          auto objs = con.wallet_api_ptr->get_object( bobcoin.dynamic_asset_data_id )
@@ -489,6 +528,9 @@ BOOST_FIXTURE_TEST_CASE( mpa_tests, cli_fixture )
          share_type funded_pool = bobcoin_dyn.fee_pool;
          BOOST_CHECK_EQUAL( funded_pool.value, old_pool.value + GRAPHENE_BLOCKCHAIN_PRECISION * 2 );
 
+         BOOST_CHECK(generate_block(app1));
+         check_nathan_last_history( "Fund" );
+
          BOOST_TEST_MESSAGE("Claim fee pool");
          con.wallet_api_ptr->claim_asset_fee_pool("BOBCOIN", "1", true);
          objs = con.wallet_api_ptr->get_object( bobcoin.dynamic_asset_data_id )
@@ -497,6 +539,9 @@ BOOST_FIXTURE_TEST_CASE( mpa_tests, cli_fixture )
          bobcoin_dyn = objs[0];
          share_type claimed_pool = bobcoin_dyn.fee_pool;
          BOOST_CHECK_EQUAL( claimed_pool.value, old_pool.value + GRAPHENE_BLOCKCHAIN_PRECISION );
+
+         BOOST_CHECK(generate_block(app1));
+         check_nathan_last_history( "Claim" );
       }
 
       {
@@ -517,6 +562,9 @@ BOOST_FIXTURE_TEST_CASE( mpa_tests, cli_fixture )
          bob_bitasset = con.wallet_api_ptr->get_bitasset_data( "BOBCOIN" );
          BOOST_CHECK_EQUAL( bob_bitasset.feeds.size(), 1u );
          BOOST_CHECK( bob_bitasset.current_feed.settlement_price.is_null() );
+
+         BOOST_CHECK(generate_block(app1));
+         check_nathan_last_history( "Update price feed producers" );
       }
 
       {
@@ -528,7 +576,35 @@ BOOST_FIXTURE_TEST_CASE( mpa_tests, cli_fixture )
          con.wallet_api_ptr->publish_asset_feed( "nathan", "BOBCOIN", feed, true );
          asset_bitasset_data_object bob_bitasset = con.wallet_api_ptr->get_bitasset_data( "BOBCOIN" );
          BOOST_CHECK( bob_bitasset.current_feed.settlement_price == feed.settlement_price );
+
+         BOOST_CHECK(generate_block(app1));
+         check_nathan_last_history( "Publish price feed" );
       }
+
+      bool balance_formatter_tested = false;
+      auto check_nathan_bobcoin_balance = [&](int64_t amount) {
+         auto nathan_balances = con.wallet_api_ptr->list_account_balances( "nathan" );
+         size_t count = 0;
+         for( auto& bal : nathan_balances )
+         {
+            if( bal.asset_id == bobcoin.id )
+            {
+               ++count;
+               BOOST_CHECK_EQUAL( bal.amount.value, amount );
+            }
+         }
+         BOOST_CHECK_EQUAL(count, 1u);
+
+         // Testing result formatter
+         if( !balance_formatter_tested && formatters.find("list_account_balances") != formatters.end() )
+         {
+            BOOST_TEST_MESSAGE("Testing formatter of list_account_balances");
+            string output = formatters["list_account_balances"](
+                  fc::variant(nathan_balances, FC_PACK_MAX_DEPTH ), fc::variants());
+            BOOST_CHECK( output.find("BOBCOIN") != string::npos );
+            balance_formatter_tested = true;
+         }
+      };
 
       {
          // Borrow
@@ -537,28 +613,74 @@ BOOST_FIXTURE_TEST_CASE( mpa_tests, cli_fixture )
          BOOST_CHECK_EQUAL( calls.size(), 0u );
          con.wallet_api_ptr->borrow_asset( "nathan", "1", "BOBCOIN", "10", true );
          calls = con.wallet_api_ptr->get_call_orders( "BOBCOIN", 10 );
-         BOOST_CHECK_EQUAL( calls.size(), 1u );
+         BOOST_REQUIRE_EQUAL( calls.size(), 1u );
+         BOOST_CHECK_EQUAL( calls.front().debt.value, 10000 );
 
-         auto nathan_balances = con.wallet_api_ptr->list_account_balances( "nathan" );
-         size_t count = 0;
-         for( auto& bal : nathan_balances )
-         {
-            if( bal.asset_id == bobcoin.id )
-            {
-               ++count;
-               BOOST_CHECK_EQUAL( bal.amount.value, 10000 );
-            }
-         }
-         BOOST_CHECK_EQUAL(count, 1u);
+         BOOST_CHECK(generate_block(app1));
+         check_nathan_bobcoin_balance( 10000 );
+         check_nathan_last_history( "Adjust debt position" );
+      }
 
-         // Testing result formatter
-         if( formatters.find("list_account_balances") != formatters.end() )
-         {
-            BOOST_TEST_MESSAGE("Testing formatter of list_account_balances");
-            string output = formatters["list_account_balances"](
-                  fc::variant(nathan_balances, FC_PACK_MAX_DEPTH ), fc::variants());
-            BOOST_CHECK( output.find("BOBCOIN") != string::npos );
-         }
+      {
+         // Settle
+         BOOST_TEST_MESSAGE("Settle BOBCOIN");
+         auto settles = con.wallet_api_ptr->get_settle_orders( "BOBCOIN", 10 );
+         BOOST_CHECK_EQUAL( settles.size(), 0u );
+         con.wallet_api_ptr->settle_asset( "nathan", "0.2", "BOBCOIN", true );
+         settles = con.wallet_api_ptr->get_settle_orders( "BOBCOIN", 10 );
+         BOOST_REQUIRE_EQUAL( settles.size(), 1u );
+         BOOST_CHECK_EQUAL( settles.front().balance.amount.value, 2000 );
+
+         BOOST_CHECK(generate_block(app1));
+         check_nathan_bobcoin_balance( 8000 );
+         check_nathan_last_history( "Force-settle" );
+      }
+
+      {
+         // Transfer
+         BOOST_TEST_MESSAGE("Transfer some BOBCOIN to init0");
+         con.wallet_api_ptr->transfer2( "nathan", "init0", "0.5", "BOBCOIN", "" );
+         con.wallet_api_ptr->transfer( "nathan", "init0", "10000", "1.3.0", "" );
+
+         BOOST_CHECK(generate_block(app1));
+         check_nathan_bobcoin_balance( 3000 );
+         check_nathan_last_history( "Transfer" );
+
+      }
+
+      {
+         // Nathan places an order
+         BOOST_TEST_MESSAGE("Nathan place an order to buy BOBCOIN");
+         auto orders = con.wallet_api_ptr->get_limit_orders( "BOBCOIN", "1.3.0", 10 );
+         BOOST_CHECK_EQUAL( orders.size(), 0u );
+         con.wallet_api_ptr->sell_asset( "nathan", "100", "1.3.0", "1", "BOBCOIN", 300, false, true );
+         orders = con.wallet_api_ptr->get_limit_orders( "BOBCOIN", "1.3.0", 10 );
+         BOOST_REQUIRE_EQUAL( orders.size(), 1u );
+         BOOST_CHECK_EQUAL( orders.front().for_sale.value, 100 * GRAPHENE_BLOCKCHAIN_PRECISION );
+         limit_order_id_type nathan_order_id = orders.front().id;
+
+         BOOST_CHECK(generate_block(app1));
+         check_nathan_bobcoin_balance( 3000 );
+         check_nathan_last_history( "Create limit order" );
+
+         // init0 place an order to partially fill Nathan's order
+         BOOST_TEST_MESSAGE("init0 place an order to sell BOBCOIN");
+         con.wallet_api_ptr->sell_asset( "init0", "0.1", "BOBCOIN", "1", "1.3.0", 200, true, true );
+         orders = con.wallet_api_ptr->get_limit_orders( "BOBCOIN", "1.3.0", 10 );
+         BOOST_REQUIRE_EQUAL( orders.size(), 1u );
+         BOOST_CHECK_EQUAL( orders.front().for_sale.value, 90 * GRAPHENE_BLOCKCHAIN_PRECISION );
+
+         BOOST_CHECK(generate_block(app1));
+         check_nathan_bobcoin_balance( 4000 );
+         check_nathan_last_history( "as maker" );
+
+         // Nathan cancel order
+         BOOST_TEST_MESSAGE("Nathan cancel order");
+         con.wallet_api_ptr->cancel_order( nathan_order_id, true );
+
+         BOOST_CHECK(generate_block(app1));
+         check_nathan_bobcoin_balance( 4000 );
+         check_nathan_last_history( "Cancel limit order" );
       }
 
    } catch( fc::exception& e ) {


### PR DESCRIPTION
Prettify more operations in account history in CLI, add tests for them and others.
- asset_update_feed_producers_operation
- asset_publish_feed_operation
- asset_fund_fee_pool_operation
- asset_claim_pool_operation

For https://github.com/bitshares/bitshares-core/issues/2296.