### PR TITLE
Fix data deletion in es_objects plugin, update program options

### DIFF
--- a/libraries/chain/db_notify.cpp
+++ b/libraries/chain/db_notify.cpp
@@ -599,7 +599,7 @@ void database::notify_changed_objects()
                                   MUST_IGNORE_CUSTOM_OP_REQD_AUTHS(chain_time));
         }
 
-        if( new_ids.size() )
+        if( !new_ids.empty() )
            GRAPHENE_TRY_NOTIFY( new_objects, new_ids, new_accounts_impacted)
       }
 
@@ -616,7 +616,7 @@ void database::notify_changed_objects()
                                 MUST_IGNORE_CUSTOM_OP_REQD_AUTHS(chain_time));
         }
 
-        if( changed_ids.size() )
+        if( !changed_ids.empty() )
            GRAPHENE_TRY_NOTIFY( changed_objects, changed_ids, changed_accounts_impacted)
       }
 
@@ -637,7 +637,7 @@ void database::notify_changed_objects()
                                 MUST_IGNORE_CUSTOM_OP_REQD_AUTHS(chain_time));
         }
 
-        if( removed_ids.size() )
+        if( !removed_ids.empty() )
            GRAPHENE_TRY_NOTIFY( removed_objects, removed_ids, removed, removed_accounts_impacted )
       }
    }

--- a/libraries/plugins/es_objects/es_objects.cpp
+++ b/libraries/plugins/es_objects/es_objects.cpp
@@ -32,6 +32,7 @@
 #include <graphene/chain/account_object.hpp>
 
 #include <graphene/utilities/elasticsearch.hpp>
