### PR TITLE
Get around CURLOPT_POSTFIELDS bug, fix node crash

### DIFF
--- a/libraries/utilities/elasticsearch.cpp
+++ b/libraries/utilities/elasticsearch.cpp
@@ -178,6 +178,8 @@ const std::string doCurl(CurlRequest& curl)
       curl_easy_setopt(curl.handler, CURLOPT_POST, true);
       curl_easy_setopt(curl.handler, CURLOPT_POSTFIELDS, curl.query.c_str());
    }
+   else
+      curl_easy_setopt(curl.handler, CURLOPT_POSTFIELDS, "");
    curl_easy_setopt(curl.handler, CURLOPT_WRITEFUNCTION, WriteCallback);
    curl_easy_setopt(curl.handler, CURLOPT_WRITEDATA, (void *)&CurlReadBuffer);
    curl_easy_setopt(curl.handler, CURLOPT_USERAGENT, "libcrp/0.1");


### PR DESCRIPTION
Fixes #2490.

Without the https://github.com/curl/curl/pull/3549 patch, there will be a `strlen` call on the uninitialized `CURLOPT_POSTFIELDS` field which causes crash.

With this pull request, `CURLOPT_POSTFIELDS` is always initialized.

Update: this patch is not ideal. See the updated issue description for more info.