### PR TITLE
Fix ES plugin by inserting maps as strings

### DIFF
--- a/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
+++ b/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
@@ -259,37 +259,23 @@ struct adaptor_struct {
          o["owner_"] = o["owner"].as_string();
          o.erase("owner");
       }
-      if (o.find("proposed_ops") != o.end())
+
+      vector<string> to_string_fields = {
+         "proposed_ops",
+         "initializer",
+         "policy",
+         "predicates",
+         "active_special_authority",
+         "owner_special_authority",
+         "acceptable_collateral",
+         "acceptable_borrowers"
+      };
+      for( const auto& name : to_string_fields )
       {
-         o["proposed_ops"] = fc::json::to_string(o["proposed_ops"]);
-      }
-      if (o.find("initializer") != o.end())
-      {
-         o["initializer"] = fc::json::to_string(o["initializer"]);
-      }
-      if (o.find("policy") != o.end())
-      {
-         o["policy"] = fc::json::to_string(o["policy"]);
-      }
-      if (o.find("predicates") != o.end())
-      {
-         o["predicates"] = fc::json::to_string(o["predicates"]);
-      }
-      if (o.find("active_special_authority") != o.end())
-      {
-         o["active_special_authority"] = fc::json::to_string(o["active_special_authority"]);
-      }
-      if (o.find("owner_special_authority") != o.end())
-      {
-         o["owner_special_authority"] = fc::json::to_string(o["owner_special_authority"]);
-      }
-      if (o.find("acceptable_collateral") != o.end())
-      {
-         o["acceptable_collateral"] = fc::json::to_string(o["acceptable_collateral"]);
-      }
-      if (o.find("acceptable_borrowers") != o.end())
-      {
-         o["acceptable_borrowers"] = fc::json::to_string(o["acceptable_borrowers"]);
+         if (o.find(name) != o.end())
+         {
+            o[name] = fc::json::to_string(o[name]);
+         }
       }
 
       variant v;

