### PR TITLE
Add OS version to cache key in sonar-scan workflow

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -92,15 +92,19 @@ jobs:
               -D Boost_USE_STATIC_LIBS=OFF \
               ..
         popd
+    # Get OS version to be used in cache key - see https://github.com/actions/cache/issues/543
+    - run: |
+        echo "OS_VERSION=`lsb_release -sr`" >> $GITHUB_ENV
     - name: Load Cache
       uses: actions/cache@v2
       with:
         path: |
           ccache
           sonar_cache
-        key: sonar-${{ github.ref }}-${{ github.sha }}
+        key: sonar-${{ env.OS_VERSION }}-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
-          sonar-${{ github.ref }}-
+          sonar-${{ env.OS_VERSION }}-${{ github.ref }}-
+          sonar-${{ env.OS_VERSION }}-
           sonar-
     - name: Build
       run: |


### PR DESCRIPTION
This fixes an issue when Github changes `ubuntu-latest` environment from `18.04` to `20.04`, and avoids similar issues in the future. See https://github.com/actions/cache/issues/543.
The fix is inspired by https://github.com/neutrinolabs/xrdp/pull/1821 .