### PR TITLE
Restore default logger of network module to "p2p"

### DIFF
--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -91,13 +91,6 @@
 
 #include "node_impl.hxx"
 
-//#define ENABLE_DEBUG_ULOGS
-
-#ifdef DEFAULT_LOGGER
-# undef DEFAULT_LOGGER
-#endif
-#define DEFAULT_LOGGER "p2p"
-
 #define INVOCATION_COUNTER(name) \
     static size_t total_ ## name ## _counter = 0; \
     static size_t active_ ## name ## _counter = 0; \
@@ -117,13 +110,6 @@
         dlog("NEWDEBUG: Leaving " #name ", now ${total} total calls, ${active} active calls", ("total", *total)("active", *active)); \
       } \
     } invocation_logger(&total_ ## name ## _counter, &active_ ## name ## _counter)
-
-//log these messages even at warn level when operating on the test network
-#ifdef GRAPHENE_TEST_NETWORK
-#define testnetlog wlog
-#else
-#define testnetlog(...) do {} while (0)
-#endif
 
 namespace graphene { namespace net { namespace detail {
 

--- a/libraries/net/node_impl.hxx
+++ b/libraries/net/node_impl.hxx
@@ -16,6 +16,20 @@ namespace bmi = boost::multi_index;
 
 #define P2P_IN_DEDICATED_THREAD
 
+//#define ENABLE_DEBUG_ULOGS
+
+#ifdef DEFAULT_LOGGER
+# undef DEFAULT_LOGGER
+#endif
+#define DEFAULT_LOGGER "p2p"
+
+//log these messages even at warn level when operating on the test network
+#ifdef GRAPHENE_TEST_NETWORK
+#define testnetlog wlog
+#else
+#define testnetlog(...) do {} while (0)
+#endif
+
 /*******
  * A class to wrap std::unordered_set for multithreading
  */


### PR DESCRIPTION
Fix a logging issue introduced by https://github.com/bitshares/bitshares-core/commit/1b2291dd169458b1bba0c7a093cb3a431b2bc414 in #2403.