### PR TITLE
Add asset authorization checks for some operations

### DIFF
--- a/libraries/chain/hardfork.d/CORE_973.hf
+++ b/libraries/chain/hardfork.d/CORE_973.hf
@@ -1,0 +1,6 @@
+// bitshares-core issue #973 check asset authorizations for operations
+#ifndef HARDFORK_CORE_973_TIME
+// Jan 1 2030, midnight; this is a dummy date until a hardfork date is scheduled
+#define HARDFORK_CORE_973_TIME (fc::time_point_sec( 1893456000 ))
+#define HARDFORK_CORE_973_PASSED(now) (now >= HARDFORK_CORE_973_TIME)
+#endif

--- a/libraries/chain/include/graphene/chain/market_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/market_evaluator.hpp
@@ -80,7 +80,6 @@ namespace graphene { namespace chain {
 
          bool _closing_order = false;
          const asset_object* _debt_asset = nullptr;
-         const account_object* _paying_account = nullptr;
          const call_order_object* _order = nullptr;
          const asset_bitasset_data_object* _bitasset_data = nullptr;
          const asset_dynamic_data_object*  _dynamic_data_obj = nullptr;
@@ -96,7 +95,6 @@ namespace graphene { namespace chain {
 
          const asset_object* _debt_asset = nullptr;
          const asset_bitasset_data_object* _bitasset_data = nullptr;
-         const account_object* _paying_account = nullptr;
          const collateral_bid_object* _bid = nullptr;
    };
 

--- a/libraries/chain/market_evaluator.cpp
+++ b/libraries/chain/market_evaluator.cpp
@@ -184,7 +184,7 @@ void_result call_order_update_evaluator::do_evaluate(const call_order_update_ope
 
    auto next_maintenance_time = d.get_dynamic_global_properties().next_maintenance_time;
 
-   _paying_account = &o.funding_account(d);
+   // Note: funding_account is the fee payer thus exists in the database
    _debt_asset     = &o.delta_debt.asset_id(d);
    FC_ASSERT( _debt_asset->is_market_issued(), "Unable to cover ${sym} as it is not a collateralized asset.",
               ("sym", _debt_asset->symbol) );
@@ -220,6 +220,15 @@ void_result call_order_update_evaluator::do_evaluate(const call_order_update_ope
    else if( _bitasset_data->current_feed.settlement_price.is_null() )
       FC_THROW_EXCEPTION(insufficient_feeds, "Cannot borrow asset with no price feed.");
 
+   // Since hard fork core-973, check asset authorization limitations
+   if( HARDFORK_CORE_973_PASSED(d.head_block_time()) )
+   {
+      FC_ASSERT( is_authorized_asset( d, *fee_paying_account, *_debt_asset ),
+                 "The account is not allowed to transact the debt asset" );
+      FC_ASSERT( is_authorized_asset( d, *fee_paying_account, _bitasset_data->options.short_backing_asset(d) ),
+                 "The account is not allowed to transact the collateral asset" );
+   }
+
    // Note: there was code here checking whether the account has enough balance to increase delta collateral,
    //       which is now removed since the check is implicitly done later by `adjust_balance()` in `do_apply()`.
 
@@ -248,7 +257,7 @@ object_id_type call_order_update_evaluator::do_apply(const call_order_update_ope
       // Adjust the total core in orders accodingly
       if( o.delta_collateral.asset_id == asset_id_type() )
       {
-         d.modify(_paying_account->statistics(d), [&](account_statistics_object& stats) {
+         d.modify( d.get_account_stats_by_owner( o.funding_account ), [&](account_statistics_object& stats) {
                stats.total_core_in_orders += o.delta_collateral.amount;
          });
       }
@@ -398,7 +407,7 @@ void_result bid_collateral_evaluator::do_evaluate(const bid_collateral_operation
 
    FC_ASSERT( d.head_block_time() > HARDFORK_CORE_216_TIME, "Not yet!" );
 
-   _paying_account = &o.bidder(d);
+   // Note: bidder is the fee payer thus exists in the database
    _debt_asset     = &o.debt_covered.asset_id(d);
    FC_ASSERT( _debt_asset->is_market_issued(), "Unable to cover ${sym} as it is not a collateralized asset.",
               ("sym", _debt_asset->symbol) );
@@ -421,18 +430,27 @@ void_result bid_collateral_evaluator::do_evaluate(const bid_collateral_operation
 
    if( o.additional_collateral.amount > 0 )
    {
+      auto collateral_balance = d.get_balance( o.bidder, _bitasset_data->options.short_backing_asset );
       if( _bid && d.head_block_time() >= HARDFORK_CORE_1692_TIME ) // TODO: see if HF check can be removed after HF
       {
          asset delta = o.additional_collateral - _bid->get_additional_collateral();
-         FC_ASSERT( d.get_balance(*_paying_account, _bitasset_data->options.short_backing_asset(d)) >= delta,
+         FC_ASSERT( collateral_balance >= delta,
                     "Cannot increase bid from ${oc} to ${nc} collateral when payer only has ${b}",
                     ("oc", _bid->get_additional_collateral().amount)("nc", o.additional_collateral.amount)
-                    ("b", d.get_balance(*_paying_account, o.additional_collateral.asset_id(d)).amount) );
+                    ("b", collateral_balance.amount) );
       } else
-         FC_ASSERT( d.get_balance( *_paying_account,
-                                   _bitasset_data->options.short_backing_asset(d) ) >= o.additional_collateral,
+         FC_ASSERT( collateral_balance >= o.additional_collateral,
                     "Cannot bid ${c} collateral when payer only has ${b}", ("c", o.additional_collateral.amount)
-                    ("b", d.get_balance(*_paying_account, o.additional_collateral.asset_id(d)).amount) );
+                    ("b", collateral_balance.amount) );
+   }
+
+   // Since hard fork core-973, check asset authorization limitations
+   if( HARDFORK_CORE_973_PASSED(d.head_block_time()) )
+   {
+      FC_ASSERT( is_authorized_asset( d, *fee_paying_account, *_debt_asset ),
+                 "The account is not allowed to transact the debt asset" );
+      FC_ASSERT( is_authorized_asset( d, *fee_paying_account, _bitasset_data->options.short_backing_asset(d) ),
+                 "The account is not allowed to transact the collateral asset" );
    }
 
    return void_result();

--- a/libraries/chain/market_evaluator.cpp
+++ b/libraries/chain/market_evaluator.cpp
@@ -257,7 +257,7 @@ object_id_type call_order_update_evaluator::do_apply(const call_order_update_ope
       // Adjust the total core in orders accodingly
       if( o.delta_collateral.asset_id == asset_id_type() )
       {
-         d.modify( d.get_account_stats_by_owner( o.funding_account ), [&](account_statistics_object& stats) {
+         d.modify( d.get_account_stats_by_owner( o.funding_account ), [&o](account_statistics_object& stats) {
                stats.total_core_in_orders += o.delta_collateral.amount;
          });
       }

--- a/libraries/chain/transfer_evaluator.cpp
+++ b/libraries/chain/transfer_evaluator.cpp
@@ -99,12 +99,16 @@ void_result override_transfer_evaluator::do_evaluate( const override_transfer_op
    const account_object& from_account    = op.from(d);
    const account_object& to_account      = op.to(d);
 
-   FC_ASSERT( is_authorized_asset( d, to_account, asset_type ) );
+   FC_ASSERT( is_authorized_asset( d, to_account, asset_type ),
+              "The to_account is not allowed to transact the asset" );
    // Since hard fork core-2295, do not check asset authorization limitations on from_account for override_transfer
    // TODO code cleanup: if applicable (could be false due to proposals),
    //      remove the check and the assertion below after the hard fork time, keep the comment about reasoning above
    if( !HARDFORK_CORE_2295_PASSED(d.head_block_time()) )
-      FC_ASSERT( is_authorized_asset( d, from_account, asset_type ) );
+   {
+      FC_ASSERT( is_authorized_asset( d, from_account, asset_type ),
+                 "The from_account is not allowed to transact the asset" );
+   }
 
    FC_ASSERT( d.get_balance( from_account, asset_type ).amount >= op.amount.amount,
               "", ("total_transfer",op.amount)("balance",d.get_balance(from_account, asset_type).amount) );

--- a/libraries/chain/vesting_balance_evaluator.cpp
+++ b/libraries/chain/vesting_balance_evaluator.cpp
@@ -27,6 +27,7 @@
 #include <graphene/chain/vesting_balance_evaluator.hpp>
 #include <graphene/chain/vesting_balance_object.hpp>
 #include <graphene/chain/hardfork.hpp>
+#include <graphene/chain/is_authorized_asset.hpp>
 
 namespace graphene { namespace chain {
 
@@ -34,14 +35,21 @@ void_result vesting_balance_create_evaluator::do_evaluate( const vesting_balance
 { try {
    const database& d = db();
 
-   const account_object& creator_account = op.creator( d );
-   /* const account_object& owner_account = */ op.owner( d );
+   const account_object& creator_account = *fee_paying_account;
+   const account_object& owner_account = op.owner( d );
 
-   // TODO: Check asset authorizations and withdrawals
+   const asset_object& asset_obj = op.amount.asset_id( d );
 
-   FC_ASSERT( op.amount.amount > 0 );
-   FC_ASSERT( d.get_balance( creator_account.id, op.amount.asset_id ) >= op.amount );
-   FC_ASSERT( !op.amount.asset_id(d).is_transfer_restricted() );
+   FC_ASSERT( !asset_obj.is_transfer_restricted(), "Asset has transfer_restricted flag enabled" );
+
+   // Since hard fork core-973, check asset authorization limitations
+   if( HARDFORK_CORE_973_PASSED(d.head_block_time()) )
+   {
+      FC_ASSERT( is_authorized_asset( d, creator_account, asset_obj ),
+                 "The creator account is not allowed to transact the asset" );
+      FC_ASSERT( is_authorized_asset( d, owner_account, asset_obj ),
+                 "The owner account is not allowed to transact the asset" );
+   }
 
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (op) ) }
@@ -90,7 +98,6 @@ object_id_type vesting_balance_create_evaluator::do_apply( const vesting_balance
    database& d = db();
    const time_point_sec now = d.head_block_time();
 
-   FC_ASSERT( d.get_balance( op.creator, op.amount.asset_id ) >= op.amount );
    d.adjust_balance( op.creator, -op.amount );
 
    const vesting_balance_object& vbo = d.create< vesting_balance_object >( [&]( vesting_balance_object& obj )
@@ -116,8 +123,8 @@ void_result vesting_balance_withdraw_evaluator::do_evaluate( const vesting_balan
    FC_ASSERT( vbo.is_withdraw_allowed( now, op.amount ), "", ("now", now)("op", op)("vbo", vbo) );
    assert( op.amount <= vbo.balance );      // is_withdraw_allowed should fail before this check is reached
 
-   /* const account_object& owner_account = */ op.owner( d );
-   // TODO: Check asset authorizations and withdrawals
+   // Note: asset authorization check is skipped here,
+   //       because it is fine to allow the funds to be moved to account balance
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (op) ) }
 
@@ -139,7 +146,6 @@ void_result vesting_balance_withdraw_evaluator::do_apply( const vesting_balance_
 
    d.adjust_balance( op.owner, op.amount );
 
-   // TODO: Check asset authorizations and withdrawals
    return void_result();
 } FC_CAPTURE_AND_RETHROW( (op) ) }
 

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -287,6 +287,161 @@ BOOST_AUTO_TEST_CASE( old_call_order_update_test_after_hardfork_583 )
    }
 }
 
+BOOST_AUTO_TEST_CASE( call_order_update_asset_auth_test )
+{
+   try {
+      generate_blocks( HARDFORK_CORE_973_TIME - fc::days(1) );
+      set_expiration( db, trx );
+
+      ACTORS((dan)(sam));
+
+      const auto& backasset = create_user_issued_asset("BACK", sam, white_list | charge_market_fee);
+      asset_id_type back_id = backasset.id;
+
+      const auto& bitusd = create_bitasset("USDBIT", sam.id, 10, white_list | charge_market_fee, 3, back_id);
+      asset_id_type usd_id = bitusd.id;
+
+      issue_uia( dan_id, backasset.amount(10000000) );
+      issue_uia( sam_id, backasset.amount(10000000) );
+
+      update_feed_producers( bitusd, {sam.id} );
+
+      price_feed current_feed;
+      current_feed.core_exchange_rate = bitusd.amount( 100 ) / asset( 100 );
+      current_feed.settlement_price = bitusd.amount( 100 ) / backasset.amount( 100 );
+      current_feed.maintenance_collateral_ratio = 1750; // need to set explicitly, testnet has a different default
+      publish_feed( bitusd, sam, current_feed );
+
+      FC_ASSERT( bitusd.bitasset_data(db).current_feed.settlement_price == current_feed.settlement_price );
+
+      BOOST_TEST_MESSAGE( "attempting to borrow using 2x collateral at 1:1 price now that there is a valid order" );
+      borrow( dan, bitusd.amount(5000), backasset.amount(10000) );
+      BOOST_REQUIRE_EQUAL( get_balance( dan, bitusd ), 5000 );
+      BOOST_REQUIRE_EQUAL( get_balance( dan, backasset ), 10000000 - 10000 );
+
+      // Make a whitelist
+      {
+         BOOST_TEST_MESSAGE( "Setting up whitelisting" );
+         asset_update_operation uop;
+         uop.issuer = sam_id;
+
+         // For USDBIT
+         uop.asset_to_update = usd_id;
+         uop.new_options = usd_id(db).options;
+         // The whitelist is managed by Sam
+         uop.new_options.whitelist_authorities.insert(sam_id);
+         trx.operations.clear();
+         trx.operations.push_back(uop);
+         PUSH_TX( db, trx, ~0 );
+
+         // For BACK
+         uop.asset_to_update = back_id;
+         uop.new_options = back_id(db).options;
+         // The whitelist is managed by Sam
+         uop.new_options.whitelist_authorities.insert(sam_id);
+         trx.operations.clear();
+         trx.operations.push_back(uop);
+         PUSH_TX( db, trx, ~0 );
+
+         // Upgrade Sam so that he can manage the whitelist
+         upgrade_to_lifetime_member( sam_id );
+
+         // Add Sam to the whitelist, but do not add Dan
+         account_whitelist_operation wop;
+         wop.authorizing_account = sam_id;
+         wop.account_to_list = sam_id;
+         wop.new_listing = account_whitelist_operation::white_listed;
+         trx.operations.clear();
+         trx.operations.push_back(wop);
+         PUSH_TX( db, trx, ~0 );
+      }
+
+      // Reproduces bitshares-core issue #973: no asset authorization check thus Dan is able to borrow
+      BOOST_TEST_MESSAGE( "Dan attempting to borrow using 2x collateral at 1:1 price again" );
+      borrow( dan_id(db), usd_id(db).amount(5000), back_id(db).amount(10000) );
+      BOOST_REQUIRE_EQUAL( get_balance( dan_id, usd_id ), 5000 + 5000);
+      BOOST_REQUIRE_EQUAL( get_balance( dan_id, back_id ), 10000000 - 10000 - 10000 );
+
+      // Apply core-973 hardfork
+      generate_blocks( HARDFORK_CORE_973_TIME );
+      set_expiration( db, trx );
+
+      // Update price feed
+      publish_feed( usd_id(db), sam_id(db), current_feed );
+
+      // Sam should be able to borrow, but Dan should be unable to borrow
+      borrow( sam_id(db), usd_id(db).amount(5000), back_id(db).amount(10000) );
+      BOOST_REQUIRE_EQUAL( get_balance( sam_id, usd_id ), 5000 );
+      BOOST_REQUIRE_EQUAL( get_balance( sam_id, back_id ), 10000000 - 10000 );
+
+      GRAPHENE_REQUIRE_THROW( borrow( dan_id(db), usd_id(db).amount(5000), back_id(db).amount(10000) ),
+                              fc::exception );
+
+      // Update USDBIT, disable remove whitelisting
+      {
+         BOOST_TEST_MESSAGE( "Disable USDBIT whitelisting" );
+         asset_update_operation uop;
+         uop.issuer = sam_id;
+
+         // For USDBIT
+         uop.asset_to_update = usd_id;
+         uop.new_options = usd_id(db).options;
+         uop.new_options.whitelist_authorities.clear();
+         trx.operations.clear();
+         trx.operations.push_back(uop);
+         PUSH_TX( db, trx, ~0 );
+      }
+
+      // Sam should be able to borrow, but Dan should be unable to borrow
+      borrow( sam_id(db), usd_id(db).amount(5000), back_id(db).amount(10000) );
+      GRAPHENE_REQUIRE_THROW( borrow( dan_id(db), usd_id(db).amount(5000), back_id(db).amount(10000) ),
+                              fc::exception );
+
+      // Update BACK, disable whitelisting
+      {
+         BOOST_TEST_MESSAGE( "Disable BACK whitelisting" );
+         asset_update_operation uop;
+         uop.issuer = sam_id;
+
+         // For USDBIT
+         uop.asset_to_update = back_id;
+         uop.new_options = back_id(db).options;
+         uop.new_options.whitelist_authorities.clear();
+         trx.operations.clear();
+         trx.operations.push_back(uop);
+         PUSH_TX( db, trx, ~0 );
+      }
+
+      // Both Sam and Dan should be able to borrow
+      borrow( sam_id(db), usd_id(db).amount(5000), back_id(db).amount(10000) );
+      borrow( dan_id(db), usd_id(db).amount(5000), back_id(db).amount(10000) );
+
+      // Update USDBIT, enable whitelisting
+      {
+         BOOST_TEST_MESSAGE( "Enable USDBIT whitelisting again" );
+         asset_update_operation uop;
+         uop.issuer = sam_id;
+
+         // For USDBIT
+         uop.asset_to_update = usd_id;
+         uop.new_options = usd_id(db).options;
+         uop.new_options.whitelist_authorities.insert( sam_id );
+         trx.operations.clear();
+         trx.operations.push_back(uop);
+         PUSH_TX( db, trx, ~0 );
+      }
+
+      // Sam should be able to borrow, but Dan should be unable to borrow
+      borrow( sam_id(db), usd_id(db).amount(5000), back_id(db).amount(10000) );
+      GRAPHENE_REQUIRE_THROW( borrow( dan_id(db), usd_id(db).amount(5000), back_id(db).amount(10000) ),
+                              fc::exception );
+
+   } catch (fc::exception& e) {
+      edump((e.to_detail_string()));
+      throw;
+   }
+}
+
 BOOST_AUTO_TEST_CASE( asset_settle_cancel_operation_test_after_hf588 )
 {
    set_expiration( db, trx );

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -436,6 +436,8 @@ BOOST_AUTO_TEST_CASE( call_order_update_asset_auth_test )
       GRAPHENE_REQUIRE_THROW( borrow( dan_id(db), usd_id(db).amount(5000), back_id(db).amount(10000) ),
                               fc::exception );
 
+      generate_block();
+
    } catch (fc::exception& e) {
       edump((e.to_detail_string()));
       throw;
@@ -599,6 +601,169 @@ BOOST_AUTO_TEST_CASE( asset_settle_operation_asset_auth_test )
       force_settle( sam_id(db), usd_id(db).amount(100) );
       BOOST_REQUIRE_EQUAL( get_balance( dan_id, usd_id ), 2800 );
       BOOST_REQUIRE_EQUAL( get_balance( sam_id, usd_id ), 1500 );
+
+      generate_block();
+
+   } catch (fc::exception& e) {
+      edump((e.to_detail_string()));
+      throw;
+   }
+}
+
+BOOST_AUTO_TEST_CASE( bid_collateral_operation_asset_auth_test )
+{
+   try {
+      generate_blocks( HARDFORK_CORE_973_TIME - fc::days(1) );
+      set_expiration( db, trx );
+
+      ACTORS((dan)(sam));
+
+      const auto& backasset = create_user_issued_asset("BACK", sam, white_list | charge_market_fee);
+      asset_id_type back_id = backasset.id;
+
+      const auto& bitusd = create_bitasset("USDBIT", sam.id, 10, white_list | charge_market_fee, 3, back_id);
+      asset_id_type usd_id = bitusd.id;
+
+      issue_uia( dan_id, backasset.amount(10000000) );
+      issue_uia( sam_id, backasset.amount(10000000) );
+
+      update_feed_producers( bitusd, {sam.id} );
+
+      price_feed current_feed;
+      current_feed.core_exchange_rate = bitusd.amount( 100 ) / asset( 100 );
+      current_feed.settlement_price = bitusd.amount( 100 ) / backasset.amount( 100 );
+      current_feed.maintenance_collateral_ratio = 1750; // need to set explicitly, testnet has a different default
+      publish_feed( bitusd, sam, current_feed );
+
+      FC_ASSERT( bitusd.bitasset_data(db).current_feed.settlement_price == current_feed.settlement_price );
+
+      BOOST_TEST_MESSAGE( "attempting to borrow using 2x collateral at 1:1 price now that there is a valid order" );
+      borrow( dan, bitusd.amount(5000), backasset.amount(10000) );
+      BOOST_REQUIRE_EQUAL( get_balance( dan, bitusd ), 5000 );
+      BOOST_REQUIRE_EQUAL( get_balance( dan, backasset ), 10000000 - 10000 );
+
+      // Make a whitelist
+      {
+         BOOST_TEST_MESSAGE( "Setting up whitelisting" );
+         asset_update_operation uop;
+         uop.issuer = sam_id;
+
+         // For USDBIT
+         uop.asset_to_update = usd_id;
+         uop.new_options = usd_id(db).options;
+         // The whitelist is managed by Sam
+         uop.new_options.whitelist_authorities.insert(sam_id);
+         trx.operations.clear();
+         trx.operations.push_back(uop);
+         PUSH_TX( db, trx, ~0 );
+
+         // For BACK
+         uop.asset_to_update = back_id;
+         uop.new_options = back_id(db).options;
+         // The whitelist is managed by Sam
+         uop.new_options.whitelist_authorities.insert(sam_id);
+         trx.operations.clear();
+         trx.operations.push_back(uop);
+         PUSH_TX( db, trx, ~0 );
+
+         // Upgrade Sam so that he can manage the whitelist
+         upgrade_to_lifetime_member( sam_id );
+
+         // Add Sam to the whitelist, but do not add Dan
+         account_whitelist_operation wop;
+         wop.authorizing_account = sam_id;
+         wop.account_to_list = sam_id;
+         wop.new_listing = account_whitelist_operation::white_listed;
+         trx.operations.clear();
+         trx.operations.push_back(wop);
+         PUSH_TX( db, trx, ~0 );
+      }
+
+      // Trigger a black swan event, globally settle USDBIT
+      BOOST_TEST_MESSAGE( "Trigger a black swan event" );
+      current_feed.settlement_price = bitusd.amount( 10 ) / backasset.amount( 100 );
+      publish_feed( bitusd, sam, current_feed );
+      BOOST_REQUIRE( bitusd.bitasset_data(db).has_settlement() );
+
+      // Reproduces bitshares-core issue #973: no asset authorization check thus Dan is able to bid collateral
+      BOOST_TEST_MESSAGE( "Dan and Sam attempting to bid collateral" );
+      bid_collateral( dan_id(db), back_id(db).amount(1), usd_id(db).amount(100) );
+      bid_collateral( sam_id(db), back_id(db).amount(1), usd_id(db).amount(100) );
+
+      // Apply core-973 hardfork
+      BOOST_TEST_MESSAGE( "Apply core-973 hardfork" );
+      generate_blocks( HARDFORK_CORE_973_TIME );
+      set_expiration( db, trx );
+
+      // Update price feed
+      publish_feed( usd_id(db), sam_id(db), current_feed );
+
+      // Sam should be able to bid collateral, but Dan should be unable to bid
+      BOOST_TEST_MESSAGE( "Dan and Sam attempting to bid collateral again" );
+      GRAPHENE_REQUIRE_THROW( bid_collateral( dan_id(db), back_id(db).amount(2), usd_id(db).amount(200) ),
+                              fc::exception );
+      bid_collateral( sam_id(db), back_id(db).amount(2), usd_id(db).amount(200) );
+
+      // Update USDBIT, disable remove whitelisting
+      {
+         BOOST_TEST_MESSAGE( "Disable USDBIT whitelisting" );
+         asset_update_operation uop;
+         uop.issuer = sam_id;
+
+         // For USDBIT
+         uop.asset_to_update = usd_id;
+         uop.new_options = usd_id(db).options;
+         uop.new_options.whitelist_authorities.clear();
+         trx.operations.clear();
+         trx.operations.push_back(uop);
+         PUSH_TX( db, trx, ~0 );
+      }
+
+      // Sam should be able to bid collateral, but Dan should be unable to bid
+      GRAPHENE_REQUIRE_THROW( bid_collateral( dan_id(db), back_id(db).amount(3), usd_id(db).amount(300) ),
+                              fc::exception );
+      bid_collateral( sam_id(db), back_id(db).amount(3), usd_id(db).amount(300) );
+
+      // Update BACK, disable whitelisting
+      {
+         BOOST_TEST_MESSAGE( "Disable BACK whitelisting" );
+         asset_update_operation uop;
+         uop.issuer = sam_id;
+
+         // For USDBIT
+         uop.asset_to_update = back_id;
+         uop.new_options = back_id(db).options;
+         uop.new_options.whitelist_authorities.clear();
+         trx.operations.clear();
+         trx.operations.push_back(uop);
+         PUSH_TX( db, trx, ~0 );
+      }
+
+      // Both Sam and Dan should be able to bid collateral
+      bid_collateral( dan_id(db), back_id(db).amount(4), usd_id(db).amount(400) );
+      bid_collateral( sam_id(db), back_id(db).amount(4), usd_id(db).amount(400) );
+
+      // Update USDBIT, enable whitelisting
+      {
+         BOOST_TEST_MESSAGE( "Enable USDBIT whitelisting again" );
+         asset_update_operation uop;
+         uop.issuer = sam_id;
+
+         // For USDBIT
+         uop.asset_to_update = usd_id;
+         uop.new_options = usd_id(db).options;
+         uop.new_options.whitelist_authorities.insert( sam_id );
+         trx.operations.clear();
+         trx.operations.push_back(uop);
+         PUSH_TX( db, trx, ~0 );
+      }
+
+      // Sam should be able to bid collateral, but Dan should be unable to bid
+      GRAPHENE_REQUIRE_THROW( bid_collateral( dan_id(db), back_id(db).amount(5), usd_id(db).amount(500) ),
+                              fc::exception );
+      bid_collateral( sam_id(db), back_id(db).amount(5), usd_id(db).amount(500) );
+
+      generate_block();
 
    } catch (fc::exception& e) {
       edump((e.to_detail_string()));

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -442,6 +442,170 @@ BOOST_AUTO_TEST_CASE( call_order_update_asset_auth_test )
    }
 }
 
+BOOST_AUTO_TEST_CASE( asset_settle_operation_asset_auth_test )
+{
+   try {
+      generate_blocks( HARDFORK_CORE_973_TIME - fc::days(1) );
+      set_expiration( db, trx );
+
+      ACTORS((dan)(sam));
+
+      const auto& backasset = create_user_issued_asset("BACK", sam, white_list | charge_market_fee);
+      asset_id_type back_id = backasset.id;
+
+      const auto& bitusd = create_bitasset("USDBIT", sam.id, 10, white_list | charge_market_fee, 3, back_id);
+      asset_id_type usd_id = bitusd.id;
+
+      issue_uia( dan_id, backasset.amount(10000000) );
+      issue_uia( sam_id, backasset.amount(10000000) );
+
+      update_feed_producers( bitusd, {sam.id} );
+
+      price_feed current_feed;
+      current_feed.core_exchange_rate = bitusd.amount( 100 ) / asset( 100 );
+      current_feed.settlement_price = bitusd.amount( 100 ) / backasset.amount( 100 );
+      current_feed.maintenance_collateral_ratio = 1750; // need to set explicitly, testnet has a different default
+      publish_feed( bitusd, sam, current_feed );
+
+      FC_ASSERT( bitusd.bitasset_data(db).current_feed.settlement_price == current_feed.settlement_price );
+
+      BOOST_TEST_MESSAGE( "attempting to borrow using 2x collateral at 1:1 price now that there is a valid order" );
+      borrow( dan, bitusd.amount(5000), backasset.amount(10000) );
+      BOOST_REQUIRE_EQUAL( get_balance( dan, bitusd ), 5000 );
+      BOOST_REQUIRE_EQUAL( get_balance( dan, backasset ), 10000000 - 10000 );
+
+      transfer( dan, sam, bitusd.amount(2000) );
+      BOOST_REQUIRE_EQUAL( get_balance( dan_id, usd_id ), 3000 );
+      BOOST_REQUIRE_EQUAL( get_balance( sam_id, usd_id ), 2000 );
+
+      // Make a whitelist
+      {
+         BOOST_TEST_MESSAGE( "Setting up whitelisting" );
+         asset_update_operation uop;
+         uop.issuer = sam_id;
+
+         // For USDBIT
+         uop.asset_to_update = usd_id;
+         uop.new_options = usd_id(db).options;
+         // The whitelist is managed by Sam
+         uop.new_options.whitelist_authorities.insert(sam_id);
+         trx.operations.clear();
+         trx.operations.push_back(uop);
+         PUSH_TX( db, trx, ~0 );
+
+         // For BACK
+         uop.asset_to_update = back_id;
+         uop.new_options = back_id(db).options;
+         // The whitelist is managed by Sam
+         uop.new_options.whitelist_authorities.insert(sam_id);
+         trx.operations.clear();
+         trx.operations.push_back(uop);
+         PUSH_TX( db, trx, ~0 );
+
+         // Upgrade Sam so that he can manage the whitelist
+         upgrade_to_lifetime_member( sam_id );
+
+         // Add Sam to the whitelist, but do not add Dan
+         account_whitelist_operation wop;
+         wop.authorizing_account = sam_id;
+         wop.account_to_list = sam_id;
+         wop.new_listing = account_whitelist_operation::white_listed;
+         trx.operations.clear();
+         trx.operations.push_back(wop);
+         PUSH_TX( db, trx, ~0 );
+      }
+
+      // Reproduces bitshares-core issue #973: no asset authorization check thus Dan is able to force-settle
+      BOOST_TEST_MESSAGE( "Dan and Sam attempting to force-settle" );
+      force_settle( dan_id(db), usd_id(db).amount(100) );
+      force_settle( sam_id(db), usd_id(db).amount(100) );
+      BOOST_REQUIRE_EQUAL( get_balance( dan_id, usd_id ), 2900 );
+      BOOST_REQUIRE_EQUAL( get_balance( sam_id, usd_id ), 1900 );
+
+      // Apply core-973 hardfork
+      BOOST_TEST_MESSAGE( "Apply core-973 hardfork" );
+      generate_blocks( HARDFORK_CORE_973_TIME );
+      set_expiration( db, trx );
+
+      // Update price feed
+      publish_feed( usd_id(db), sam_id(db), current_feed );
+
+      // Sam should be able to force-settle, but Dan should be unable to force-settle
+      BOOST_TEST_MESSAGE( "Dan and Sam attempting to force-settle again" );
+      GRAPHENE_REQUIRE_THROW( force_settle( dan_id(db), usd_id(db).amount(100) ), fc::exception );
+      force_settle( sam_id(db), usd_id(db).amount(100) );
+      BOOST_REQUIRE_EQUAL( get_balance( dan_id, usd_id ), 2900 );
+      BOOST_REQUIRE_EQUAL( get_balance( sam_id, usd_id ), 1800 );
+
+      // Update USDBIT, disable remove whitelisting
+      {
+         BOOST_TEST_MESSAGE( "Disable USDBIT whitelisting" );
+         asset_update_operation uop;
+         uop.issuer = sam_id;
+
+         // For USDBIT
+         uop.asset_to_update = usd_id;
+         uop.new_options = usd_id(db).options;
+         uop.new_options.whitelist_authorities.clear();
+         trx.operations.clear();
+         trx.operations.push_back(uop);
+         PUSH_TX( db, trx, ~0 );
+      }
+
+      // Sam should be able to force-settle, but Dan should be unable to force-settle
+      GRAPHENE_REQUIRE_THROW( force_settle( dan_id(db), usd_id(db).amount(100) ), fc::exception );
+      force_settle( sam_id(db), usd_id(db).amount(100) );
+      BOOST_REQUIRE_EQUAL( get_balance( dan_id, usd_id ), 2900 );
+      BOOST_REQUIRE_EQUAL( get_balance( sam_id, usd_id ), 1700 );
+
+      // Update BACK, disable whitelisting
+      {
+         BOOST_TEST_MESSAGE( "Disable BACK whitelisting" );
+         asset_update_operation uop;
+         uop.issuer = sam_id;
+
+         // For USDBIT
+         uop.asset_to_update = back_id;
+         uop.new_options = back_id(db).options;
+         uop.new_options.whitelist_authorities.clear();
+         trx.operations.clear();
+         trx.operations.push_back(uop);
+         PUSH_TX( db, trx, ~0 );
+      }
+
+      // Both Sam and Dan should be able to force-settle
+      force_settle( dan_id(db), usd_id(db).amount(100) );
+      force_settle( sam_id(db), usd_id(db).amount(100) );
+      BOOST_REQUIRE_EQUAL( get_balance( dan_id, usd_id ), 2800 );
+      BOOST_REQUIRE_EQUAL( get_balance( sam_id, usd_id ), 1600 );
+
+      // Update USDBIT, enable whitelisting
+      {
+         BOOST_TEST_MESSAGE( "Enable USDBIT whitelisting again" );
+         asset_update_operation uop;
+         uop.issuer = sam_id;
+
+         // For USDBIT
+         uop.asset_to_update = usd_id;
+         uop.new_options = usd_id(db).options;
+         uop.new_options.whitelist_authorities.insert( sam_id );
+         trx.operations.clear();
+         trx.operations.push_back(uop);
+         PUSH_TX( db, trx, ~0 );
+      }
+
+      // Sam should be able to force-settle, but Dan should be unable to force-settle
+      GRAPHENE_REQUIRE_THROW( force_settle( dan_id(db), usd_id(db).amount(100) ), fc::exception );
+      force_settle( sam_id(db), usd_id(db).amount(100) );
+      BOOST_REQUIRE_EQUAL( get_balance( dan_id, usd_id ), 2800 );
+      BOOST_REQUIRE_EQUAL( get_balance( sam_id, usd_id ), 1500 );
+
+   } catch (fc::exception& e) {
+      edump((e.to_detail_string()));
+      throw;
+   }
+}
+
 BOOST_AUTO_TEST_CASE( asset_settle_cancel_operation_test_after_hf588 )
 {
    set_expiration( db, trx );


### PR DESCRIPTION
Add asset authorization checks for some operations.

Affected operations:
- asset_settle_operation
  * new rule: unable to settle if not authorized by either the debt asset or collateral asset
- bid_collateral_operation
  * new rule: unable to bid (newly bid, or update or cancel existing bid) if not authorized by either the debt asset or collateral asset
- call_order_update_operation
  * new rule: unable to update debt position (create new position, or update or close existing position) if not authorized by either the debt asset or collateral asset
- vesting_balance_create_operation
  * new rule: unable to create the vesting_balance object if either the creator or the receiver is not authorized by the asset
  * note: no asset authorization check on `vesting_balance_withdraw_operation` since in my opinion it's OK to allow the funds to be moved from vesting balance objects to account balance.

And slightly refactor nearby code for better performance.

Fixes #972, fixes #973.