--- a/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
+++ b/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
@@ -283,7 +283,14 @@ struct adaptor_struct {
       {
          o["owner_special_authority"] = fc::json::to_string(o["owner_special_authority"]);
       }
-
+      if (o.find("acceptable_collateral") != o.end())
+      {
+         o["acceptable_collateral"] = fc::json::to_string(o["acceptable_collateral"]);
+      }
+      if (o.find("acceptable_borrowers") != o.end())
+      {
+         o["acceptable_borrowers"] = fc::json::to_string(o["acceptable_borrowers"]);
+      }
 
       variant v;
       fc::to_variant(o, v, FC_PACK_MAX_DEPTH);

--- a/tests/elasticsearch/main.cpp
+++ b/tests/elasticsearch/main.cpp
@@ -196,6 +196,7 @@ BOOST_AUTO_TEST_CASE(elasticsearch_account_history) {
 
          generate_block();
 
+         es.endpoint = es.index_prefix + "*/data/_count";
          fc::wait_for( ES_WAIT_TIME,  [&]() {
             res = graphene::utilities::simpleQuery(es);
             j = fc::json::from_string(res);

--- a/tests/elasticsearch/main.cpp
+++ b/tests/elasticsearch/main.cpp
@@ -22,6 +22,7 @@
  * THE SOFTWARE.
  */
 
+#include <graphene/chain/hardfork.hpp>
 #include <graphene/app/api.hpp>
 #include <graphene/utilities/tempdir.hpp>
 #include <fc/crypto/digest.hpp>
@@ -127,6 +128,81 @@ BOOST_AUTO_TEST_CASE(elasticsearch_account_history) {
          j = fc::json::from_string(res);
          auto last_transfer_amount = j["_source"]["operation_history"]["op_object"]["amount_"]["amount"].as_string();
          BOOST_CHECK_EQUAL(last_transfer_amount, "300");
+
+         // To test credit offers
+         generate_blocks( HARDFORK_CORE_2362_TIME );
+         set_expiration( db, trx );
+
+         ACTORS((sam)(ted)(por));
+
+         auto init_amount = 10000000 * GRAPHENE_BLOCKCHAIN_PRECISION;
+         fund( sam, asset(init_amount) );
+         fund( ted, asset(init_amount) );
+
+         const asset_object& core = asset_id_type()(db);
+         asset_id_type core_id;
+
+         const asset_object& usd = create_user_issued_asset( "MYUSD" );
+         asset_id_type usd_id = usd.id;
+         issue_uia( sam, usd.amount(init_amount) );
+         issue_uia( ted, usd.amount(init_amount) );
+
+         const asset_object& eur = create_user_issued_asset( "MYEUR", sam, white_list );
+         asset_id_type eur_id = eur.id;
+         issue_uia( sam, eur.amount(init_amount) );
+         issue_uia( ted, eur.amount(init_amount) );
+
+         // propose
+         {
+            flat_map<asset_id_type, price> collateral_map;
+            collateral_map[usd_id] = price( asset(1), asset(1, usd_id) );
+
+            credit_offer_create_operation cop = make_credit_offer_create_op( sam_id, core.id, 10000, 100, 3600, 0,
+                                                   false, db.head_block_time() + fc::days(1), collateral_map, {} );
+            propose( cop );
+         }
+
+         // create credit offers
+         // 1.
+         auto disable_time1 = db.head_block_time() - fc::minutes(1); // a time in the past
+
+         flat_map<asset_id_type, price> collateral_map1;
+         collateral_map1[usd_id] = price( asset(1), asset(2, usd_id) );
+
+         const credit_offer_object& coo1 = create_credit_offer( sam_id, core.id, 10000, 100, 3600, 0, false,
+                                              disable_time1, collateral_map1, {} );
+
+         BOOST_CHECK( coo1.owner_account == sam_id );
+         BOOST_CHECK( coo1.current_balance == 10000 );
+
+         // 2.
+         auto duration2 = GRAPHENE_MAX_CREDIT_DEAL_SECS;
+         auto disable_time2 = db.head_block_time() + fc::days(GRAPHENE_MAX_CREDIT_OFFER_DAYS);
+
+         flat_map<asset_id_type, price> collateral_map2;
+         collateral_map2[core_id] = price( asset(2, usd_id), asset(3) );
+         collateral_map2[eur_id] = price( asset(3, usd_id), asset(4, eur_id) );
+
+         flat_map<account_id_type, share_type> borrower_map2;
+         borrower_map2[account_id_type()] = 0;
+         borrower_map2[sam_id] = 1;
+         borrower_map2[ted_id] = GRAPHENE_MAX_SHARE_SUPPLY;
+
+         const credit_offer_object& coo2 = create_credit_offer( ted_id, usd_id, 1, 10000000u, duration2, 10000, true,
+                                              disable_time2, collateral_map2, borrower_map2 );
+         BOOST_CHECK( coo2.owner_account == ted_id );
+         BOOST_CHECK( coo2.asset_type == usd_id );
+         BOOST_CHECK( coo2.total_balance == 1 );
+
+         generate_block();
+
+         fc::wait_for( ES_WAIT_TIME,  [&]() {
+            res = graphene::utilities::simpleQuery(es);
+            j = fc::json::from_string(res);
+            total = j["count"].as_string();
+            return (std::stoi(total) > 13);
+         });
+
       }
    }
    catch (fc::exception &e) {


### PR DESCRIPTION
PR for #2549.

Note this is an ugly fix.

The final fix should be something like the one mentioned in https://github.com/bitshares/bitshares-core/pull/1396#issuecomment-432725835 :
>https://www.elastic.co/guide/en/elasticsearch/reference/current/array.html :
>> ...however, all values in the array must be of the same datatype...
>
>That sucks. I'm surprised this doesn't bite us more often, since all ``static_variant``s serialize like this IIRC.
Then again, static variant serialization sucks even more. :-/
>
>Ok for now, but we should change this in the next release IMO. E. g.
>```
>[ tag_no, { object:data }] -> { _type: type_name, object:data }
>```