### PR TITLE
Add defensive check to mute SonarScanner warning

### DIFF
--- a/libraries/protocol/asset.cpp
+++ b/libraries/protocol/asset.cpp
@@ -149,6 +149,7 @@ namespace graphene { namespace protocol {
          {
             uint128_t num = ocp.numerator();
             uint128_t den = ocp.denominator();
+            FC_ASSERT( num > 0 && den > 0, "Internal error" );
             if( num > den )
             {
                num /= den;


### PR DESCRIPTION
SonarScanner (version 4.6.2.2472) reports a division by zero error in the `/=` operation below, which is a false positive.