### PR TITLE
Remove unavailable item from active sync requests, fix node stuck issue

### DIFF
--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -2359,6 +2359,7 @@ namespace graphene { namespace net { namespace detail {
       auto sync_item_iter = originating_peer->sync_items_requested_from_peer.find(requested_item.item_hash);
       if (sync_item_iter != originating_peer->sync_items_requested_from_peer.end())
       {
+        _active_sync_requests.erase(*sync_item_iter);
         originating_peer->sync_items_requested_from_peer.erase(sync_item_iter);
 
         if (originating_peer->peer_needs_sync_items_from_us)

--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -1610,7 +1610,7 @@ namespace graphene { namespace net { namespace detail {
       originating_peer->send_message(address_request_message());
       fc::time_point now = fc::time_point::now();
       if (_is_firewalled == firewalled_state::unknown &&
-          _last_firewall_check_message_sent < now - fc::minutes(5) &&
+          _last_firewall_check_message_sent < (now - fc::minutes(5)) &&
           originating_peer->core_protocol_version >= 106)
       {
         wlog("I don't know if I'm firewalled.  Sending a firewall check message to peer ${peer}",
@@ -2169,7 +2169,7 @@ namespace graphene { namespace net { namespace detail {
               originating_peer->last_block_time_delegate_has_seen + // timestamp of the block immediately before the first unfetched block
               originating_peer->number_of_unfetched_item_ids * GRAPHENE_MIN_BLOCK_INTERVAL;
           fc::time_point_sec now = fc::time_point::now();
-          if (minimum_time_of_last_offered_block > now + GRAPHENE_NET_FUTURE_SYNC_BLOCKS_GRACE_PERIOD_SEC)
+          if (minimum_time_of_last_offered_block > (now + GRAPHENE_NET_FUTURE_SYNC_BLOCKS_GRACE_PERIOD_SEC))
           {
             wlog("Disconnecting from peer ${peer} who offered us an implausible number of blocks, their last block would be in the future (${timestamp})",
                  ("peer", originating_peer->get_remote_endpoint())


### PR DESCRIPTION
Fixes #2434 (node gets stuck when syncing).

When got an `item_not_available_message` from a peer, the item was
removed from the `sync_items_requested_from_peer` list of the peer,
but it was left in the `_active_sync_requests` list.
When disconnecting from the peer, since the
`sync_items_requested_from_peer` list of the peer no longer contains
the item, the cleanup process does not remove it from the
`_active_sync_requests` list either.
As a result, the node will not request the item from another peer,
thus gets stuck.

This Ci job reproduces the issue: https://github.com/abitmore/bitshares-core/runs/2491471762 ,
this CI job verifies the fix: https://github.com/abitmore/bitshares-core/runs/2491784005 (note: the log files are large).