### PR TITLE
Remove default value from the optional `new_fee_rate` member in `samet_fund_update_operation`

### DIFF
--- a/libraries/protocol/include/graphene/protocol/samet_fund.hpp
+++ b/libraries/protocol/include/graphene/protocol/samet_fund.hpp
@@ -79,7 +79,7 @@ namespace graphene { namespace protocol {
       account_id_type      owner_account;         ///< Owner of the fund
       samet_fund_id_type   fund_id;               ///< ID of the SameT Fund object
       optional<asset>      delta_amount;          ///< Delta amount, optional
-      optional<uint32_t>   new_fee_rate = 0;   ///< New fee rate, optional
+      optional<uint32_t>   new_fee_rate;          ///< New fee rate, optional
 
       extensions_type extensions;  ///< Unused. Reserved for future use.
 


### PR DESCRIPTION
If the type of a member variable is Optional, setting a non-standard default value will cause serialization / deserialization problems.

Follow-up of https://github.com/bitshares/bitshares-core/pull/2469.

To reproduce:
>unlocked >>> sign_transaction { "operations": [[66,{ "fee": { "amount": 100000, "asset_id": "1.3.0" }, "owner_account": "1.2.3833", "fund_id": "1.20.1", "delta_amount": {"asset_id":"1.3.0","amount":"2000000"}, "new_fee_rate": null}]] } true
Execution error: missing required active authority: Missing Active Authority 1.2.3833
... "data":{"trx":{ ...,"operations":[[66,{"fee":{"amount":100000,"asset_id":"1.3.0"},"owner_account":"1.2.3833","fund_id":"1.20.1","delta_amount":{"amount":2000000,"asset_id":"1.3.0"},"new_fee_rate":0, ...
