### PR TITLE
Add option for MPA owners to disable collateral bidding

### DIFF
--- a/libraries/chain/db_market.cpp
+++ b/libraries/chain/db_market.cpp
@@ -439,10 +439,8 @@ void database::_cancel_bids_and_revive_mpa( const asset_object& bitasset, const 
 
    // cancel remaining bids
    const auto& bid_idx = get_index_type< collateral_bid_index >().indices().get<by_price>();
-   auto itr = bid_idx.lower_bound( boost::make_tuple( bitasset.id,
-                                                      price::max( bad.options.short_backing_asset, bitasset.id ),
-                                                      collateral_bid_id_type() ) );
-   while( itr != bid_idx.end() && itr->inv_swan_price.quote.asset_id == bitasset.id )
+   auto itr = bid_idx.lower_bound( bad.asset_id );
+   while( itr != bid_idx.end() && itr->inv_swan_price.quote.asset_id == bad.asset_id )
    {
       const collateral_bid_object& bid = *itr;
       ++itr;

--- a/libraries/chain/hardfork.d/CORE_2281.hf
+++ b/libraries/chain/hardfork.d/CORE_2281.hf
@@ -1,0 +1,6 @@
+// bitshares-core issue #2281 Add option for MPA owners to disable collateral bidding
+#ifndef HARDFORK_CORE_2281_TIME
+// Jan 1 2030, midnight; this is a dummy date until a hardfork date is scheduled
+#define HARDFORK_CORE_2281_TIME (fc::time_point_sec( 1893456000 ))
+#define HARDFORK_CORE_2281_PASSED(now) (now > HARDFORK_CORE_2281_TIME)
+#endif

--- a/libraries/chain/include/graphene/chain/asset_object.hpp
+++ b/libraries/chain/include/graphene/chain/asset_object.hpp
@@ -112,6 +112,8 @@ namespace graphene { namespace chain {
          bool can_owner_update_mssr()const { return (0 == (options.issuer_permissions & disable_mssr_update)); }
          /// @return true if the asset owner can change black swan response method
          bool can_owner_update_bsrm()const { return (0 == (options.issuer_permissions & disable_bsrm_update)); }
+         /// @return true if can bid collateral for the asset
+         bool can_bid_collateral()const { return (0 == (options.flags & disable_collateral_bidding)); }
 
          /// Helper function to get an asset object with the given amount in this asset's type
          asset amount(share_type a)const { return asset(a, id); }

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -51,6 +51,7 @@ namespace detail {
    void check_asset_claim_fees_hardfork_87_74_collatfee(const fc::time_point_sec& block_time,
                                                         const asset_claim_fees_operation& op); // HF_REMOVABLE
 
+   void check_asset_options_hf_core2281(const fc::time_point_sec& next_maint_time, const asset_options& options);
    void check_asset_options_hf_core2467(const fc::time_point_sec& next_maint_time, const asset_options& options);
    void check_bitasset_opts_hf_core2467(const fc::time_point_sec& next_maint_time, const bitasset_options& options);
 }
@@ -72,6 +73,7 @@ struct proposal_operation_hardfork_visitor
       detail::check_asset_options_hf_1774(block_time, v.common_options);
       detail::check_asset_options_hf_bsip_48_75(block_time, v.common_options);
       detail::check_asset_options_hf_bsip81(block_time, v.common_options);
+      detail::check_asset_options_hf_core2281( next_maintenance_time, v.common_options ); // HF_REMOVABLE
       detail::check_asset_options_hf_core2467( next_maintenance_time, v.common_options ); // HF_REMOVABLE
       if( v.bitasset_opts.valid() ) {
          detail::check_bitasset_options_hf_bsip_48_75( block_time, *v.bitasset_opts );
@@ -82,9 +84,14 @@ struct proposal_operation_hardfork_visitor
       }
 
       // TODO move as many validations as possible to validate() if not triggered before hardfork
-      if( HARDFORK_BSIP_48_75_PASSED( block_time ) )
+      if( HARDFORK_CORE_2281_PASSED( next_maintenance_time ) )
       {
          v.common_options.validate_flags( v.bitasset_opts.valid() );
+      }
+      else if( HARDFORK_BSIP_48_75_PASSED( block_time ) )
+      {
+         // do not allow the 'disable_collateral_bidding' bit
+         v.common_options.validate_flags( v.bitasset_opts.valid(), false );
       }
    }
 
@@ -92,14 +99,20 @@ struct proposal_operation_hardfork_visitor
       detail::check_asset_options_hf_1774(block_time, v.new_options);
       detail::check_asset_options_hf_bsip_48_75(block_time, v.new_options);
       detail::check_asset_options_hf_bsip81(block_time, v.new_options);
+      detail::check_asset_options_hf_core2281( next_maintenance_time, v.new_options ); // HF_REMOVABLE
       detail::check_asset_options_hf_core2467( next_maintenance_time, v.new_options ); // HF_REMOVABLE
 
       detail::check_asset_update_extensions_hf_bsip_48_75( block_time, v.extensions.value );
 
       // TODO move as many validations as possible to validate() if not triggered before hardfork
-      if( HARDFORK_BSIP_48_75_PASSED( block_time ) )
+      if( HARDFORK_CORE_2281_PASSED( next_maintenance_time ) )
       {
          v.new_options.validate_flags( true );
+      }
+      else if( HARDFORK_BSIP_48_75_PASSED( block_time ) )
+      {
+         // do not allow the 'disable_collateral_bidding' bit
+         v.new_options.validate_flags( true, false );
       }
 
    }

--- a/libraries/protocol/asset_ops.cpp
+++ b/libraries/protocol/asset_ops.cpp
@@ -112,9 +112,9 @@ void  asset_create_operation::validate()const
    FC_ASSERT( fee.amount >= 0 );
    FC_ASSERT( is_valid_symbol(symbol) );
    common_options.validate();
-   if( 0 != ( common_options.issuer_permissions
-              & (disable_force_settle|global_settle
-                 |disable_mcr_update|disable_icr_update|disable_mssr_update|disable_bsrm_update) ) )
+   // TODO fix the missing check for witness_fed_asset and committee_fed_asset with a hard fork
+   if( 0 != ( common_options.issuer_permissions & NON_UIA_ONLY_ISSUER_PERMISSION_MASK
+              & (uint16_t)( ~(witness_fed_asset|committee_fed_asset) ) ) )
       FC_ASSERT( bitasset_opts.valid() );
    if( is_prediction_market )
    {

--- a/libraries/protocol/asset_ops.cpp
+++ b/libraries/protocol/asset_ops.cpp
@@ -308,10 +308,15 @@ void asset_options::validate()const
       FC_ASSERT( *extensions.value.reward_percent <= GRAPHENE_100_PERCENT );
 }
 
-void asset_options::validate_flags( bool is_market_issued )const
+// Note: this function is only called after the BSIP 48/75 hardfork
+void asset_options::validate_flags( bool is_market_issued, bool allow_disable_collateral_bid )const
 {
    FC_ASSERT( 0 == (flags & (uint16_t)(~ASSET_ISSUER_PERMISSION_MASK)),
               "Can not set an unknown bit in flags" );
+   if( !allow_disable_collateral_bid ) // before core-2281 hf, can not set the disable_collateral_bidding bit
+      FC_ASSERT( 0 == (flags & disable_collateral_bidding),
+                 "Can not set the 'disable_collateral_bidding' bit in flags between the core-2281 hardfork "
+                 "and the BSIP_48_75 hardfork" );
    // Note: global_settle is checked in validate(), so do not check again here
    FC_ASSERT( 0 == (flags & disable_mcr_update),
               "Can not set disable_mcr_update flag, it is for issuer permission only" );

--- a/libraries/protocol/include/graphene/protocol/asset_ops.hpp
+++ b/libraries/protocol/include/graphene/protocol/asset_ops.hpp
@@ -98,7 +98,7 @@ namespace graphene { namespace protocol {
 
       /// Perform checks about @ref flags.
       /// @throws fc::exception if any check fails
-      void validate_flags( bool is_market_issued )const;
+      void validate_flags( bool is_market_issued, bool allow_disable_collateral_bid = true )const;
    };
 
    /**

--- a/libraries/protocol/include/graphene/protocol/market.hpp
+++ b/libraries/protocol/include/graphene/protocol/market.hpp
@@ -172,7 +172,7 @@ namespace graphene { namespace protocol {
    /**
     *  @ingroup operations
     *
-    *  This operation can be used after a black swan to bid collateral for
+    *  This operation can be used after a global settlement to bid collateral for
     *  taking over part of the debt and the settlement_fund (see BSIP-0018).
     */
    struct bid_collateral_operation : public base_operation

--- a/libraries/protocol/include/graphene/protocol/types.hpp
+++ b/libraries/protocol/include/graphene/protocol/types.hpp
@@ -159,7 +159,7 @@ enum asset_issuer_permission_flags {
     override_authority   = 0x04, ///< issuer may transfer asset back to himself
     transfer_restricted  = 0x08, ///< require the issuer to be one party to every transfer
     disable_force_settle = 0x10, ///< disable force settling
-    global_settle        = 0x20, ///< allow the bitasset owner to force a global settling, permission only
+    global_settle        = 0x20, ///< allow the bitasset owner to force a global settlement, permission only
     disable_confidential = 0x40, ///< disallow the asset to be used with confidential transactions
     witness_fed_asset    = 0x80, ///< the bitasset is to be fed by witnesses
     committee_fed_asset  = 0x100, ///< the bitasset is to be fed by the committee
@@ -180,7 +180,8 @@ enum asset_issuer_permission_flags {
     disable_mcr_update   = 0x800, ///< the bitasset owner can not update MCR, permisison only
     disable_icr_update   = 0x1000, ///< the bitasset owner can not update ICR, permisison only
     disable_mssr_update  = 0x2000, ///< the bitasset owner can not update MSSR, permisison only
-    disable_bsrm_update  = 0x4000  ///< the bitasset owner can not update BSRM, permission only
+    disable_bsrm_update  = 0x4000, ///< the bitasset owner can not update BSRM, permission only
+    disable_collateral_bidding = 0x8000  ///< Can not bid collateral after a global settlement
     ///@}
     ///@}
 };
@@ -201,7 +202,8 @@ const static uint16_t ASSET_ISSUER_PERMISSION_MASK =
         | disable_mcr_update
         | disable_icr_update
         | disable_mssr_update
-        | disable_bsrm_update;
+        | disable_bsrm_update
+        | disable_collateral_bidding;
 // The "enable" bits for non-UIA assets
 const static uint16_t ASSET_ISSUER_PERMISSION_ENABLE_BITS_MASK =
         charge_market_fee
@@ -220,7 +222,8 @@ const static uint16_t ASSET_ISSUER_PERMISSION_DISABLE_BITS_MASK =
         | disable_mcr_update
         | disable_icr_update
         | disable_mssr_update
-        | disable_bsrm_update;
+        | disable_bsrm_update
+        | disable_collateral_bidding;
 // The bits that can be used in asset issuer permissions for UIA assets
 const static uint16_t UIA_ASSET_ISSUER_PERMISSION_MASK =
         charge_market_fee
@@ -365,6 +368,7 @@ FC_REFLECT_ENUM(graphene::protocol::asset_issuer_permission_flags,
                 (disable_icr_update)
                 (disable_mssr_update)
                 (disable_bsrm_update)
+                (disable_collateral_bidding)
                )
 
 namespace fc { namespace raw {

--- a/tests/common/database_fixture.hpp
+++ b/tests/common/database_fixture.hpp
@@ -219,7 +219,7 @@ struct database_fixture_base {
    bool skip_key_index_test = false;
    uint32_t anon_acct_count;
    bool hf1270 = false;
-   bool hf2467 = false;
+   bool hf2467 = false; // Note: used by hf core-2281 too, assuming hf core-2281 and core-2467 occur at the same time
    bool hf2481 = false;
    bool bsip77 = false;
 

--- a/tests/tests/bsrm_basic_tests.cpp
+++ b/tests/tests/bsrm_basic_tests.cpp
@@ -385,7 +385,7 @@ BOOST_AUTO_TEST_CASE( uia_issuer_permissions_update_test )
 }
 
 /// Tests what kind of assets can have BSRM-related flags / issuer permissions / extensions
-BOOST_AUTO_TEST_CASE( asset_permissions_flags_extensions_test )
+BOOST_AUTO_TEST_CASE( bsrm_asset_permissions_flags_extensions_test )
 {
    try {
 
@@ -395,11 +395,10 @@ BOOST_AUTO_TEST_CASE( asset_permissions_flags_extensions_test )
       generate_blocks(db.get_dynamic_global_properties().next_maintenance_time);
       set_expiration( db, trx );
 
-      ACTORS((sam)(feeder));
+      ACTORS((sam));
 
       auto init_amount = 10000000 * GRAPHENE_BLOCKCHAIN_PRECISION;
       fund( sam, asset(init_amount) );
-      fund( feeder, asset(init_amount) );
 
       // Unable to create a PM with the disable_bsrm_update bit in flags
       BOOST_CHECK_THROW( create_prediction_market( "TESTPM", sam_id, 0, disable_bsrm_update ), fc::exception );
@@ -555,7 +554,7 @@ BOOST_AUTO_TEST_CASE( asset_permissions_flags_extensions_test )
 }
 
 /// Tests whether asset owner has permission to update bsrm
-BOOST_AUTO_TEST_CASE( asset_owner_permissions_update_bsrm )
+BOOST_AUTO_TEST_CASE( bsrm_asset_owner_permissions_update_bsrm )
 {
    try {
 

--- a/tests/tests/swan_tests.cpp
+++ b/tests/tests/swan_tests.cpp
@@ -287,8 +287,10 @@ BOOST_AUTO_TEST_CASE( black_swan_issue_346 )
          set_price( bitusd, bitusd.amount(40) / core.amount(1000) ); // $0.04
          borrow( borrower, bitusd.amount(100), asset(5000) );    // 2x collat
          transfer( borrower, seller, bitusd.amount(100) );
-         limit_order_id_type oid_019 = create_sell_order( seller, bitusd.amount(39), core.amount(2000) )->id;   // this order is at $0.019, we should not be able to match against it
-         limit_order_id_type oid_020 = create_sell_order( seller, bitusd.amount(40), core.amount(2000) )->id;   // this order is at $0.020, we should be able to match against it
+         // this order is at $0.019, we should not be able to match against it
+         limit_order_id_type oid_019 = create_sell_order( seller, bitusd.amount(39), core.amount(2000) )->id;
+         // this order is at $0.020, we should be able to match against it
+         limit_order_id_type oid_020 = create_sell_order( seller, bitusd.amount(40), core.amount(2000) )->id;
          set_price( bitusd, bitusd.amount(21) / core.amount(1000) ); // $0.021
          //
          // We attempt to match against $0.019 order and black swan,
@@ -360,7 +362,8 @@ BOOST_AUTO_TEST_CASE( recollateralize )
       // can't bid zero collateral
       GRAPHENE_REQUIRE_THROW( bid_collateral( borrower2(), back().amount(0), swan().amount(100) ), fc::exception );
       // can't bid more than we have
-      GRAPHENE_REQUIRE_THROW( bid_collateral( borrower2(), back().amount(b2_balance + 100), swan().amount(100) ), fc::exception );
+      GRAPHENE_REQUIRE_THROW( bid_collateral( borrower2(), back().amount(b2_balance + 100), swan().amount(100) ),
+                              fc::exception );
       trx.operations.clear();
 
       // can't bid on a live bitasset


### PR DESCRIPTION
PR for #2281.

Add new option for MPA owners to disable collateral bidding.

Specifications:
* new `disable_collateral_bidding` bit in asset `flags` and `issuers_permissions`
  * unable to set before hard fork
  * unable to set on UIAs, but can be set on PMs (although useless)
  * common logic about issuer permissions (if permission is forfeited, unable to update flag, unable to enable permission if supply is non-zero, etc)
* if set in `flags`, unable to bid collateral
* when newly configured via `asset_update_operation`, cancel all collateral bids
* at hard fork time, cancel all collateral bids of asset which already disabled collateral bidding (due to old bug)
