### PR TITLE
Clear operation_results when generating block

### DIFF
--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -1668,7 +1668,8 @@ BOOST_AUTO_TEST_CASE( cli_create_htlc )
          BOOST_CHECK(generate_block(app1, result_block));
 
          // get the ID:
-         htlc_id_type htlc_id = result_block.transactions[result_block.transactions.size()-1].operation_results[0].get<object_id_type>();
+         auto tmp_hist = con.wallet_api_ptr->get_account_history("alice", 1);
+         htlc_id_type htlc_id = tmp_hist[0].op.result.get<object_id_type>();
          alice_htlc_id_as_string = (std::string)(object_id_type)htlc_id;
          BOOST_TEST_MESSAGE("Alice shares the HTLC ID with Bob. The HTLC ID is: " + alice_htlc_id_as_string);
       }
@@ -1690,7 +1691,8 @@ BOOST_AUTO_TEST_CASE( cli_create_htlc )
          BOOST_CHECK(generate_block(app1, result_block));
 
          // get the ID:
-         htlc_id_type htlc_id = result_block.transactions[result_block.transactions.size()-1].operation_results[0].get<object_id_type>();
+         auto tmp_hist = con.wallet_api_ptr->get_account_history("bob", 1);
+         htlc_id_type htlc_id = tmp_hist[0].op.result.get<object_id_type>();
          bob_htlc_id_as_string = (std::string)(object_id_type)htlc_id;
          BOOST_TEST_MESSAGE("Bob shares the HTLC ID with Alice. The HTLC ID is: " + bob_htlc_id_as_string);
       }
@@ -2213,8 +2215,8 @@ BOOST_AUTO_TEST_CASE( cli_create_htlc_bsip64 )
          BOOST_CHECK(generate_block(app1, result_block));
 
          // get the ID:
-         htlc_id_type htlc_id = result_block.transactions[result_block.transactions.size()-1]
-               .operation_results[0].get<object_id_type>();
+         auto tmp_hist = con.wallet_api_ptr->get_account_history("alice", 1);
+         htlc_id_type htlc_id = tmp_hist[0].op.result.get<object_id_type>();
          alice_htlc_id_as_string = (std::string)(object_id_type)htlc_id;
          BOOST_TEST_MESSAGE("Alice shares the HTLC ID with Bob. The HTLC ID is: " + alice_htlc_id_as_string);
       }
@@ -2237,8 +2239,8 @@ BOOST_AUTO_TEST_CASE( cli_create_htlc_bsip64 )
          BOOST_CHECK(generate_block(app1, result_block));
 
          // get the ID:
-         htlc_id_type htlc_id = result_block.transactions[result_block.transactions.size()-1]
-               .operation_results[0].get<object_id_type>();
+         auto tmp_hist = con.wallet_api_ptr->get_account_history("bob", 1);
+         htlc_id_type htlc_id = tmp_hist[0].op.result.get<object_id_type>();
          bob_htlc_id_as_string = (std::string)(object_id_type)htlc_id;
          BOOST_TEST_MESSAGE("Bob shares the HTLC ID with Alice. The HTLC ID is: " + bob_htlc_id_as_string);
       }

--- a/tests/tests/htlc_tests.cpp
+++ b/tests/tests/htlc_tests.cpp
@@ -103,10 +103,9 @@ try {
       create_operation.fee = db.get_global_properties().parameters.current_fees->calculate_fee(create_operation);
       trx.operations.push_back(create_operation);
       sign(trx, alice_private_key);
-      PUSH_TX(db, trx, ~0);
+      processed_transaction alice_trx = PUSH_TX(db, trx, ~0);
       trx.clear();
-      graphene::chain::signed_block blk = generate_block();
-      processed_transaction alice_trx = blk.transactions[0];
+      generate_block();
       alice_htlc_id = alice_trx.operation_results[0].get<object_id_type>();
       generate_block();
    }
@@ -553,10 +552,9 @@ try {
       create_operation.fee = db.current_fee_schedule().calculate_fee( create_operation );
       trx.operations.push_back( create_operation );
       sign(trx, alice_private_key);
-      PUSH_TX(db, trx, ~0);
+      processed_transaction alice_trx = PUSH_TX(db, trx, ~0);
       trx.clear();
-      graphene::chain::signed_block blk = generate_block();
-      processed_transaction alice_trx = blk.transactions[0];
+      generate_block();
       alice_htlc_id = alice_trx.operation_results[0].get<object_id_type>();
    }
 
@@ -1053,10 +1051,9 @@ try {
       trx.operations.push_back( create_operation );
       sign(trx, alice_private_key);
       // bob can now accept it, so it works
-      PUSH_TX( db, trx, ~0 );
+      processed_transaction alice_trx = PUSH_TX( db, trx, ~0 );
       trx.clear();
-      graphene::chain::signed_block blk = generate_block();
-      processed_transaction alice_trx = blk.transactions[0];
+      generate_block();
       alice_htlc_id = alice_trx.operation_results[0].get<object_id_type>();
    }
 
@@ -1129,11 +1126,10 @@ try {
       create_operation.fee = db.get_global_properties().parameters.current_fees->calculate_fee(create_operation);
       trx.operations.push_back(create_operation);
       sign(trx, alice_private_key);
-      PUSH_TX(db, trx, ~0);
+      processed_transaction alice_trx = PUSH_TX(db, trx, ~0);
       trx.clear();
       set_expiration( db, trx );
-      graphene::chain::signed_block blk = generate_block();
-      processed_transaction alice_trx = blk.transactions[0];
+      generate_block();
       alice_htlc_id_bob = alice_trx.operation_results[0].get<object_id_type>();
       generate_block();
       set_expiration( db, trx );
@@ -1153,11 +1149,10 @@ try {
       create_operation.fee = db.get_global_properties().parameters.current_fees->calculate_fee(create_operation);
       trx.operations.push_back(create_operation);
       sign(trx, alice_private_key);
-      PUSH_TX(db, trx, ~0);
+      processed_transaction alice_trx = PUSH_TX(db, trx, ~0);
       trx.clear();
       set_expiration( db, trx );
-      graphene::chain::signed_block blk = generate_block();
-      processed_transaction alice_trx = blk.transactions[0];
+      generate_block();
       alice_htlc_id_carl = alice_trx.operation_results[0].get<object_id_type>();
       generate_block();
       set_expiration( db, trx );
@@ -1177,11 +1172,10 @@ try {
       create_operation.fee = db.get_global_properties().parameters.current_fees->calculate_fee(create_operation);
       trx.operations.push_back(create_operation);
       sign(trx, alice_private_key);
-      PUSH_TX(db, trx, ~0);
+      processed_transaction alice_trx = PUSH_TX(db, trx, ~0);
       trx.clear();
       set_expiration( db, trx );
-      graphene::chain::signed_block blk = generate_block();
-      processed_transaction alice_trx = blk.transactions[0];
+      generate_block();
       alice_htlc_id_dan = alice_trx.operation_results[0].get<object_id_type>();
       generate_block();
       set_expiration( db, trx );


### PR DESCRIPTION
To save disk space and network bandwidth.

And makes it more flexible to store larger data in operation results for certain purposes.

Note:
* **this change may break client applications which rely on `operation_results` fields of `get_block` API**, because newly-generated blocks will have empty `operation_results` fields, thus the `get_block` API will return empty operation result vectors for those blocks;
* after this change, full operation results are still in account history (unchanged).