+#include <graphene/utilities/boost_program_options.hpp>
 
 namespace graphene { namespace db {
    template<uint8_t SpaceID, uint8_t TypeID>
@@ -394,74 +395,26 @@ void detail::es_objects_plugin_impl::init_program_options(const boost::program_o
 
 void detail::es_objects_plugin_impl::plugin_options::init(const boost::program_options::variables_map& options)
 {
-   if (options.count("es-objects-elasticsearch-url") > 0) {
-      elasticsearch_url = options["es-objects-elasticsearch-url"].as<std::string>();
-   }
-   if (options.count("es-objects-auth") > 0) {
-      auth = options["es-objects-auth"].as<std::string>();
-   }
-   if (options.count("es-objects-bulk-replay") > 0) {
-      bulk_replay = options["es-objects-bulk-replay"].as<uint32_t>();
-   }
-   if (options.count("es-objects-bulk-sync") > 0) {
-      bulk_sync = options["es-objects-bulk-sync"].as<uint32_t>();
-   }
-
-   if (options.count("es-objects-proposals") > 0) {
-      proposals.enabled = options["es-objects-proposals"].as<bool>();
-   }
-   if (options.count("es-objects-proposals-store-updates") > 0) {
-      proposals.store_updates = options["es-objects-proposals-store-updates"].as<bool>();
-   }
-   if (options.count("es-objects-proposals-no-delete") > 0) {
-      proposals.no_delete = options["es-objects-proposals-no-delete"].as<bool>();
-   }
-
-
-   if (options.count("es-objects-accounts") > 0) {
-      accounts.enabled = options["es-objects-accounts"].as<bool>();
-   }
-   if (options.count("es-objects-accounts-store-updates") > 0) {
-      accounts.store_updates = options["es-objects-accounts-store-updates"].as<bool>();
-   }
-
-   if (options.count("es-objects-assets") > 0) {
-      assets.enabled = options["es-objects-assets"].as<bool>();
-   }
-   if (options.count("es-objects-assets-store-updates") > 0) {
-      assets.store_updates = options["es-objects-assets-store-updates"].as<bool>();
-   }
-
-   if (options.count("es-objects-balances") > 0) {
-      balances.enabled = options["es-objects-balances"].as<bool>();
-   }
-   if (options.count("es-objects-balances-store-updates") > 0) {
-      balances.store_updates = options["es-objects-balances-store-updates"].as<bool>();
-   }
-
-   if (options.count("es-objects-limit-orders") > 0) {
-      limit_orders.enabled = options["es-objects-limit-orders"].as<bool>();
-   }
-   if (options.count("es-objects-limit-orders-store-updates") > 0) {
-      limit_orders.store_updates = options["es-objects-limit-orders-store-updates"].as<bool>();
-   }
-   if (options.count("es-objects-limit-orders-no-delete") > 0) {
-      limit_orders.no_delete = options["es-objects-limit-orders-no-delete"].as<bool>();
-   }
-
-   if (options.count("es-objects-asset-bitasset") > 0) {
-      asset_bitasset.enabled = options["es-objects-asset-bitasset"].as<bool>();
-   }
-   if (options.count("es-objects-asset-bitasset-store-updates") > 0) {
-      asset_bitasset.store_updates = options["es-objects-asset-bitasset-store-updates"].as<bool>();
-   }
-
-   if (options.count("es-objects-index-prefix") > 0) {
-      index_prefix = options["es-objects-index-prefix"].as<std::string>();
-   }
-   if (options.count("es-objects-start-es-after-block") > 0) {
-      start_es_after_block = options["es-objects-start-es-after-block"].as<uint32_t>();
-   }
+   utilities::get_program_option( options, "es-objects-elasticsearch-url", elasticsearch_url );
+   utilities::get_program_option( options, "es-objects-auth",              auth );
+   utilities::get_program_option( options, "es-objects-bulk-replay",       bulk_replay );
+   utilities::get_program_option( options, "es-objects-bulk-sync",         bulk_sync );
+   utilities::get_program_option( options, "es-objects-proposals",                    proposals.enabled );
+   utilities::get_program_option( options, "es-objects-proposals-store-updates",      proposals.store_updates );
+   utilities::get_program_option( options, "es-objects-proposals-no-delete",          proposals.no_delete );
+   utilities::get_program_option( options, "es-objects-accounts",                     accounts.enabled );
+   utilities::get_program_option( options, "es-objects-accounts-store-updates",       accounts.store_updates );
+   utilities::get_program_option( options, "es-objects-assets",                       assets.enabled );
+   utilities::get_program_option( options, "es-objects-assets-store-updates",         assets.store_updates );
+   utilities::get_program_option( options, "es-objects-balances",                     balances.enabled );
+   utilities::get_program_option( options, "es-objects-balances-store-updates",       balances.store_updates );
+   utilities::get_program_option( options, "es-objects-limit-orders",                 limit_orders.enabled );
+   utilities::get_program_option( options, "es-objects-limit-orders-store-updates",   limit_orders.store_updates );
+   utilities::get_program_option( options, "es-objects-limit-orders-no-delete",       limit_orders.no_delete );
+   utilities::get_program_option( options, "es-objects-asset-bitasset",               asset_bitasset.enabled );
+   utilities::get_program_option( options, "es-objects-asset-bitasset-store-updates", asset_bitasset.store_updates );
+   utilities::get_program_option( options, "es-objects-index-prefix",         index_prefix );
+   utilities::get_program_option( options, "es-objects-start-es-after-block", start_es_after_block );
 }
 
 void es_objects_plugin::plugin_initialize(const boost::program_options::variables_map& options)

--- a/libraries/plugins/es_objects/es_objects.cpp
+++ b/libraries/plugins/es_objects/es_objects.cpp
@@ -189,7 +189,31 @@ void es_objects_plugin_impl::index_database(const vector<object_id_type>& ids, a
       if( action_type::deletion == action )
          remove_from_database( value, prefix );
       else
-         prepareTemplate( db.get_object(value), prefix );
+      {
+         switch( itr->first )
+         {
+         case account_id_type::space_type:
+            prepareTemplate( db.get<account_object>(value), prefix );
+            break;
+         case account_balance_id_type::space_type:
+            prepareTemplate( db.get<account_balance_object>(value), prefix );
+            break;
+         case asset_id_type::space_type:
+            prepareTemplate( db.get<asset_object>(value), prefix );
+            break;
+         case asset_bitasset_data_id_type::space_type:
+            prepareTemplate( db.get<asset_bitasset_data_object>(value), prefix );
+            break;
+         case limit_order_id_type::space_type:
+            prepareTemplate( db.get<limit_order_object>(value), prefix );
+            break;
+         case proposal_id_type::space_type:
+            prepareTemplate( db.get<proposal_object>(value), prefix );
+            break;
+         default:
+            break;
+         }
+      }
    }
 
 }

--- a/libraries/plugins/es_objects/es_objects.cpp
+++ b/libraries/plugins/es_objects/es_objects.cpp
@@ -71,7 +71,7 @@ class es_objects_plugin_impl
 
       void index_database(const vector<object_id_type>& ids, action_type action);
       void genesis();
-      void remove_from_database(object_id_type id, std::string index);
+      void remove_from_database(const object_id_type& id, const std::string& index);
 
       struct plugin_options
       {
@@ -107,7 +107,7 @@ class es_objects_plugin_impl
       bool is_es_version_7_or_above = true;
 
       template<typename T>
-      void prepareTemplate(const T& blockchain_object, string index_name);
+      void prepareTemplate(const T& blockchain_object, const string& index_name);
 
       void init_program_options(const boost::program_options::variables_map& options);
 
@@ -208,7 +208,7 @@ void es_objects_plugin_impl::index_database(const vector<object_id_type>& ids, a
 
 }
 
-void es_objects_plugin_impl::remove_from_database( object_id_type id, std::string index)
+void es_objects_plugin_impl::remove_from_database( const object_id_type& id, const std::string& index)
 {
    if(_options._es_objects_keep_only_current)
    {
@@ -228,7 +228,7 @@ void es_objects_plugin_impl::remove_from_database( object_id_type id, std::strin
 }
 
 template<typename T>
-void es_objects_plugin_impl::prepareTemplate(const T& blockchain_object, string index_name)
+void es_objects_plugin_impl::prepareTemplate(const T& blockchain_object, const string& index_name)
 {
    fc::mutable_variant_object bulk_header;
    bulk_header["_index"] = _options._es_objects_index_prefix + index_name;

--- a/libraries/plugins/es_objects/es_objects.cpp
+++ b/libraries/plugins/es_objects/es_objects.cpp
@@ -33,6 +33,11 @@
 
 #include <graphene/utilities/elasticsearch.hpp>
 
+namespace graphene { namespace db {
+   template<uint8_t SpaceID, uint8_t TypeID>
+   constexpr uint16_t object_id<SpaceID, TypeID>::space_type;
+} };
+
 namespace graphene { namespace es_objects {
 
 namespace detail

--- a/libraries/plugins/es_objects/include/graphene/es_objects/es_objects.hpp
+++ b/libraries/plugins/es_objects/include/graphene/es_objects/es_objects.hpp
@@ -48,6 +48,7 @@ class es_objects_plugin : public graphene::app::plugin
          boost::program_options::options_description& cfg) override;
       void plugin_initialize(const boost::program_options::variables_map& options) override;
       void plugin_startup() override;
+      void plugin_shutdown() override;
 
    private:
       std::unique_ptr<detail::es_objects_plugin_impl> my;

--- a/libraries/protocol/include/graphene/protocol/object_id.hpp
+++ b/libraries/protocol/include/graphene/protocol/object_id.hpp
@@ -57,11 +57,7 @@ namespace graphene { namespace db {
       friend bool  operator > ( const object_id_type& a, const object_id_type& b ) { return a.number > b.number; }
 
       object_id_type& operator++(int) { ++number; return *this; }
-      object_id_type& operator++()    { ++number; return *this; }
 
-      friend object_id_type operator+(const object_id_type& a, int delta ) {
-         return object_id_type( a.space(), a.type(), a.instance() + delta );
-      }
       friend object_id_type operator+(const object_id_type& a, int64_t delta ) {
          return object_id_type( a.space(), a.type(), a.instance() + delta );
       }
@@ -82,7 +78,7 @@ namespace graphene { namespace db {
 
       explicit operator std::string() const
       {
-          return fc::to_string(space()) + "." + fc::to_string(type()) + "." + fc::to_string(instance());
+         return fc::to_string(space()) + "." + fc::to_string(type()) + "." + fc::to_string(instance());
       }
 
       uint64_t                   number;
@@ -110,6 +106,8 @@ namespace graphene { namespace db {
       static constexpr uint8_t space_id = SpaceID;
       static constexpr uint8_t type_id = TypeID;
 
+      static constexpr uint16_t space_type = (uint16_t(space_id) << 8) | (uint16_t(type_id));
+
       object_id() = default;
       object_id( unsigned_int i ):instance(i){}
       explicit object_id( uint64_t i ):instance(i)
@@ -121,7 +119,6 @@ namespace graphene { namespace db {
       }
 
       friend object_id operator+(const object_id a, int64_t delta ) { return object_id( uint64_t(a.instance.value+delta) ); }
-      friend object_id operator+(const object_id a, int delta ) { return object_id( uint64_t(a.instance.value+delta) ); }
 
       operator object_id_type()const { return object_id_type( SpaceID, TypeID, instance.value ); }
       explicit operator uint64_t()const { return object_id_type( *this ).number; }
@@ -144,6 +141,11 @@ namespace graphene { namespace db {
       friend bool  operator > ( const object_id& a, const object_id& b ) { return a.instance.value > b.instance.value; }
 
       friend size_t hash_value( object_id v ) { return std::hash<uint64_t>()(v.instance.value); }
+
+      explicit operator std::string() const
+      {
+         return fc::to_string(space_id) + "." + fc::to_string(type_id) + "." + fc::to_string(instance.value);
+      }
 
       unsigned_int instance;
    };

--- a/libraries/protocol/include/graphene/protocol/object_id.hpp
+++ b/libraries/protocol/include/graphene/protocol/object_id.hpp
@@ -216,7 +216,7 @@ struct member_name<graphene::db::object_id<S,T>, 0> { static constexpr const cha
  template<uint8_t SpaceID, uint8_t TypeID>
  void to_variant( const graphene::db::object_id<SpaceID,TypeID>& var,  fc::variant& vo, uint32_t max_depth = 1 )
  {
-    vo = fc::to_string(SpaceID) + "." + fc::to_string(TypeID) + "." + fc::to_string(var.instance.value);
+    vo = std::string( var );
  }
  template<uint8_t SpaceID, uint8_t TypeID>
  void from_variant( const fc::variant& var,  graphene::db::object_id<SpaceID,TypeID>& vo, uint32_t max_depth = 1 )

--- a/libraries/protocol/include/graphene/protocol/object_id.hpp
+++ b/libraries/protocol/include/graphene/protocol/object_id.hpp
@@ -106,7 +106,7 @@ namespace graphene { namespace db {
       static constexpr uint8_t space_id = SpaceID;
       static constexpr uint8_t type_id = TypeID;
 
-      static constexpr uint16_t space_type = (uint16_t(space_id) << 8) | (uint16_t(type_id));
+      static constexpr uint16_t space_type = uint16_t(uint16_t(space_id) << 8) | uint16_t(type_id);
 
       object_id() = default;
       object_id( unsigned_int i ):instance(i){}

--- a/libraries/protocol/include/graphene/protocol/object_id.hpp
+++ b/libraries/protocol/include/graphene/protocol/object_id.hpp
@@ -56,7 +56,7 @@ namespace graphene { namespace db {
       friend bool  operator < ( const object_id_type& a, const object_id_type& b ) { return a.number < b.number; }
       friend bool  operator > ( const object_id_type& a, const object_id_type& b ) { return a.number > b.number; }
 
-      object_id_type& operator++(int) { ++number; return *this; }
+      object_id_type& operator++() { ++number; return *this; }
 
       friend object_id_type operator+(const object_id_type& a, int64_t delta ) {
          return object_id_type( a.space(), a.type(), a.instance() + delta );

--- a/libraries/utilities/elasticsearch.cpp
+++ b/libraries/utilities/elasticsearch.cpp
@@ -222,16 +222,13 @@ fc::variant es_data_adaptor::adapt(const fc::variant_object& op)
    fc::mutable_variant_object o(op);
 
    // Note: these fields are maps, but were stored in ES as flattened arrays
-   static const std::map<std::string, data_type, std::less<>> flattened_fields = {
-      { "account_auths",    data_type::map_type },
-      { "address_auths",    data_type::map_type },
-      { "key_auths",        data_type::map_type }
-   };
+   static const std::unordered_set<std::string> flattened_fields = { "account_auths", "address_auths", "key_auths" };
+
    // Note:
    // object arrays listed in this map are stored redundantly in ES, with one instance as a nested object and
    //      the other as a string for backward compatibility,
    // object arrays not listed in this map are stored as nested objects only.
-   static const std::map<std::string, data_type, std::less<>> to_string_fields = {
+   static const std::unordered_map<std::string, data_type> to_string_fields = {
       { "parameters",               data_type::array_type }, // in committee proposals, current_fees.parameters
       { "op",                       data_type::static_variant_type }, // proposal_create_op.proposed_ops[*].op
       { "proposed_ops",             data_type::array_type },
@@ -246,7 +243,7 @@ fc::variant es_data_adaptor::adapt(const fc::variant_object& op)
       { "acceptable_collateral",    data_type::map_type },
       { "acceptable_borrowers",     data_type::map_type }
    };
-   std::map<std::string, fc::variants, std::less<>> original_arrays;
+   std::vector<std::pair<std::string, fc::variants>> original_arrays;
    std::vector<std::string> keys_to_rename;
    for( auto& i : o )
    {
@@ -265,14 +262,14 @@ fc::variant es_data_adaptor::adapt(const fc::variant_object& op)
          if( to_string_fields.find(name) != to_string_fields.end() )
          {
             // make a backup and convert to string
-            original_arrays[name] = array;
+            original_arrays.emplace_back( std::make_pair( name, array ) );
             element = fc::json::to_string(element);
          }
          else if( flattened_fields.find(name) != flattened_fields.end() )
          {
             // make a backup and adapt the original
             auto backup = array;
-            original_arrays[name] = backup;
+            original_arrays.emplace_back( std::make_pair( name, backup ) );
             adapt(array);
          }
          else

--- a/libraries/utilities/elasticsearch.cpp
+++ b/libraries/utilities/elasticsearch.cpp
@@ -262,14 +262,14 @@ fc::variant es_data_adaptor::adapt(const fc::variant_object& op)
          if( to_string_fields.find(name) != to_string_fields.end() )
          {
             // make a backup and convert to string
-            original_arrays.emplace_back( std::make_pair( name, array ) );
+            original_arrays.emplace_back( name, array );
             element = fc::json::to_string(element);
          }
          else if( flattened_fields.find(name) != flattened_fields.end() )
          {
             // make a backup and adapt the original
             auto backup = array;
-            original_arrays.emplace_back( std::make_pair( name, backup ) );
+            original_arrays.emplace_back( name, backup );
             adapt(array);
          }
          else

--- a/libraries/utilities/include/graphene/utilities/boost_program_options.hpp
+++ b/libraries/utilities/include/graphene/utilities/boost_program_options.hpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 Abit More, and contributors.
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#pragma once
+#include <boost/program_options.hpp>
+
+namespace graphene { namespace utilities {
+
+template<typename T>
+void get_program_option( const boost::program_options::variables_map& from, const std::string& key, T& to )
+{
+   if( from.count( key ) > 0 )
+   {
+      to = from[key].as<T>();
+   }
+}
+
+} } // end namespace graphene::utilities


### PR DESCRIPTION
PR for #2464.

Features:
- Add new option `es-objects-sync-db-on-startup` to copy all applicable objects from the object database (chain state) to ES on program startup
- Deprecate the `es-objects-keep-only-current` option, add new options
  - `es-objects-accounts-store-updates`, default `false`
  - `es-objects-assets-store-updates`, default `false`
  - `es-objects-asset-bitasset-store-updates`, default `false`
  - `es-objects-balances-store-updates`, default `false`
  - `es-objects-proposals-store-updates`, default `false`
  - `es-objects-proposals-no-delete`, default `true`
  - `es-objects-limit-orders-store-updates`, default `false`
  - `es-objects-limit-orders-no-delete`, default `false`
- Update default value of `es-objects-limit-orders` to `true`

Done some code cleanups and refactory.

---

Tasks:
- [x] sync (objects in) ES database from node on startup via `--es-objects-sync-db-on-startup` option
- [x] deal with errors on deletion i.e. data does not exist in ES due to out of sync: `{ ..., "errors":false, "items":[{"delete":{ ..., "result":"not_found", ..., "status":404}}, ... ]}`
- [x] deprecate the `keep-only-current` option, add dedicated `store-updates` and `no-delete` options for each applicable object