### PR TITLE
Require OS version in cache key for sonar-scan workflow

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -105,7 +105,6 @@ jobs:
         restore-keys: |
           sonar-${{ env.OS_VERSION }}-${{ github.ref }}-
           sonar-${{ env.OS_VERSION }}-
-          sonar-
     - name: Build
       run: |
         export CCACHE_DIR="$GITHUB_WORKSPACE/ccache"


### PR DESCRIPTION
Follow-up of #2486.