### PR TITLE
ElasticSearch related code refactory

### DIFF
--- a/libraries/plugins/elasticsearch/CMakeLists.txt
+++ b/libraries/plugins/elasticsearch/CMakeLists.txt
@@ -4,20 +4,12 @@ add_library( graphene_elasticsearch
         elasticsearch_plugin.cpp
            )
 
-find_curl()
-
-include_directories(${CURL_INCLUDE_DIRS})
 if(MSVC)
   set_source_files_properties(elasticsearch_plugin.cpp PROPERTIES COMPILE_FLAGS "/bigobj" )
 endif(MSVC)
-if(CURL_STATICLIB)
-  SET_TARGET_PROPERTIES(graphene_elasticsearch PROPERTIES
-  COMPILE_DEFINITIONS "CURL_STATICLIB")
-endif(CURL_STATICLIB)
-target_link_libraries( graphene_elasticsearch graphene_chain graphene_app ${CURL_LIBRARIES} )
+target_link_libraries( graphene_elasticsearch graphene_chain graphene_app )
 target_include_directories( graphene_elasticsearch
-                            PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
-                            PUBLIC "${CURL_INCLUDE_DIR}" )
+                            PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
 
 
 install( TARGETS

--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -30,6 +30,8 @@
 
 #include <boost/algorithm/string.hpp>
 
+#include <graphene/utilities/boost_program_options.hpp>
+
 namespace graphene { namespace elasticsearch {
 
 namespace detail
@@ -46,6 +48,29 @@ class elasticsearch_plugin_impl
       }
       virtual ~elasticsearch_plugin_impl();
 
+   private:
+      friend class graphene::elasticsearch::elasticsearch_plugin;
+
+      struct plugin_options
+      {
+         std::string elasticsearch_url = "http://localhost:9200/";
+         std::string auth = "";
+         uint32_t bulk_replay = 10000;
+         uint32_t bulk_sync = 100;
+
+         std::string index_prefix = "bitshares-";
+
+         uint32_t start_es_after_block = 0;
+
+         bool visitor = false;
+         bool operation_object = true;
+         bool operation_string = false;
+
+         mode elasticsearch_mode = mode::only_save;
+
+         void init(const boost::program_options::variables_map& options);
+      };
+
       bool update_account_histories( const signed_block& b );
 
       graphene::chain::database& database()
@@ -53,28 +78,18 @@ class elasticsearch_plugin_impl
          return _self.database();
       }
 
-      friend class graphene::elasticsearch::elasticsearch_plugin;
-
-   private:
       elasticsearch_plugin& _self;
+      plugin_options _options;
+
       primary_index< operation_history_index >* _oho_index;
 
-      std::string _elasticsearch_node_url = "http://localhost:9200/";
-      uint32_t _elasticsearch_bulk_replay = 10000;
-      uint32_t _elasticsearch_bulk_sync = 100;
-      bool _elasticsearch_visitor = false;
-      std::string _elasticsearch_basic_auth = "";
-      std::string _elasticsearch_index_prefix = "bitshares-";
-      bool _elasticsearch_operation_object = true;
-      uint32_t _elasticsearch_start_es_after_block = 0;
-      bool _elasticsearch_operation_string = false;
-      mode _elasticsearch_mode = mode::only_save;
+      uint32_t limit_documents = _options.bulk_replay;
+
       CURL *curl; // curl handler
       vector <string> bulk_lines; //  vector of op lines
       vector<std::string> prepare;
 
       graphene::utilities::ES es;
-      uint32_t limit_documents;
       int16_t op_type;
       operation_history_struct os;
       block_struct bs;
@@ -113,19 +128,19 @@ elasticsearch_plugin_impl::~elasticsearch_plugin_impl()
 }
 
 static std::string generateIndexName( const fc::time_point_sec& block_date,
-                                      const std::string& _elasticsearch_index_prefix )
+                                      const std::string& index_prefix )
 {
    auto block_date_string = block_date.to_iso_string();
    std::vector<std::string> parts;
    boost::split(parts, block_date_string, boost::is_any_of("-"));
-   std::string index_name = _elasticsearch_index_prefix + parts[0] + "-" + parts[1];
+   std::string index_name = index_prefix + parts[0] + "-" + parts[1];
    return index_name;
 }
 
 bool elasticsearch_plugin_impl::update_account_histories( const signed_block& b )
 {
    checkState(b.timestamp);
-   index_name = generateIndexName(b.timestamp, _elasticsearch_index_prefix);
+   index_name = generateIndexName(b.timestamp, _options.index_prefix);
 
    graphene::chain::database& db = database();
    const vector<optional< operation_history_object > >& hist = db.get_applied_operations();
@@ -168,7 +183,7 @@ bool elasticsearch_plugin_impl::update_account_histories( const signed_block& b 
       getOperationType(oho);
       doOperationHistory(oho);
       doBlock(oho->trx_in_block, b);
-      if(_elasticsearch_visitor)
+      if(_options.visitor)
          doVisitor(oho);
 
       const operation_history_object& op = *o_op;
@@ -247,12 +262,12 @@ void elasticsearch_plugin_impl::checkState(const fc::time_point_sec& block_time)
 {
    if((fc::time_point::now() - block_time) < fc::seconds(30))
    {
-      limit_documents = _elasticsearch_bulk_sync;
+      limit_documents = _options.bulk_sync;
       is_sync = true;
    }
    else
    {
-      limit_documents = _elasticsearch_bulk_replay;
+      limit_documents = _options.bulk_replay;
       is_sync = false;
    }
 }
@@ -270,7 +285,7 @@ void elasticsearch_plugin_impl::doOperationHistory(const optional <operation_his
    os.operation_result = fc::json::to_string(oho->result);
    os.virtual_op = oho->virtual_op;
 
-   if(_elasticsearch_operation_object) {
+   if(_options.operation_object) {
       // op
       oho->op.visit(fc::from_static_variant(os.op_object, FC_PACK_MAX_DEPTH));
       os.op_object = graphene::utilities::es_data_adaptor::adapt( os.op_object.get_object() );
@@ -279,7 +294,7 @@ void elasticsearch_plugin_impl::doOperationHistory(const optional <operation_his
       fc::to_variant( oho->result, v, FC_PACK_MAX_DEPTH );
       os.operation_result_object = graphene::utilities::es_data_adaptor::adapt_static_variant( v.get_array() );
    }
-   if(_elasticsearch_operation_string)
+   if(_options.operation_string)
       os.op = fc::json::to_string(oho->op);
 } FC_CAPTURE_LOG_AND_RETHROW( (oho) ) }
 
@@ -402,7 +417,7 @@ bool elasticsearch_plugin_impl::add_elasticsearch( const account_id_type account
    const auto &ath = addNewEntry(stats_obj, account_id, oho);
    growStats(stats_obj, ath);
 
-   if(block_number > _elasticsearch_start_es_after_block)  {
+   if(block_number > _options.start_es_after_block)  {
       createBulkLine(ath);
       prepareBulk(ath.id);
    }
@@ -470,20 +485,18 @@ void elasticsearch_plugin_impl::createBulkLine(const account_transaction_history
    bulk_line_struct.operation_type = op_type;
    bulk_line_struct.operation_id_num = ath.operation_id.instance.value;
    bulk_line_struct.block_data = bs;
-   if(_elasticsearch_visitor)
+   if(_options.visitor)
       bulk_line_struct.additional_data = vs;
    bulk_line = fc::json::to_string(bulk_line_struct, fc::json::legacy_generator);
 }
 
 void elasticsearch_plugin_impl::prepareBulk(const account_transaction_history_id_type& ath_id)
 {
-   const std::string _id = fc::json::to_string(ath_id);
    fc::mutable_variant_object bulk_header;
    bulk_header["_index"] = index_name;
-   if(!is_es_version_7_or_above)
+   if( !is_es_version_7_or_above )
       bulk_header["_type"] = "_doc";
-   bulk_header["_id"] = fc::to_string(ath_id.space_id) + "." + fc::to_string(ath_id.type_id) + "."
-                      + fc::to_string(ath_id.instance.value);
+   bulk_header["_id"] = std::string( ath_id );
    prepare = graphene::utilities::createBulk(bulk_header, std::move(bulk_line));
    std::move(prepare.begin(), prepare.end(), std::back_inserter(bulk_lines));
    prepare.clear();
@@ -523,9 +536,9 @@ void elasticsearch_plugin_impl::populateESstruct()
 {
    es.curl = curl;
    es.bulk_lines = std::move(bulk_lines);
-   es.elasticsearch_url = _elasticsearch_node_url;
-   es.auth = _elasticsearch_basic_auth;
-   es.index_prefix = _elasticsearch_index_prefix;
+   es.elasticsearch_url = _options.elasticsearch_url;
+   es.auth = _options.auth;
+   es.index_prefix = _options.index_prefix;
    es.endpoint = "";
    es.query = "";
 }
@@ -582,53 +595,43 @@ void elasticsearch_plugin::plugin_set_program_options(
 
 void detail::elasticsearch_plugin_impl::init_program_options(const boost::program_options::variables_map& options)
 {
-   if (options.count("elasticsearch-node-url") > 0) {
-      _elasticsearch_node_url = options["elasticsearch-node-url"].as<std::string>();
-   }
-   if (options.count("elasticsearch-bulk-replay") > 0) {
-      _elasticsearch_bulk_replay = options["elasticsearch-bulk-replay"].as<uint32_t>();
-   }
-   if (options.count("elasticsearch-bulk-sync") > 0) {
-      _elasticsearch_bulk_sync = options["elasticsearch-bulk-sync"].as<uint32_t>();
-   }
-   if (options.count("elasticsearch-visitor") > 0) {
-      _elasticsearch_visitor = options["elasticsearch-visitor"].as<bool>();
-   }
-   if (options.count("elasticsearch-basic-auth") > 0) {
-      _elasticsearch_basic_auth = options["elasticsearch-basic-auth"].as<std::string>();
-   }
-   if (options.count("elasticsearch-index-prefix") > 0) {
-      _elasticsearch_index_prefix = options["elasticsearch-index-prefix"].as<std::string>();
-   }
-   if (options.count("elasticsearch-operation-object") > 0) {
-      _elasticsearch_operation_object = options["elasticsearch-operation-object"].as<bool>();
-   }
-   if (options.count("elasticsearch-start-es-after-block") > 0) {
-      _elasticsearch_start_es_after_block = options["elasticsearch-start-es-after-block"].as<uint32_t>();
-   }
-   if (options.count("elasticsearch-operation-string") > 0) {
-      _elasticsearch_operation_string = options["elasticsearch-operation-string"].as<bool>();
-   }
-   if (options.count("elasticsearch-mode") > 0) {
-      const auto option_number = options["elasticsearch-mode"].as<uint16_t>();
-      if(option_number > mode::all)
-         FC_THROW_EXCEPTION(graphene::chain::plugin_exception, "Elasticsearch mode not valid");
-      _elasticsearch_mode = static_cast<mode>(options["elasticsearch-mode"].as<uint16_t>());
+   _options.init( options );
+}
+
+void detail::elasticsearch_plugin_impl::plugin_options::init(const boost::program_options::variables_map& options)
+{
+   utilities::get_program_option( options, "elasticsearch-node-url",     elasticsearch_url );
+   utilities::get_program_option( options, "elasticsearch-basic-auth",   auth );
+   utilities::get_program_option( options, "elasticsearch-bulk-replay",  bulk_replay );
+   utilities::get_program_option( options, "elasticsearch-bulk-sync",    bulk_sync );
+   utilities::get_program_option( options, "elasticsearch-index-prefix",         index_prefix );
+   utilities::get_program_option( options, "elasticsearch-start-es-after-block", start_es_after_block );
+   utilities::get_program_option( options, "elasticsearch-visitor",          visitor );
+   utilities::get_program_option( options, "elasticsearch-operation-object", operation_object );
+   utilities::get_program_option( options, "elasticsearch-operation-string", operation_string );
+
+   auto es_mode = static_cast<uint16_t>( elasticsearch_mode );
+   utilities::get_program_option( options, "elasticsearch-mode", es_mode );
+   if( es_mode > static_cast<uint16_t>( mode::all ) )
+      FC_THROW_EXCEPTION( graphene::chain::plugin_exception, "Elasticsearch mode not valid" );
+   elasticsearch_mode = static_cast<mode>( es_mode );
+
+   if( mode::all == elasticsearch_mode && !operation_string )
+   {
+      FC_THROW_EXCEPTION( graphene::chain::plugin_exception,
+            "If elasticsearch-mode is set to all then elasticsearch-operation-string need to be true");
    }
 }
 
 void elasticsearch_plugin::plugin_initialize(const boost::program_options::variables_map& options)
 {
+   my->init_program_options( options );
+
    my->_oho_index = database().add_index< primary_index< operation_history_index > >();
    database().add_index< primary_index< account_transaction_history_index > >();
 
-   my->init_program_options( options );
-
-   if(my->_elasticsearch_mode != mode::only_query) {
-      if (my->_elasticsearch_mode == mode::all && !my->_elasticsearch_operation_string)
-         FC_THROW_EXCEPTION(graphene::chain::plugin_exception,
-               "If elasticsearch-mode is set to all then elasticsearch-operation-string need to be true");
-
+   if( my->_options.elasticsearch_mode != mode::only_query )
+   {
       database().applied_block.connect([this](const signed_block &b) {
          if (!my->update_account_histories(b))
             FC_THROW_EXCEPTION(graphene::chain::plugin_exception,
@@ -638,11 +641,11 @@ void elasticsearch_plugin::plugin_initialize(const boost::program_options::varia
 
    graphene::utilities::ES es;
    es.curl = my->curl;
-   es.elasticsearch_url = my->_elasticsearch_node_url;
-   es.auth = my->_elasticsearch_basic_auth;
+   es.elasticsearch_url = my->_options.elasticsearch_url;
+   es.auth = my->_options.auth;
 
    if(!graphene::utilities::checkES(es))
-      FC_THROW( "ES database is not up in url ${url}", ("url", my->_elasticsearch_node_url) );
+      FC_THROW( "ES database is not up in url ${url}", ("url", my->_options.elasticsearch_url) );
 
    graphene::utilities::checkESVersion7OrAbove(es, my->is_es_version_7_or_above);
 }
@@ -764,8 +767,8 @@ graphene::utilities::ES elasticsearch_plugin::prepareHistoryQuery(string query)
 
    graphene::utilities::ES es;
    es.curl = curl;
-   es.elasticsearch_url = my->_elasticsearch_node_url;
-   es.index_prefix = my->_elasticsearch_index_prefix;
+   es.elasticsearch_url = my->_options.elasticsearch_url;
+   es.index_prefix = my->_options.index_prefix;
    es.endpoint = es.index_prefix + "*/_doc/_search";
    es.query = query;
 
@@ -774,7 +777,7 @@ graphene::utilities::ES elasticsearch_plugin::prepareHistoryQuery(string query)
 
 mode elasticsearch_plugin::get_running_mode()
 {
-   return my->_elasticsearch_mode;
+   return my->_options.elasticsearch_mode;
 }
 
 } }

--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -94,9 +94,9 @@ class elasticsearch_plugin_impl
                               uint32_t block_number );
       void send_bulk();
 
-      void doOperationHistory(const optional <operation_history_object>& oho, operation_history_struct& os);
-      void doBlock(uint32_t trx_in_block, const signed_block& b, block_struct& bs);
-      void doVisitor(const optional <operation_history_object>& oho, visitor_struct& vs);
+      void doOperationHistory(const optional <operation_history_object>& oho, operation_history_struct& os) const;
+      void doBlock(uint32_t trx_in_block, const signed_block& b, block_struct& bs) const;
+      void doVisitor(const optional <operation_history_object>& oho, visitor_struct& vs) const;
       void checkState(const fc::time_point_sec& block_time);
       void cleanObjects(const account_transaction_history_id_type& ath, const account_id_type& account_id);
 
@@ -247,7 +247,7 @@ void elasticsearch_plugin_impl::checkState(const fc::time_point_sec& block_time)
 }
 
 void elasticsearch_plugin_impl::doOperationHistory( const optional <operation_history_object>& oho,
-                                                    operation_history_struct& os )
+                                                    operation_history_struct& os ) const
 { try {
    os.trx_in_block = oho->trx_in_block;
    os.op_in_trx = oho->op_in_trx;
@@ -267,7 +267,7 @@ void elasticsearch_plugin_impl::doOperationHistory( const optional <operation_hi
       os.op = fc::json::to_string(oho->op);
 } FC_CAPTURE_LOG_AND_RETHROW( (oho) ) }
 
-void elasticsearch_plugin_impl::doBlock(uint32_t trx_in_block, const signed_block& b, block_struct& bs)
+void elasticsearch_plugin_impl::doBlock(uint32_t trx_in_block, const signed_block& b, block_struct& bs) const
 {
    std::string trx_id = "";
    if(trx_in_block < b.transactions.size())
@@ -332,9 +332,9 @@ struct operation_visitor
    }
 };
 
-void elasticsearch_plugin_impl::doVisitor(const optional <operation_history_object>& oho, visitor_struct& vs)
+void elasticsearch_plugin_impl::doVisitor(const optional <operation_history_object>& oho, visitor_struct& vs) const
 {
-   graphene::chain::database& db = database();
+   const graphene::chain::database& db = _self.database();
 
    operation_visitor o_v;
    oho->op.visit(o_v);

--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -613,7 +613,7 @@ vector<operation_history_object> elasticsearch_plugin::get_account_history(
       uint64_t limit,
       const operation_history_id_type& start ) const
 {
-   const string account_id_string = std::string( account_id );
+   const auto account_id_string = std::string( account_id );
 
    const auto stop_number = stop.instance.value;
    const auto start_number = start.instance.value;

--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -26,7 +26,6 @@
 #include <graphene/chain/impacted.hpp>
 #include <graphene/chain/account_evaluator.hpp>
 #include <graphene/chain/hardfork.hpp>
-#include <curl/curl.h>
 
 #include <boost/algorithm/string.hpp>
 
@@ -42,11 +41,7 @@ class elasticsearch_plugin_impl
    public:
       explicit elasticsearch_plugin_impl(elasticsearch_plugin& _plugin)
          : _self( _plugin )
-      {
-         curl = curl_easy_init();
-         curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
-      }
-      virtual ~elasticsearch_plugin_impl();
+      { }
 
    private:
       friend class graphene::elasticsearch::elasticsearch_plugin;
@@ -71,7 +66,7 @@ class elasticsearch_plugin_impl
          void init(const boost::program_options::variables_map& options);
       };
 
-      bool update_account_histories( const signed_block& b );
+      void update_account_histories( const signed_block& b );
 
       graphene::chain::database& database()
       {
@@ -85,47 +80,31 @@ class elasticsearch_plugin_impl
 
       uint32_t limit_documents = _options.bulk_replay;
 
-      CURL *curl; // curl handler
-      vector <string> bulk_lines; //  vector of op lines
-      vector<std::string> prepare;
+      std::unique_ptr<graphene::utilities::es_client> es;
 
-      graphene::utilities::ES es;
+      vector <string> bulk_lines; //  vector of op lines
+
       int16_t op_type;
       operation_history_struct os;
       block_struct bs;
       visitor_struct vs;
-      bulk_struct bulk_line_struct;
-      std::string bulk_line;
       std::string index_name;
       bool is_sync = false;
       bool is_es_version_7_or_above = true;
 
-      bool add_elasticsearch( const account_id_type account_id, const optional<operation_history_object>& oho,
-                              const uint32_t block_number );
-      const account_transaction_history_object& addNewEntry(const account_statistics_object& stats_obj,
-                                                            const account_id_type& account_id,
-                                                            const optional <operation_history_object>& oho);
-      const account_statistics_object& getStatsObject(const account_id_type& account_id);
-      void growStats(const account_statistics_object& stats_obj, const account_transaction_history_object& ath);
+      void add_elasticsearch( const account_id_type& account_id, const optional<operation_history_object>& oho,
+                              uint32_t block_number );
+      void send_bulk();
+
       void getOperationType(const optional <operation_history_object>& oho);
       void doOperationHistory(const optional <operation_history_object>& oho);
       void doBlock(uint32_t trx_in_block, const signed_block& b);
       void doVisitor(const optional <operation_history_object>& oho);
       void checkState(const fc::time_point_sec& block_time);
       void cleanObjects(const account_transaction_history_id_type& ath, const account_id_type& account_id);
-      void createBulkLine(const account_transaction_history_object& ath);
-      void prepareBulk(const account_transaction_history_id_type& ath_id);
-      void populateESstruct();
+
       void init_program_options(const boost::program_options::variables_map& options);
 };
-
-elasticsearch_plugin_impl::~elasticsearch_plugin_impl()
-{
-   if (curl) {
-      curl_easy_cleanup(curl);
-      curl = nullptr;
-   }
-}
 
 static std::string generateIndexName( const fc::time_point_sec& block_date,
                                       const std::string& index_prefix )
@@ -137,7 +116,7 @@ static std::string generateIndexName( const fc::time_point_sec& block_date,
    return index_name;
 }
 
-bool elasticsearch_plugin_impl::update_account_histories( const signed_block& b )
+void elasticsearch_plugin_impl::update_account_histories( const signed_block& b )
 {
    checkState(b.timestamp);
    index_name = generateIndexName(b.timestamp, _options.index_prefix);
@@ -221,41 +200,34 @@ bool elasticsearch_plugin_impl::update_account_histories( const signed_block& b 
 
       for( auto& account_id : impacted )
       {
-         if(!add_elasticsearch( account_id, oho, b.block_num() ))
-         {
-            elog( "Error adding data to Elastic Search: block num ${b}, account ${a}, data ${d}",
-                  ("b",b.block_num()) ("a",account_id) ("d", oho) );
-            return false;
-         }
+         // Note: we send bulk if there are too many items in bulk_lines
+         add_elasticsearch( account_id, oho, b.block_num() );
       }
+
    }
+
    // we send bulk at end of block when we are in sync for better real time client experience
-   if(is_sync)
+   if( is_sync && !bulk_lines.empty() )
+      send_bulk();
+
+}
+
+void elasticsearch_plugin_impl::send_bulk()
+{
+   if( !es->send_bulk( bulk_lines ) )
    {
-      populateESstruct();
-      if(es.bulk_lines.size() > 0)
+      elog( "Error sending ${n} lines of bulk data to ElasticSearch, the first lines are:",
+            ("n",bulk_lines.size()) );
+      const auto log_max = std::min( bulk_lines.size(), size_t(10) );
+      for( size_t i = 0; i < log_max; ++i )
       {
-         prepare.clear();
-         if(!graphene::utilities::SendBulk(std::move(es)))
-         {
-            // Note: although called with `std::move()`, `es` is not updated in `SendBulk()`
-            elog( "Error sending ${n} lines of bulk data to Elastic Search, the first lines are:",
-                  ("n",es.bulk_lines.size()) );
-            for( size_t i = 0; i < es.bulk_lines.size() && i < 10; ++i )
-            {
-               edump( (es.bulk_lines[i]) );
-            }
-            return false;
-         }
-         else
-            bulk_lines.clear();
+         edump( (bulk_lines[i]) );
       }
+      FC_THROW_EXCEPTION( graphene::chain::plugin_exception,
+            "Error populating ES database, we are going to keep trying." );
    }
-
-   if(bulk_lines.size() != limit_documents)
-      bulk_lines.reserve(limit_documents);
-
-   return true;
+   bulk_lines.clear();
+   bulk_lines.reserve(limit_documents);
 }
 
 void elasticsearch_plugin_impl::checkState(const fc::time_point_sec& block_time)
@@ -270,6 +242,7 @@ void elasticsearch_plugin_impl::checkState(const fc::time_point_sec& block_time)
       limit_documents = _options.bulk_replay;
       is_sync = false;
    }
+   bulk_lines.reserve(limit_documents);
 }
 
 void elasticsearch_plugin_impl::getOperationType(const optional <operation_history_object>& oho)
@@ -409,97 +382,51 @@ void elasticsearch_plugin_impl::doVisitor(const optional <operation_history_obje
    vs.fill_data.is_maker = o_v.fill_is_maker;
 }
 
-bool elasticsearch_plugin_impl::add_elasticsearch( const account_id_type account_id,
-                                                   const optional <operation_history_object>& oho,
-                                                   const uint32_t block_number)
-{
-   const auto &stats_obj = getStatsObject(account_id);
-   const auto &ath = addNewEntry(stats_obj, account_id, oho);
-   growStats(stats_obj, ath);
-
-   if(block_number > _options.start_es_after_block)  {
-      createBulkLine(ath);
-      prepareBulk(ath.id);
-   }
-   cleanObjects(ath.id, account_id);
-
-   if (curl && bulk_lines.size() >= limit_documents) { // we are in bulk time, ready to add data to elasticsearech
-      prepare.clear();
-      populateESstruct();
-      if(!graphene::utilities::SendBulk(std::move(es)))
-      {
-         // Note: although called with `std::move()`, `es` is not updated in `SendBulk()`
-         elog( "Error sending ${n} lines of bulk data to Elastic Search, the first lines are:",
-               ("n",es.bulk_lines.size()) );
-         for( size_t i = 0; i < es.bulk_lines.size() && i < 10; ++i )
-         {
-            edump( (es.bulk_lines[i]) );
-         }
-         return false;
-      }
-      else
-         bulk_lines.clear();
-   }
-
-   return true;
-}
-
-const account_statistics_object& elasticsearch_plugin_impl::getStatsObject(const account_id_type& account_id)
+void elasticsearch_plugin_impl::add_elasticsearch( const account_id_type& account_id,
+                                                   const optional<operation_history_object>& oho,
+                                                   uint32_t block_number )
 {
    graphene::chain::database& db = database();
-   const auto &stats_obj = db.get_account_stats_by_owner(account_id);
 
-   return stats_obj;
-}
+   const auto &stats_obj = db.get_account_stats_by_owner( account_id );
 
-const account_transaction_history_object& elasticsearch_plugin_impl::addNewEntry(
-      const account_statistics_object& stats_obj,
-      const account_id_type& account_id,
-      const optional <operation_history_object>& oho)
-{
-   graphene::chain::database& db = database();
-   const auto &ath = db.create<account_transaction_history_object>([&](account_transaction_history_object &obj) {
+   const auto &ath = db.create<account_transaction_history_object>(
+         [&oho,&account_id,&stats_obj]( account_transaction_history_object &obj ) {
       obj.operation_id = oho->id;
       obj.account = account_id;
       obj.sequence = stats_obj.total_ops + 1;
       obj.next = stats_obj.most_recent_op;
    });
 
-   return ath;
-}
-
-void elasticsearch_plugin_impl::growStats(const account_statistics_object& stats_obj,
-                                          const account_transaction_history_object& ath)
-{
-   graphene::chain::database& db = database();
-   db.modify(stats_obj, [&](account_statistics_object &obj) {
+   db.modify( stats_obj, [&ath]( account_statistics_object &obj ) {
       obj.most_recent_op = ath.id;
       obj.total_ops = ath.sequence;
    });
-}
 
-void elasticsearch_plugin_impl::createBulkLine(const account_transaction_history_object& ath)
-{
-   bulk_line_struct.account_history = ath;
-   bulk_line_struct.operation_history = os;
-   bulk_line_struct.operation_type = op_type;
-   bulk_line_struct.operation_id_num = ath.operation_id.instance.value;
-   bulk_line_struct.block_data = bs;
-   if(_options.visitor)
-      bulk_line_struct.additional_data = vs;
-   bulk_line = fc::json::to_string(bulk_line_struct, fc::json::legacy_generator);
-}
+   if( block_number > _options.start_es_after_block )
+   {
+      bulk_struct bulk_line_struct;
+      bulk_line_struct.account_history = ath;
+      bulk_line_struct.operation_history = os;
+      bulk_line_struct.operation_type = op_type;
+      bulk_line_struct.operation_id_num = ath.operation_id.instance.value;
+      bulk_line_struct.block_data = bs;
+      if(_options.visitor)
+         bulk_line_struct.additional_data = vs;
+      auto bulk_line = fc::json::to_string(bulk_line_struct, fc::json::legacy_generator);
 
-void elasticsearch_plugin_impl::prepareBulk(const account_transaction_history_id_type& ath_id)
-{
-   fc::mutable_variant_object bulk_header;
-   bulk_header["_index"] = index_name;
-   if( !is_es_version_7_or_above )
-      bulk_header["_type"] = "_doc";
-   bulk_header["_id"] = std::string( ath_id );
-   prepare = graphene::utilities::createBulk(bulk_header, std::move(bulk_line));
-   std::move(prepare.begin(), prepare.end(), std::back_inserter(bulk_lines));
-   prepare.clear();
+      fc::mutable_variant_object bulk_header;
+      bulk_header["_index"] = index_name;
+      if( !is_es_version_7_or_above )
+         bulk_header["_type"] = "_doc";
+      bulk_header["_id"] = std::string( ath.id );
+      auto prepare = graphene::utilities::createBulk(bulk_header, std::move(bulk_line));
+      std::move(prepare.begin(), prepare.end(), std::back_inserter(bulk_lines));
+
+      if( bulk_lines.size() >= limit_documents )
+         send_bulk();
+   }
+   cleanObjects(ath.id, account_id);
 }
 
 void elasticsearch_plugin_impl::cleanObjects( const account_transaction_history_id_type& ath_id,
@@ -530,17 +457,6 @@ void elasticsearch_plugin_impl::cleanObjects( const account_transaction_history_
          db.remove(remove_op_id(db));
       }
    }
-}
-
-void elasticsearch_plugin_impl::populateESstruct()
-{
-   es.curl = curl;
-   es.bulk_lines = std::move(bulk_lines);
-   es.elasticsearch_url = _options.elasticsearch_url;
-   es.auth = _options.auth;
-   es.index_prefix = _options.index_prefix;
-   es.endpoint = "";
-   es.query = "";
 }
 
 } // end namespace detail
@@ -596,6 +512,12 @@ void elasticsearch_plugin::plugin_set_program_options(
 void detail::elasticsearch_plugin_impl::init_program_options(const boost::program_options::variables_map& options)
 {
    _options.init( options );
+
+   es = std::make_unique<graphene::utilities::es_client>( _options.elasticsearch_url, _options.auth );
+
+   FC_ASSERT( es->check_status(), "ES database is not up in url ${url}", ("url", _options.elasticsearch_url) );
+
+   es->check_version_7_or_above( is_es_version_7_or_above );
 }
 
 void detail::elasticsearch_plugin_impl::plugin_options::init(const boost::program_options::variables_map& options)
@@ -633,26 +555,35 @@ void elasticsearch_plugin::plugin_initialize(const boost::program_options::varia
    if( my->_options.elasticsearch_mode != mode::only_query )
    {
       database().applied_block.connect([this](const signed_block &b) {
-         if (!my->update_account_histories(b))
-            FC_THROW_EXCEPTION(graphene::chain::plugin_exception,
-                  "Error populating ES database, we are going to keep trying.");
+         my->update_account_histories(b);
       });
    }
-
-   graphene::utilities::ES es;
-   es.curl = my->curl;
-   es.elasticsearch_url = my->_options.elasticsearch_url;
-   es.auth = my->_options.auth;
-
-   if(!graphene::utilities::checkES(es))
-      FC_THROW( "ES database is not up in url ${url}", ("url", my->_options.elasticsearch_url) );
-
-   graphene::utilities::checkESVersion7OrAbove(es, my->is_es_version_7_or_above);
 }
 
 void elasticsearch_plugin::plugin_startup()
 {
    // Nothing to do
+}
+
+static operation_history_object fromEStoOperation(const variant& source)
+{
+   operation_history_object result;
+
+   const auto operation_id = source["account_history"]["operation_id"];
+   fc::from_variant( operation_id, result.id, GRAPHENE_MAX_NESTED_OBJECTS );
+
+   const auto op = fc::json::from_string(source["operation_history"]["op"].as_string());
+   fc::from_variant( op, result.op, GRAPHENE_MAX_NESTED_OBJECTS );
+
+   const auto operation_result = fc::json::from_string(source["operation_history"]["operation_result"].as_string());
+   fc::from_variant( operation_result, result.result, GRAPHENE_MAX_NESTED_OBJECTS );
+
+   result.block_num = source["block_data"]["block_num"].as_uint64();
+   result.trx_in_block = source["operation_history"]["trx_in_block"].as_uint64();
+   result.op_in_trx = source["operation_history"]["op_in_trx"].as_uint64();
+   result.trx_in_block = source["operation_history"]["virtual_op"].as_uint64();
+
+   return result;
 }
 
 operation_history_object elasticsearch_plugin::get_operation_by_id(operation_history_id_type id)
@@ -670,8 +601,7 @@ operation_history_object elasticsearch_plugin::get_operation_by_id(operation_his
    }
    )";
 
-   auto es = prepareHistoryQuery(query);
-   const auto response = graphene::utilities::simpleQuery(es);
+   const auto response = my->es->query( my->_options.index_prefix + "*/_doc/_search", query );
    variant variant_response = fc::json::from_string(response);
    const auto source = variant_response["hits"]["hits"][size_t(0)]["_source"];
    return fromEStoOperation(source);
@@ -712,67 +642,30 @@ vector<operation_history_object> elasticsearch_plugin::get_account_history(
    }
    )";
 
-   auto es = prepareHistoryQuery(query);
-
    vector<operation_history_object> result;
 
-   if(!graphene::utilities::checkES(es))
+   if( !my->es->check_status() )
       return result;
 
-   const auto response = graphene::utilities::simpleQuery(es);
+   const auto response = my->es->query( my->_options.index_prefix + "*/_doc/_search", query );
+
    variant variant_response = fc::json::from_string(response);
 
    const auto hits = variant_response["hits"]["total"];
-   uint32_t size;
+   size_t size;
    if( hits.is_object() ) // ES-7 ?
-      size = static_cast<uint32_t>(hits["value"].as_uint64());
+      size = static_cast<size_t>(hits["value"].as_uint64());
    else // probably ES-6
-      size = static_cast<uint32_t>(hits.as_uint64());
-   size = std::min( size, limit );
+      size = static_cast<size_t>(hits.as_uint64());
+   size = std::min( size, size_t(limit) );
 
-   for(unsigned i=0; i<size; i++)
+   const auto& data = variant_response["hits"]["hits"];
+   for(size_t i=0; i<size; i++)
    {
-      const auto source = variant_response["hits"]["hits"][size_t(i)]["_source"];
+      const auto& source = data[size_t(i)]["_source"];
       result.push_back(fromEStoOperation(source));
    }
    return result;
-}
-
-operation_history_object elasticsearch_plugin::fromEStoOperation(variant source)
-{
-   operation_history_object result;
-
-   const auto operation_id = source["account_history"]["operation_id"];
-   fc::from_variant( operation_id, result.id, GRAPHENE_MAX_NESTED_OBJECTS );
-
-   const auto op = fc::json::from_string(source["operation_history"]["op"].as_string());
-   fc::from_variant( op, result.op, GRAPHENE_MAX_NESTED_OBJECTS );
-
-   const auto operation_result = fc::json::from_string(source["operation_history"]["operation_result"].as_string());
-   fc::from_variant( operation_result, result.result, GRAPHENE_MAX_NESTED_OBJECTS );
-
-   result.block_num = source["block_data"]["block_num"].as_uint64();
-   result.trx_in_block = source["operation_history"]["trx_in_block"].as_uint64();
-   result.op_in_trx = source["operation_history"]["op_in_trx"].as_uint64();
-   result.trx_in_block = source["operation_history"]["virtual_op"].as_uint64();
-
-   return result;
-}
-
-graphene::utilities::ES elasticsearch_plugin::prepareHistoryQuery(string query)
-{
-   CURL *curl;
-   curl = curl_easy_init();
-   curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
-
-   graphene::utilities::ES es;
-   es.curl = curl;
-   es.elasticsearch_url = my->_options.elasticsearch_url;
-   es.index_prefix = my->_options.index_prefix;
-   es.endpoint = es.index_prefix + "*/_doc/_search";
-   es.query = query;
-
-   return es;
 }
 
 mode elasticsearch_plugin::get_running_mode()

--- a/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
+++ b/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
@@ -80,17 +80,17 @@ class elasticsearch_plugin : public graphene::app::plugin
 
 
 struct operation_history_struct {
-   int trx_in_block;
-   int op_in_trx;
+   uint16_t trx_in_block;
+   uint16_t op_in_trx;
    std::string operation_result;
-   int virtual_op;
+   uint32_t virtual_op;
    std::string op;
    variant op_object;
    variant operation_result_object;
 };
 
 struct block_struct {
-   int block_num;
+   uint32_t block_num;
    fc::time_point_sec block_time;
    std::string trx_id;
 };
@@ -136,8 +136,8 @@ struct visitor_struct {
 struct bulk_struct {
    account_transaction_history_object account_history;
    operation_history_struct operation_history;
-   int operation_type;
-   int operation_id_num;
+   int64_t  operation_type;
+   uint64_t operation_id_num;
    block_struct block_data;
    optional<visitor_struct> additional_data;
 };

--- a/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
+++ b/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
@@ -71,12 +71,8 @@ class elasticsearch_plugin : public graphene::app::plugin
             operation_history_id_type stop, unsigned limit, operation_history_id_type start);
       mode get_running_mode();
 
-      friend class detail::elasticsearch_plugin_impl;
-      std::unique_ptr<detail::elasticsearch_plugin_impl> my;
-
    private:
-      operation_history_object fromEStoOperation(variant source);
-      graphene::utilities::ES prepareHistoryQuery(string query);
+      std::unique_ptr<detail::elasticsearch_plugin_impl> my;
 };
 
 

--- a/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
+++ b/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
@@ -66,10 +66,13 @@ class elasticsearch_plugin : public graphene::app::plugin
       void plugin_initialize(const boost::program_options::variables_map& options) override;
       void plugin_startup() override;
 
-      operation_history_object get_operation_by_id(operation_history_id_type id);
-      vector<operation_history_object> get_account_history(const account_id_type account_id,
-            operation_history_id_type stop, unsigned limit, operation_history_id_type start);
-      mode get_running_mode();
+      operation_history_object get_operation_by_id(const operation_history_id_type& id) const;
+      vector<operation_history_object> get_account_history(
+            const account_id_type& account_id,
+            const operation_history_id_type& stop = operation_history_id_type(),
+            uint64_t limit = 100,
+            const operation_history_id_type& start = operation_history_id_type() ) const;
+      mode get_running_mode() const;
 
    private:
       std::unique_ptr<detail::elasticsearch_plugin_impl> my;

--- a/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
+++ b/libraries/plugins/elasticsearch/include/graphene/elasticsearch/elasticsearch_plugin.hpp
@@ -50,7 +50,7 @@ namespace detail
     class elasticsearch_plugin_impl;
 }
 
-enum mode { only_save = 0 , only_query = 1, all = 2 };
+enum class mode { only_save = 0 , only_query = 1, all = 2 };
 
 class elasticsearch_plugin : public graphene::app::plugin
 {

--- a/libraries/plugins/es_objects/CMakeLists.txt
+++ b/libraries/plugins/es_objects/CMakeLists.txt
@@ -4,18 +4,11 @@ add_library( graphene_es_objects
         es_objects.cpp
            )
 
-find_curl()
-
-include_directories(${CURL_INCLUDE_DIRS})
-if(CURL_STATICLIB)
-  SET_TARGET_PROPERTIES(graphene_es_objects PROPERTIES
-	COMPILE_DEFINITIONS "CURL_STATICLIB")
-endif(CURL_STATICLIB)
 if(MSVC)
   set_source_files_properties(es_objects.cpp PROPERTIES COMPILE_FLAGS "/bigobj" )
 endif(MSVC)
 
-target_link_libraries( graphene_es_objects graphene_chain graphene_app ${CURL_LIBRARIES} )
+target_link_libraries( graphene_es_objects graphene_chain graphene_app )
 target_include_directories( graphene_es_objects
                             PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
 

--- a/libraries/utilities/elasticsearch.cpp
+++ b/libraries/utilities/elasticsearch.cpp
@@ -222,6 +222,11 @@ std::string doCurl(CurlRequest& curl)
    return CurlReadBuffer;
 }
 
+bool curl_wrapper::http_response::is_200() const
+{
+   return ( http_response_code::HTTP_200 == code );
+}
+
 CURL* curl_wrapper::init_curl()
 {
    CURL* curl = curl_easy_init();
@@ -244,6 +249,18 @@ curl_wrapper::curl_wrapper()
 {
    curl_easy_setopt( curl.get(), CURLOPT_HTTPHEADER, request_headers.get() );
    curl_easy_setopt( curl.get(), CURLOPT_USERAGENT, "bitshares-core/6.1" );
+}
+
+void curl_wrapper::curl_deleter::operator()( CURL* curl ) const
+{
+   if( !curl )
+      curl_easy_cleanup( curl );
+}
+
+void curl_wrapper::curl_slist_deleter::operator()( curl_slist* slist ) const
+{
+   if( !slist )
+      curl_slist_free_all( slist );
 }
 
 curl_wrapper::http_response curl_wrapper::request( curl_wrapper::http_request_method method,
@@ -298,6 +315,28 @@ curl_wrapper::http_response curl_wrapper::request( curl_wrapper::http_request_me
    resp.code = static_cast<uint16_t>( code );
 
    return resp;
+}
+
+curl_wrapper::http_response curl_wrapper::get( const std::string& url, const std::string& auth ) const
+{
+   return request( http_request_method::HTTP_GET, url, auth, "" );
+}
+
+curl_wrapper::http_response curl_wrapper::del( const std::string& url, const std::string& auth ) const
+{
+   return request( http_request_method::HTTP_DELETE, url, auth, "" );
+}
+
+curl_wrapper::http_response curl_wrapper::post( const std::string& url, const std::string& auth,
+                                                const std::string& query ) const
+{
+   return request( http_request_method::HTTP_POST, url, auth, query );
+}
+
+curl_wrapper::http_response curl_wrapper::put( const std::string& url, const std::string& auth,
+                                               const std::string& query ) const
+{
+   return request( http_request_method::HTTP_PUT, url, auth, query );
 }
 
 bool es_client::check_status() const

--- a/libraries/utilities/elasticsearch.cpp
+++ b/libraries/utilities/elasticsearch.cpp
@@ -251,10 +251,10 @@ curl_wrapper::curl_wrapper()
    curl_easy_setopt( curl.get(), CURLOPT_USERAGENT, "bitshares-core/6.1" );
 }
 
-void curl_wrapper::curl_deleter::operator()( CURL* curl ) const
+void curl_wrapper::curl_deleter::operator()( CURL* p_curl ) const
 {
-   if( !curl )
-      curl_easy_cleanup( curl );
+   if( !p_curl )
+      curl_easy_cleanup( p_curl );
 }
 
 void curl_wrapper::curl_slist_deleter::operator()( curl_slist* slist ) const

--- a/libraries/utilities/elasticsearch.cpp
+++ b/libraries/utilities/elasticsearch.cpp
@@ -222,18 +222,24 @@ std::string doCurl(CurlRequest& curl)
    return CurlReadBuffer;
 }
 
-curl_wrapper::curl_wrapper()
+static CURL* init_curl()
 {
-   curl.reset( curl_easy_init() );
-   if( !curl )
-      FC_THROW( "Unable to init cURL" );
+   CURL* curl = curl_easy_init();
+   FC_ASSERT( curl, "Unable to init cURL" );
+   return curl;
+}
 
+static curl_slist* init_request_headers()
+{
+   curl_slist* request_headers = curl_slist_append( NULL, "Content-Type: application/json" );
+   FC_ASSERT( request_headers, "Unable to init cURL request headers" );
+   return request_headers;
+}
+
+curl_wrapper::curl_wrapper()
+: curl( init_curl() ), request_headers( init_request_headers() )
+{
    curl_easy_setopt( curl.get(), CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2 );
-
-   request_headers.reset( curl_slist_append( NULL, "Content-Type: application/json" ) );
-   if( !request_headers )
-      FC_THROW( "Unable to init cURL request headers" );
-
    curl_easy_setopt( curl.get(), CURLOPT_HTTPHEADER, request_headers.get() );
    curl_easy_setopt( curl.get(), CURLOPT_USERAGENT, "bitshares-core/6.1" );
 }

--- a/libraries/utilities/elasticsearch.cpp
+++ b/libraries/utilities/elasticsearch.cpp
@@ -309,7 +309,7 @@ std::string es_client::get_version() const
    const auto response = curl.get( base_url, auth );
    if( response.code != 200 )
       FC_THROW( "Error on es_client::get_version(): code = ${code}, message = ${message} ",
-                ("code", response.code) ("message", response.content) );
+                ("code", int64_t(response.code)) ("message", response.content) );
 
    fc::variant content = fc::json::from_string( response.content );
    return content["version"]["number"].as_string();

--- a/libraries/utilities/elasticsearch.cpp
+++ b/libraries/utilities/elasticsearch.cpp
@@ -273,8 +273,8 @@ curl_wrapper::response curl_wrapper::request( curl_wrapper::http_request_method 
    const auto* p_custom_request = custom_request.empty() ? NULL : custom_request.c_str();
    curl_easy_setopt( curl.get(), CURLOPT_CUSTOMREQUEST, p_custom_request );
 
-   if( curl_wrapper::http_request_method::POST == method
-       || curl_wrapper::http_request_method::PUT == method )
+   if( curl_wrapper::http_request_method::_POST == method
+       || curl_wrapper::http_request_method::_PUT == method )
    {
       curl_easy_setopt( curl.get(), CURLOPT_HTTPGET, false );
       curl_easy_setopt( curl.get(), CURLOPT_POST, true );

--- a/libraries/utilities/elasticsearch.cpp
+++ b/libraries/utilities/elasticsearch.cpp
@@ -128,11 +128,11 @@ static std::string joinBulkLines(const std::vector<std::string>& bulk)
    return bulking;
 }
 
-static long getResponseCode(CURL *handler)
+static uint16_t getResponseCode(CURL *handler)
 {
    long http_code = 0;
    curl_easy_getinfo (handler, CURLINFO_RESPONSE_CODE, &http_code);
-   return http_code;
+   return static_cast<uint16_t>(http_code);
 }
 
 bool SendBulk(ES&& es)

--- a/libraries/utilities/elasticsearch.cpp
+++ b/libraries/utilities/elasticsearch.cpp
@@ -108,13 +108,13 @@ curl_wrapper::curl_wrapper()
 
 void curl_wrapper::curl_deleter::operator()( CURL* p_curl ) const
 {
-   if( !p_curl )
+   if( p_curl )
       curl_easy_cleanup( p_curl );
 }
 
 void curl_wrapper::curl_slist_deleter::operator()( curl_slist* slist ) const
 {
-   if( !slist )
+   if( slist )
       curl_slist_free_all( slist );
 }
 

--- a/libraries/utilities/elasticsearch.cpp
+++ b/libraries/utilities/elasticsearch.cpp
@@ -225,8 +225,12 @@ std::string doCurl(CurlRequest& curl)
 static CURL* init_curl()
 {
    CURL* curl = curl_easy_init();
-   FC_ASSERT( curl, "Unable to init cURL" );
-   return curl;
+   if( curl )
+   {
+      curl_easy_setopt( curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2 );
+      return curl;
+   }
+   FC_THROW( "Unable to init cURL" );
 }
 
 static curl_slist* init_request_headers()
@@ -239,7 +243,6 @@ static curl_slist* init_request_headers()
 curl_wrapper::curl_wrapper()
 : curl( init_curl() ), request_headers( init_request_headers() )
 {
-   curl_easy_setopt( curl.get(), CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2 );
    curl_easy_setopt( curl.get(), CURLOPT_HTTPHEADER, request_headers.get() );
    curl_easy_setopt( curl.get(), CURLOPT_USERAGENT, "bitshares-core/6.1" );
 }

--- a/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
+++ b/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
@@ -40,13 +40,13 @@ public:
    // Note: the numbers are used in the request() function. If we need to update or add, please check the function
    enum class http_request_method
    {
-      GET     = 0,
-      POST    = 1,
-      HEAD    = 2,
-      PUT     = 3,
-      DELETE  = 4,
-      PATCH   = 5,
-      OPTIONS = 6
+      _GET     = 0,
+      _POST    = 1,
+      _HEAD    = 2,
+      _PUT     = 3,
+      _DELETE  = 4,
+      _PATCH   = 5,
+      _OPTIONS = 6
    };
 
    struct response
@@ -61,16 +61,16 @@ public:
                      const std::string& query ) const;
 
    response get( const std::string& url, const std::string& auth ) const
-   { return request( http_request_method::GET, url, auth, "" ); }
+   { return request( http_request_method::_GET, url, auth, "" ); }
 
    response del( const std::string& url, const std::string& auth ) const
-   { return request( http_request_method::DELETE, url, auth, "" ); }
+   { return request( http_request_method::_DELETE, url, auth, "" ); }
 
    response post( const std::string& url, const std::string& auth, const std::string& query ) const
-   { return request( http_request_method::POST, url, auth, query ); }
+   { return request( http_request_method::_POST, url, auth, query ); }
 
    response put( const std::string& url, const std::string& auth, const std::string& query ) const
-   { return request( http_request_method::PUT, url, auth, query ); }
+   { return request( http_request_method::_PUT, url, auth, query ); }
 
 private:
 

--- a/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
+++ b/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
@@ -60,7 +60,7 @@ public:
    {
       uint16_t    code;
       std::string content;
-      bool is_200() const { return ( http_response_code::HTTP_200 == code ); }
+      bool is_200() const; ///< @return if @ref code is 200
    };
 
    http_response request( http_request_method method,
@@ -68,17 +68,10 @@ public:
                           const std::string& auth,
                           const std::string& query ) const;
 
-   http_response get( const std::string& url, const std::string& auth ) const
-   { return request( http_request_method::HTTP_GET, url, auth, "" ); }
-
-   http_response del( const std::string& url, const std::string& auth ) const
-   { return request( http_request_method::HTTP_DELETE, url, auth, "" ); }
-
-   http_response post( const std::string& url, const std::string& auth, const std::string& query ) const
-   { return request( http_request_method::HTTP_POST, url, auth, query ); }
-
-   http_response put( const std::string& url, const std::string& auth, const std::string& query ) const
-   { return request( http_request_method::HTTP_PUT, url, auth, query ); }
+   http_response get( const std::string& url, const std::string& auth ) const;
+   http_response del( const std::string& url, const std::string& auth ) const;
+   http_response post( const std::string& url, const std::string& auth, const std::string& query ) const;
+   http_response put( const std::string& url, const std::string& auth, const std::string& query ) const;
 
 private:
 
@@ -87,20 +80,12 @@ private:
 
    struct curl_deleter
    {
-      void operator()( CURL* curl ) const
-      {
-         if( !curl )
-            curl_easy_cleanup( curl );
-      }
+      void operator()( CURL* curl ) const;
    };
 
    struct curl_slist_deleter
    {
-      void operator()( curl_slist* slist ) const
-      {
-         if( !slist )
-            curl_slist_free_all( slist );
-      }
+      void operator()( curl_slist* slist ) const;
    };
 
    std::unique_ptr<CURL, curl_deleter> curl { init_curl() };

--- a/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
+++ b/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
@@ -80,7 +80,7 @@ private:
 
    struct curl_deleter
    {
-      void operator()( CURL* curl ) const;
+      void operator()( CURL* p_curl ) const;
    };
 
    struct curl_slist_deleter

--- a/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
+++ b/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
@@ -27,7 +27,7 @@
 #include <vector>
 
 #include <curl/curl.h>
-#include <fc/time.hpp>
+
 #include <fc/variant_object.hpp>
 
 namespace graphene { namespace utilities {
@@ -111,36 +111,7 @@ private:
    curl_wrapper curl;
 };
 
-   class ES {
-      public:
-         CURL *curl;
-         std::vector <std::string> bulk_lines;
-         std::string elasticsearch_url;
-         std::string index_prefix;
-         std::string auth;
-         std::string endpoint;
-         std::string query;
-   };
-   class CurlRequest {
-      public:
-         CURL *handler;
-         std::string url;
-         std::string type;
-         std::string auth;
-         std::string query;
-   };
-
-   bool SendBulk(ES&& es);
-   bool checkES(ES& es);
-   std::string getESVersion(ES& es);
-   void checkESVersion7OrAbove(ES& es, bool& result) noexcept;
-   std::string simpleQuery(ES& es);
-   bool deleteAll(ES& es);
-   std::string getEndPoint(ES& es);
-
-   std::string doCurl(CurlRequest& curl);
-
-   std::vector<std::string> createBulk(const fc::mutable_variant_object& bulk_header, std::string&& data);
+std::vector<std::string> createBulk(const fc::mutable_variant_object& bulk_header, std::string&& data);
 
 struct es_data_adaptor
 {

--- a/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
+++ b/libraries/utilities/include/graphene/utilities/elasticsearch.hpp
@@ -40,39 +40,50 @@ public:
    // Note: the numbers are used in the request() function. If we need to update or add, please check the function
    enum class http_request_method
    {
-      _GET     = 0,
-      _POST    = 1,
-      _HEAD    = 2,
-      _PUT     = 3,
-      _DELETE  = 4,
-      _PATCH   = 5,
-      _OPTIONS = 6
+      HTTP_GET     = 0,
+      HTTP_POST    = 1,
+      HTTP_HEAD    = 2,
+      HTTP_PUT     = 3,
+      HTTP_DELETE  = 4,
+      HTTP_PATCH   = 5,
+      HTTP_OPTIONS = 6
    };
 
-   struct response
+   struct http_response_code
    {
-      long        code;
-      std::string content;
+      static constexpr uint16_t HTTP_200 = 200;
+      static constexpr uint16_t HTTP_401 = 401;
+      static constexpr uint16_t HTTP_413 = 413;
    };
 
-   response request( http_request_method method,
-                     const std::string& url,
-                     const std::string& auth,
-                     const std::string& query ) const;
+   struct http_response
+   {
+      uint16_t    code;
+      std::string content;
+      bool is_200() const { return ( http_response_code::HTTP_200 == code ); }
+   };
 
-   response get( const std::string& url, const std::string& auth ) const
-   { return request( http_request_method::_GET, url, auth, "" ); }
+   http_response request( http_request_method method,
+                          const std::string& url,
+                          const std::string& auth,
+                          const std::string& query ) const;
 
-   response del( const std::string& url, const std::string& auth ) const
-   { return request( http_request_method::_DELETE, url, auth, "" ); }
+   http_response get( const std::string& url, const std::string& auth ) const
+   { return request( http_request_method::HTTP_GET, url, auth, "" ); }
 
-   response post( const std::string& url, const std::string& auth, const std::string& query ) const
-   { return request( http_request_method::_POST, url, auth, query ); }
+   http_response del( const std::string& url, const std::string& auth ) const
+   { return request( http_request_method::HTTP_DELETE, url, auth, "" ); }
 
-   response put( const std::string& url, const std::string& auth, const std::string& query ) const
-   { return request( http_request_method::_PUT, url, auth, query ); }
+   http_response post( const std::string& url, const std::string& auth, const std::string& query ) const
+   { return request( http_request_method::HTTP_POST, url, auth, query ); }
+
+   http_response put( const std::string& url, const std::string& auth, const std::string& query ) const
+   { return request( http_request_method::HTTP_PUT, url, auth, query ); }
 
 private:
+
+   static CURL* init_curl();
+   static curl_slist* init_request_headers();
 
    struct curl_deleter
    {
@@ -92,8 +103,8 @@ private:
       }
    };
 
-   std::unique_ptr<CURL, curl_deleter> curl;
-   std::unique_ptr<curl_slist, curl_slist_deleter> request_headers;
+   std::unique_ptr<CURL, curl_deleter> curl { init_curl() };
+   std::unique_ptr<curl_slist, curl_slist_deleter> request_headers { init_request_headers() };
 };
 
 class es_client
@@ -113,10 +124,6 @@ private:
    std::string base_url;
    std::string auth;
    curl_wrapper curl;
-   //std::string index_prefix; // bitshares-, objects-
-   //std::string endpoint; // index_prefix + "*/_doc/_search";
-   //std::string query; // json
-   //std::vector <std::string> bulk_lines;
 };
 
    class ES {

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -48,6 +48,7 @@
 #include <iomanip>
 
 #include "database_fixture.hpp"
+#include "elasticsearch.hpp"
 
 using namespace graphene::chain::test;
 

--- a/tests/common/elasticsearch.cpp
+++ b/tests/common/elasticsearch.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2018 oxarbitrage, and contributors.
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "elasticsearch.hpp"
+
+#include <fc/exception/exception.hpp>
+#include <fc/io/json.hpp>
+#include <fc/time.hpp>
+#include <fc/variant_object.hpp>
+
+static size_t curl_write_function(void *contents, size_t size, size_t nmemb, void *userp)
+{
+   ((std::string*)userp)->append((char*)contents, size * nmemb);
+   return size * nmemb;
+}
+
+namespace graphene { namespace utilities {
+
+bool checkES(ES& es)
+{
+   graphene::utilities::CurlRequest curl_request;
+   curl_request.handler = es.curl;
+   curl_request.url = es.elasticsearch_url + "_nodes";
+   curl_request.auth = es.auth;
+   curl_request.type = "GET";
+
+   if(doCurl(curl_request).empty())
+      return false;
+   return true;
+
+}
+
+std::string getESVersion(ES& es)
+{
+   graphene::utilities::CurlRequest curl_request;
+   curl_request.handler = es.curl;
+   curl_request.url = es.elasticsearch_url;
+   curl_request.auth = es.auth;
+   curl_request.type = "GET";
+
+   fc::variant response = fc::json::from_string(doCurl(curl_request));
+
+   return response["version"]["number"].as_string();
+}
+
+void checkESVersion7OrAbove(ES& es, bool& result) noexcept
+{
+   static const int64_t version_7 = 7;
+   try {
+      const auto es_version = graphene::utilities::getESVersion(es);
+      auto dot_pos = es_version.find('.');
+      result = ( std::stoi(es_version.substr(0,dot_pos)) >= version_7 );
+   }
+   catch( ... )
+   {
+      wlog( "Unable to get ES version, assuming it is 7 or above" );
+      result = true;
+   }
+}
+
+std::string simpleQuery(ES& es)
+{
+   graphene::utilities::CurlRequest curl_request;
+   curl_request.handler = es.curl;
+   curl_request.url = es.elasticsearch_url + es.endpoint;
+   curl_request.auth = es.auth;
+   curl_request.type = "POST";
+   curl_request.query = es.query;
+
+   return doCurl(curl_request);
+}
+
+bool deleteAll(ES& es)
+{
+   graphene::utilities::CurlRequest curl_request;
+   curl_request.handler = es.curl;
+   curl_request.url = es.elasticsearch_url + es.index_prefix + "*";
+   curl_request.auth = es.auth;
+   curl_request.type = "DELETE";
+
+   auto curl_response = doCurl(curl_request);
+   if(curl_response.empty())
+      return false;
+   else
+      return true;
+}
+
+std::string getEndPoint(ES& es)
+{
+   graphene::utilities::CurlRequest curl_request;
+   curl_request.handler = es.curl;
+   curl_request.url = es.elasticsearch_url + es.endpoint;
+   curl_request.auth = es.auth;
+   curl_request.type = "GET";
+
+   return doCurl(curl_request);
+}
+
+std::string doCurl(CurlRequest& curl)
+{
+   std::string CurlReadBuffer;
+   struct curl_slist *headers = NULL;
+   headers = curl_slist_append(headers, "Content-Type: application/json");
+
+   // Note: the variable curl.handler has a long lifetime, it only gets initialized once, then be used many times,
+   //       thus we need to clear old data
+   curl_easy_setopt(curl.handler, CURLOPT_HTTPHEADER, headers);
+   curl_easy_setopt(curl.handler, CURLOPT_URL, curl.url.c_str());
+   curl_easy_setopt(curl.handler, CURLOPT_CUSTOMREQUEST, curl.type.c_str()); // this is OK
+   if(curl.type == "POST")
+   {
+      curl_easy_setopt(curl.handler, CURLOPT_HTTPGET, false);
+      curl_easy_setopt(curl.handler, CURLOPT_POST, true);
+      curl_easy_setopt(curl.handler, CURLOPT_POSTFIELDS, curl.query.c_str());
+   }
+   else // GET or DELETE (only these are used in this file)
+   {
+      curl_easy_setopt(curl.handler, CURLOPT_POSTFIELDS, NULL);
+      curl_easy_setopt(curl.handler, CURLOPT_POST, false);
+      curl_easy_setopt(curl.handler, CURLOPT_HTTPGET, true);
+   }
+   curl_easy_setopt(curl.handler, CURLOPT_WRITEFUNCTION, curl_write_function);
+   curl_easy_setopt(curl.handler, CURLOPT_WRITEDATA, (void *)&CurlReadBuffer);
+   curl_easy_setopt(curl.handler, CURLOPT_USERAGENT, "libcrp/0.1");
+   if(!curl.auth.empty())
+      curl_easy_setopt(curl.handler, CURLOPT_USERPWD, curl.auth.c_str());
+   curl_easy_perform(curl.handler);
+
+   return CurlReadBuffer;
+}
+
+} } // graphene::utilities

--- a/tests/common/elasticsearch.hpp
+++ b/tests/common/elasticsearch.hpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2018 oxarbitrage, and contributors.
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <curl/curl.h>
+
+namespace graphene { namespace utilities {
+
+   class ES {
+      public:
+         CURL *curl;
+         std::vector <std::string> bulk_lines;
+         std::string elasticsearch_url;
+         std::string index_prefix;
+         std::string auth;
+         std::string endpoint;
+         std::string query;
+   };
+
+   class CurlRequest {
+      public:
+         CURL *handler;
+         std::string url;
+         std::string type;
+         std::string auth;
+         std::string query;
+   };
+
+   bool checkES(ES& es);
+   std::string getESVersion(ES& es);
+   void checkESVersion7OrAbove(ES& es, bool& result) noexcept;
+   std::string simpleQuery(ES& es);
+   bool deleteAll(ES& es);
+   std::string getEndPoint(ES& es);
+
+   std::string doCurl(CurlRequest& curl);
+
+} } // graphene::utilities

--- a/tests/elasticsearch/main.cpp
+++ b/tests/elasticsearch/main.cpp
@@ -31,9 +31,8 @@
 #include <graphene/elasticsearch/elasticsearch_plugin.hpp>
 
 #include "../common/init_unit_test_suite.hpp"
-
 #include "../common/database_fixture.hpp"
-
+#include "../common/elasticsearch.hpp"
 #include "../common/utils.hpp"
 
 #define ES_WAIT_TIME (fc::milliseconds(10000))


### PR DESCRIPTION
Refactored code mainly in the sense of object-oriented programming.

---
BTW here is an interesting error during development. -_-! 
```
.../elasticsearch.hpp:47:7: error: expected identifier before ‘(’ token
   47 |       DELETE  = 4,
      |       ^~~~~~
```
> In Win32, `DELETE` is a macro used for dealing with ACLs (access control lists). ([link](https://stackoverflow.com/questions/13488104/enum-not-working-with-c-using-mingw-compiler-on-windows7))

