### PR TITLE
Fix sign_memo command for signing with public keys

### DIFF
--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -802,8 +802,8 @@ class wallet_api
 
       /** Sign a memo message.
        *
-       * @param from the name or id of signing account; or a public key
-       * @param to the name or id of receiving account; or a public key
+       * @param from the name or id of signing account, or a public key, or a label of a public key
+       * @param to the name or id of receiving account, or a public key, or a label of a public key
        * @param memo text to sign
        * @return the signed memo data
        */

--- a/libraries/wallet/wallet_sign.cpp
+++ b/libraries/wallet/wallet_sign.cpp
@@ -138,11 +138,11 @@ namespace graphene { namespace wallet { namespace detail {
       try {
          account_object from_account = get_account(from);
          md.from = from_account.options.memo_key;
-      } catch (const fc::exception& e) {
+      } catch (const fc::exception&) {
          // check if the string itself is a pubkey, if not, consider it as a label
          try {
             md.from = public_key_type( from );
-         } catch (const fc::exception& e) {
+         } catch (const fc::exception&) {
             md.from = self.get_public_key( from );
          }
       }
@@ -150,11 +150,11 @@ namespace graphene { namespace wallet { namespace detail {
       try {
          account_object to_account = get_account(to);
          md.to = to_account.options.memo_key;
-      } catch (const fc::exception& e) {
+      } catch (const fc::exception&) {
          // check if the string itself is a pubkey, if not, consider it as a label
          try {
             md.to = public_key_type( to );
-         } catch (const fc::exception& e) {
+         } catch (const fc::exception&) {
             md.to = self.get_public_key( to );
          }
       }
@@ -162,7 +162,7 @@ namespace graphene { namespace wallet { namespace detail {
       // try to get private key of from and sign, if that fails, try to sign with to
       try {
          md.set_message(get_private_key(md.from), md.to, memo);
-      } catch (const fc::exception& e) {
+      } catch (const fc::exception&) {
          std::swap( md.from, md.to );
          md.set_message(get_private_key(md.from), md.to, memo);
          std::swap( md.from, md.to );

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -517,7 +517,7 @@ BOOST_FIXTURE_TEST_CASE( uia_tests, cli_fixture )
       check_bobcoin_balance( "init0", 30000 );
 
       {
-         // Override transfer
+         // Override transfer, and test sign_memo and read_memo by the way
          BOOST_TEST_MESSAGE("Override-transfer BOBCOIN from init0");
          auto handle = con.wallet_api_ptr->begin_builder_transaction();
          override_transfer_operation op;
@@ -525,13 +525,29 @@ BOOST_FIXTURE_TEST_CASE( uia_tests, cli_fixture )
          op.from = con.wallet_api_ptr->get_account( "init0" ).id;
          op.to = con.wallet_api_ptr->get_account( "nathan" ).id;
          op.amount = bobcoin.amount(10000);
-         op.memo = con.wallet_api_ptr->sign_memo( "nathan", "init0", "get back some coin" );
+
+         const auto test_bki = con.wallet_api_ptr->suggest_brain_key();
+         auto test_pubkey = fc::json::to_string( test_bki.pub_key );
+         test_pubkey = test_pubkey.substr( 1, test_pubkey.size() - 2 );
+         idump( (test_pubkey) );
+         op.memo = con.wallet_api_ptr->sign_memo( test_pubkey, "nathan", "get back some coin" );
+         idump( (op.memo) );
          con.wallet_api_ptr->add_operation_to_builder_transaction( handle, op );
          con.wallet_api_ptr->set_fees_on_builder_transaction( handle, "1.3.0" );
          con.wallet_api_ptr->sign_builder_transaction( handle, true );
 
          auto memo = con.wallet_api_ptr->read_memo( *op.memo );
          BOOST_CHECK_EQUAL( memo, "get back some coin" );
+
+         op.memo = con.wallet_api_ptr->sign_memo( "nathan", test_pubkey, "another test" );
+         idump( (op.memo) );
+         memo = con.wallet_api_ptr->read_memo( *op.memo );
+         BOOST_CHECK_EQUAL( memo, "another test" );
+
+         BOOST_CHECK_THROW( con.wallet_api_ptr->sign_memo( "non-exist-account-or-label", "nathan", "some text" ),
+                            fc::exception );
+         BOOST_CHECK_THROW( con.wallet_api_ptr->sign_memo( "nathan", "non-exist-account-or-label", "some text" ),
+                            fc::exception );
       }
       BOOST_CHECK(generate_block(app1));
 
@@ -875,6 +891,15 @@ BOOST_FIXTURE_TEST_CASE( cli_vote_for_2_witnesses, cli_fixture )
       int init1_last_votes = init1_obj.total_votes;
       if( !is_hf2262_passed(app1) )
          BOOST_CHECK(init1_last_votes > init1_start_votes);
+
+      auto check_account_last_history = [&]( string account, string keyword ) {
+         auto history = con.wallet_api_ptr->get_relative_account_history(account, 0, 1, 0);
+         BOOST_REQUIRE_GT( history.size(), 0 );
+         BOOST_CHECK( history[0].description.find( keyword ) != string::npos );
+      };
+
+      check_account_last_history( "jmjatlanta", "Update Account 'jmjatlanta'" );
+
    } catch( fc::exception& e ) {
       edump((e.to_detail_string()));
       throw;
@@ -1668,6 +1693,20 @@ BOOST_AUTO_TEST_CASE( cli_create_htlc )
          BOOST_CHECK(generate_block(app1));
       }
 
+      // test operation_printer
+      auto hist = con.wallet_api_ptr->get_account_history("alice", 10);
+      for(size_t i = 0; i < hist.size(); ++i)
+      {
+         auto obj = hist[i];
+         std::stringstream ss;
+         ss << "Description: " << obj.description << "\n";
+         auto str = ss.str();
+         BOOST_TEST_MESSAGE( str );
+         if (i == 3 || i == 4)
+         {
+            BOOST_CHECK( str.find("SHA256 8a45f62f47") != std::string::npos );
+         }
+      }
    } catch( fc::exception& e ) {
       edump((e.to_detail_string()));
       throw;

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -437,6 +437,8 @@ BOOST_FIXTURE_TEST_CASE( uia_tests, cli_fixture )
 
       INVOKE(upgrade_nathan_account);
 
+      BOOST_CHECK(generate_block(app1));
+
       account_object nathan_acct = con.wallet_api_ptr->get_account("nathan");
 
       auto formatters = con.wallet_api_ptr->get_result_formatters();
@@ -449,6 +451,8 @@ BOOST_FIXTURE_TEST_CASE( uia_tests, cli_fixture )
       auto check_nathan_last_history = [&]( string keyword ) {
          check_account_last_history( "nathan", keyword );
       };
+
+      check_nathan_last_history( "account_upgrade_operation" );
 
       // Create new asset called BOBCOIN
       {


### PR DESCRIPTION
Fix sign_memo command for signing with public keys, and add CLI tests
- more tests about read_memo and sign_memo
- formatter of account_update_operation in account history
- result formatter for SHA256 hashes in HTLC operations