### PR TITLE
Extend custom_operations_api::get_storage_info API

### DIFF
--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -445,6 +445,10 @@ void application_impl::set_api_limit() {
       _app_options.api_limit_get_credit_offers =
             _options->at("api-limit-get-credit-offers").as<uint32_t>();
    }
+   if(_options->count("api-limit-get-storage-info") > 0) {
+      _app_options.api_limit_get_storage_info =
+            _options->at("api-limit-get-storage-info").as<uint32_t>();
+   }
 }
 
 graphene::chain::genesis_state_type application_impl::initialize_genesis_state() const
@@ -1287,6 +1291,9 @@ void application::set_program_options(boost::program_options::options_descriptio
          ("api-limit-get-credit-offers",
           bpo::value<uint32_t>()->default_value(default_opts.api_limit_get_credit_offers),
           "Set maximum limit value for database APIs which query for credit offers or credit deals")
+         ("api-limit-get-storage-info",
+          bpo::value<uint32_t>()->default_value(default_opts.api_limit_get_storage_info),
+          "Set maximum limit value for APIs which query for account storage info")
          ;
    command_line_options.add(configuration_file_options);
    command_line_options.add_options()

--- a/libraries/app/include/graphene/app/api.hpp
+++ b/libraries/app/include/graphene/app/api.hpp
@@ -621,26 +621,29 @@ namespace graphene { namespace app {
        * @brief Get stored objects
        *
        * @param account_name_or_id The account name or ID to get info from. Optional.
-       * @param catalog Category classification. Each account can store multiple catalogs. Optional.
-       * @param key Key classification. Each catalog can contain multiple keys. Optional.
+       * @param catalog The catalog to get info from. Each account can store data in multiple catalogs. Optional.
+       * @param key The key to get info from. Each catalog can contain multiple keys. Optional.
        * @param limit The limitation of items each query can fetch, not greater than the configured value of
        *              @a api_limit_get_storage_info
        * @param start_id Start ID of stored object, fetch objects whose IDs are greater than or equal to this ID
-       * @return The stored objects found, ordered by their IDs
+       * @return The stored objects found, sorted by their ID
        *
        * @note
-       * 1. By passing @a null to various optional arguments, this API can be used to query stored objects by
+       * 1. By passing @a null to various optional parameters, or omitting where applicable, this API can be used to
+       *    query stored objects by
        *    a) account, catalog and key, or
        *    b) account and catalog, or
        *    c) account, or
        *    d) catalog and key, or
        *    e) catalog, or
-       *    f) no condition.
+       *    f) unconditionally.
+       *    Queries with keys without a catalog are not allowed.
        * 2. If @p account_name_or_id is specified but cannot be tied to an account, an error will be returned.
        * 3. @p limit can be omitted or be @a null, if so the default value of
        *       @ref application_options::api_limit_get_tickets will be used.
-       * 4. @p start_id can be omitted or be null, if so the api will return the "first page" of objects.
-       * 5. Can only omit one or more arguments in the end of the list, but not one or more in the middle.
+       * 4. @p start_id can be omitted or be @a null, if so the API will return the "first page" of objects.
+       * 5. One or more parameters can be omitted from the end of the parameter list, and the parameters in the
+       *    middle cannot be omitted (but can be @a null).
        */
       vector<account_storage_object> get_storage_info(
             const optional<std::string>& account_name_or_id = optional<std::string>(),

--- a/libraries/app/include/graphene/app/api.hpp
+++ b/libraries/app/include/graphene/app/api.hpp
@@ -618,16 +618,36 @@ namespace graphene { namespace app {
       explicit custom_operations_api(application& app);
 
       /**
-       * @brief Get all stored objects of an account in a particular catalog
+       * @brief Get stored objects
        *
-       * @param account_name_or_id The account name or ID to get info from
-       * @param catalog Category classification. Each account can store multiple catalogs.
+       * @param account_name_or_id The account name or ID to get info from. Optional.
+       * @param catalog Category classification. Each account can store multiple catalogs. Optional.
+       * @param key Key classification. Each catalog can contain multiple keys. Optional.
+       * @param limit The limitation of items each query can fetch, not greater than the configured value of
+       *              @a api_limit_get_storage_info
+       * @param start_id Start ID of stored object, fetch objects whose IDs are greater than or equal to this ID
+       * @return The stored objects found, ordered by their IDs
        *
-       * @return The vector of objects of the account or empty
+       * @note
+       * 1. By passing @a null to various optional arguments, this API can be used to query stored objects by
+       *    a) account, catalog and key, or
+       *    b) account and catalog, or
+       *    c) account, or
+       *    d) catalog and key, or
+       *    e) catalog, or
+       *    f) no condition.
+       * 2. If @p account_name_or_id is specified but cannot be tied to an account, an error will be returned.
+       * 3. @p limit can be omitted or be @a null, if so the default value of
+       *       @ref application_options::api_limit_get_tickets will be used.
+       * 4. @p start_id can be omitted or be null, if so the api will return the "first page" of objects.
+       * 5. Can only omit one or more arguments in the end of the list, but not one or more in the middle.
        */
       vector<account_storage_object> get_storage_info(
-            const std::string& account_name_or_id,
-            const std::string& catalog )const;
+            const optional<std::string>& account_name_or_id = optional<std::string>(),
+            const optional<std::string>& catalog = optional<std::string>(),
+            const optional<std::string>& key = optional<std::string>(),
+            const optional<uint32_t>& limit = application_options::get_default().api_limit_get_storage_info,
+            const optional<account_storage_id_type>& start_id = optional<account_storage_id_type>() )const;
 
    private:
       application& _app;

--- a/libraries/app/include/graphene/app/application.hpp
+++ b/libraries/app/include/graphene/app/application.hpp
@@ -79,6 +79,7 @@ namespace graphene { namespace app {
          uint32_t api_limit_get_liquidity_pools = 101;
          uint32_t api_limit_get_samet_funds = 101;
          uint32_t api_limit_get_credit_offers = 101;
+         uint32_t api_limit_get_storage_info = 101;
 
          static constexpr application_options get_default()
          {
@@ -210,6 +211,7 @@ FC_REFLECT( graphene::app::application_options,
             ( api_limit_get_liquidity_pools )
             ( api_limit_get_samet_funds )
             ( api_limit_get_credit_offers )
+            ( api_limit_get_storage_info )
           )
 
 GRAPHENE_DECLARE_EXTERNAL_SERIALIZATION( graphene::app::application_options )

--- a/libraries/plugins/custom_operations/include/graphene/custom_operations/custom_objects.hpp
+++ b/libraries/plugins/custom_operations/include/graphene/custom_operations/custom_objects.hpp
@@ -50,6 +50,10 @@ struct account_storage_object : public abstract_object<account_storage_object>
 };
 
 struct by_account_catalog_key;
+struct by_account_catalog;
+struct by_account;
+struct by_catalog_key;
+struct by_catalog;
 
 using account_storage_multi_idx_type = multi_index_container<
       account_storage_object,
@@ -60,6 +64,32 @@ using account_storage_multi_idx_type = multi_index_container<
                         member< account_storage_object, account_id_type, &account_storage_object::account >,
                         member< account_storage_object, string, &account_storage_object::catalog >,
                         member< account_storage_object, string, &account_storage_object::key >
+                  >
+            >,
+            ordered_unique< tag<by_account_catalog>,
+                  composite_key< account_storage_object,
+                        member< account_storage_object, account_id_type, &account_storage_object::account >,
+                        member< account_storage_object, string, &account_storage_object::catalog >,
+                        member< object, object_id_type, &object::id >
+                  >
+            >,
+            ordered_unique< tag<by_account>,
+                  composite_key< account_storage_object,
+                        member< account_storage_object, account_id_type, &account_storage_object::account >,
+                        member< object, object_id_type, &object::id >
+                  >
+            >,
+            ordered_unique< tag<by_catalog_key>,
+                  composite_key< account_storage_object,
+                        member< account_storage_object, string, &account_storage_object::catalog >,
+                        member< account_storage_object, string, &account_storage_object::key >,
+                        member< object, object_id_type, &object::id >
+                  >
+            >,
+            ordered_unique< tag<by_catalog>,
+                  composite_key< account_storage_object,
+                        member< account_storage_object, string, &account_storage_object::catalog >,
+                        member< object, object_id_type, &object::id >
                   >
             >
       >

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -440,6 +440,8 @@ std::shared_ptr<boost::program_options::variables_map> database_fixture_base::in
       fixture.current_test_name == "custom_operations_account_storage_list_test") {
       fixture.app.register_plugin<graphene::custom_operations::custom_operations_plugin>(true);
       fc::set_option( options, "custom-operations-start-block", uint32_t(1) );
+      if( fixture.current_test_name == "custom_operations_account_storage_map_test" )
+         fc::set_option( options, "api-limit-get-storage-info", uint32_t(120) );
    }
 
    fc::set_option( options, "bucket-size", string("[15]") );

--- a/tests/tests/custom_operations.cpp
+++ b/tests/tests/custom_operations.cpp
@@ -123,7 +123,7 @@ try {
 
    // check nathan stored data with the api
    storage_results_nathan = custom_operations_api.get_storage_info("nathan", "settings");
-   BOOST_CHECK_EQUAL(storage_results_nathan.size(), 2 );
+   BOOST_REQUIRE_EQUAL(storage_results_nathan.size(), 2U );
    BOOST_CHECK_EQUAL(storage_results_nathan[0].account.instance.value, 16 );
    BOOST_CHECK_EQUAL(storage_results_nathan[0].key, "image_url");
    BOOST_CHECK_EQUAL(storage_results_nathan[0].value->as_string(), "http://some.image.url/img.jpg");
@@ -140,7 +140,7 @@ try {
 
    // check old and new stuff
    storage_results_nathan = custom_operations_api.get_storage_info("nathan", "settings");
-   BOOST_CHECK_EQUAL(storage_results_nathan.size(), 3 );
+   BOOST_REQUIRE_EQUAL(storage_results_nathan.size(), 3U );
    BOOST_CHECK_EQUAL(storage_results_nathan[0].account.instance.value, 16 );
    BOOST_CHECK_EQUAL(storage_results_nathan[0].key, "image_url");
    BOOST_CHECK_EQUAL(storage_results_nathan[0].value->as_string(), "http://new.image.url/newimg.jpg");
@@ -158,7 +158,7 @@ try {
 
    // theme is removed from the storage
    storage_results_nathan = custom_operations_api.get_storage_info("nathan", "settings");
-   BOOST_CHECK_EQUAL(storage_results_nathan.size(), 2 );
+   BOOST_REQUIRE_EQUAL(storage_results_nathan.size(), 2U );
    BOOST_CHECK_EQUAL(storage_results_nathan[0].account.instance.value, 16 );
    BOOST_CHECK_EQUAL(storage_results_nathan[0].key, "image_url");
    BOOST_CHECK_EQUAL(storage_results_nathan[0].value->as_string(), "http://new.image.url/newimg.jpg");
@@ -174,7 +174,7 @@ try {
 
    // nothing changes
    storage_results_nathan = custom_operations_api.get_storage_info("nathan", "settings");
-   BOOST_CHECK_EQUAL(storage_results_nathan.size(), 2 );
+   BOOST_REQUIRE_EQUAL(storage_results_nathan.size(), 2U );
    BOOST_CHECK_EQUAL(storage_results_nathan[0].account.instance.value, 16 );
    BOOST_CHECK_EQUAL(storage_results_nathan[0].key, "image_url");
    BOOST_CHECK_EQUAL(storage_results_nathan[0].value->as_string(), "http://new.image.url/newimg.jpg");
@@ -191,7 +191,7 @@ try {
    generate_block();
 
    vector<account_storage_object> storage_results_alice = custom_operations_api.get_storage_info("alice", "random");
-   BOOST_CHECK_EQUAL(storage_results_alice.size(), 1 );
+   BOOST_REQUIRE_EQUAL(storage_results_alice.size(), 1U );
    BOOST_CHECK_EQUAL(storage_results_alice[0].account.instance.value, 17 );
    BOOST_CHECK_EQUAL(storage_results_alice[0].key, "key1");
    BOOST_CHECK_EQUAL(storage_results_alice[0].value->as_string(), "value2");
@@ -204,7 +204,7 @@ try {
    generate_block();
 
    storage_results_alice = custom_operations_api.get_storage_info("alice", "account_object");
-   BOOST_CHECK_EQUAL(storage_results_alice.size(), 1);
+   BOOST_REQUIRE_EQUAL(storage_results_alice.size(), 1U);
    BOOST_CHECK_EQUAL(storage_results_alice[0].account.instance.value, 17);
    BOOST_CHECK_EQUAL(storage_results_alice[0].key, "nathan");
    BOOST_CHECK_EQUAL(storage_results_alice[0].value->as<account_object>(20).name, "nathan");
@@ -218,7 +218,7 @@ try {
    generate_block();
 
    storage_results_alice = custom_operations_api.get_storage_info("alice", "account_object");
-   BOOST_CHECK_EQUAL(storage_results_alice.size(), 3);
+   BOOST_REQUIRE_EQUAL(storage_results_alice.size(), 3U);
    BOOST_CHECK_EQUAL(storage_results_alice[0].account.instance.value, 17);
    BOOST_CHECK_EQUAL(storage_results_alice[0].key, "nathan");
    BOOST_CHECK_EQUAL(storage_results_alice[0].value->as<account_object>(20).name, "nathan");
@@ -227,6 +227,154 @@ try {
    BOOST_CHECK_EQUAL(storage_results_alice[1].value->as<account_object>(20).name, "patty");
    BOOST_CHECK_EQUAL(storage_results_alice[2].key, "robert");
    BOOST_CHECK_EQUAL(storage_results_alice[2].value->as<account_object>(20).name, "robert");
+
+   // alice adds key-value data via custom operation to a settings catalog
+   catalog = "settings";
+   pairs.clear();
+   pairs["image_url"] = fc::json::to_string("http://some.other.image.url/img.jpg");
+   map_operation(pairs, false, catalog, alice_id, alice_private_key, db);
+   generate_block();
+
+   // test API limit config
+   BOOST_CHECK_THROW( custom_operations_api.get_storage_info("alice", "account_object", {}, 121), fc::exception );
+
+   // This does not throw
+   storage_results_alice = custom_operations_api.get_storage_info("alice", "account_object", {}, 120);
+   BOOST_REQUIRE_EQUAL(storage_results_alice.size(), 3U);
+   BOOST_CHECK_EQUAL(storage_results_alice[0].account.instance.value, 17);
+   BOOST_CHECK_EQUAL(storage_results_alice[0].key, "nathan");
+   BOOST_CHECK_EQUAL(storage_results_alice[0].value->as<account_object>(20).name, "nathan");
+   BOOST_CHECK_EQUAL(storage_results_alice[1].account.instance.value, 17);
+   BOOST_CHECK_EQUAL(storage_results_alice[1].key, "patty");
+   BOOST_CHECK_EQUAL(storage_results_alice[1].value->as<account_object>(20).name, "patty");
+   BOOST_CHECK_EQUAL(storage_results_alice[2].key, "robert");
+   BOOST_CHECK_EQUAL(storage_results_alice[2].value->as<account_object>(20).name, "robert");
+
+   // query by a wrong account
+   BOOST_CHECK_THROW( custom_operations_api.get_storage_info("alice1", "account_object" ), fc::exception );
+
+   // query by account and key
+   BOOST_CHECK_THROW( custom_operations_api.get_storage_info("alice", {}, "patty" ), fc::exception );
+
+   // query by key only
+   BOOST_CHECK_THROW( custom_operations_api.get_storage_info({}, {}, "patty" ), fc::exception );
+
+   // query by account, catalog and key
+   storage_results_alice = custom_operations_api.get_storage_info("alice", "account_object", "alice1");
+   BOOST_CHECK_EQUAL(storage_results_alice.size(), 0 );
+
+   storage_results_alice = custom_operations_api.get_storage_info("alice", "account_object1", "patty");
+   BOOST_CHECK_EQUAL(storage_results_alice.size(), 0 );
+
+   storage_results_alice = custom_operations_api.get_storage_info("alice", "account_object", "patty");
+   BOOST_REQUIRE_EQUAL(storage_results_alice.size(), 1U );
+   BOOST_CHECK_EQUAL(storage_results_alice[0].key, "patty");
+   BOOST_CHECK_EQUAL(storage_results_alice[0].value->as<account_object>(20).name, "patty");
+
+   // query by account only
+   storage_results_alice = custom_operations_api.get_storage_info("alice");
+   BOOST_REQUIRE_EQUAL(storage_results_alice.size(), 5U );
+   BOOST_CHECK_EQUAL(storage_results_alice[0].catalog, "random");
+   BOOST_CHECK_EQUAL(storage_results_alice[0].key, "key1");
+   BOOST_CHECK_EQUAL(storage_results_alice[0].value->as_string(), "value2");
+   BOOST_CHECK_EQUAL(storage_results_alice[1].catalog, "account_object");
+   BOOST_CHECK_EQUAL(storage_results_alice[1].key, "nathan");
+   BOOST_CHECK_EQUAL(storage_results_alice[1].value->as<account_object>(20).name, "nathan");
+   BOOST_CHECK_EQUAL(storage_results_alice[2].catalog, "account_object");
+   BOOST_CHECK_EQUAL(storage_results_alice[2].key, "patty");
+   BOOST_CHECK_EQUAL(storage_results_alice[2].value->as<account_object>(20).name, "patty");
+   BOOST_CHECK_EQUAL(storage_results_alice[3].catalog, "account_object");
+   BOOST_CHECK_EQUAL(storage_results_alice[3].key, "robert");
+   BOOST_CHECK_EQUAL(storage_results_alice[3].value->as<account_object>(20).name, "robert");
+   BOOST_CHECK_EQUAL(storage_results_alice[4].catalog, "settings");
+   BOOST_CHECK_EQUAL(storage_results_alice[4].key, "image_url");
+   BOOST_CHECK_EQUAL(storage_results_alice[4].value->as_string(), "http://some.other.image.url/img.jpg");
+
+   // query by catalog only
+   auto storage_results = custom_operations_api.get_storage_info({}, "settings1");
+   BOOST_REQUIRE_EQUAL(storage_results.size(), 0 );
+
+   storage_results = custom_operations_api.get_storage_info({}, "settings");
+   BOOST_REQUIRE_EQUAL(storage_results.size(), 3U );
+   BOOST_CHECK_EQUAL(storage_results[0].account.instance.value, 16 );
+   BOOST_CHECK_EQUAL(storage_results[0].key, "image_url");
+   BOOST_CHECK_EQUAL(storage_results[0].value->as_string(), "http://new.image.url/newimg.jpg");
+   BOOST_CHECK_EQUAL(storage_results[1].account.instance.value, 16 );
+   BOOST_CHECK_EQUAL(storage_results[1].key, "language");
+   BOOST_CHECK_EQUAL(storage_results[1].value->as_string(), "en");
+   BOOST_CHECK_EQUAL(storage_results[2].account.instance.value, 17 );
+   BOOST_CHECK_EQUAL(storage_results[2].key, "image_url");
+   BOOST_CHECK_EQUAL(storage_results[2].value->as_string(), "http://some.other.image.url/img.jpg");
+
+   // Pagination
+   storage_results = custom_operations_api.get_storage_info({}, "settings", {}, 2);
+   BOOST_REQUIRE_EQUAL(storage_results.size(), 2U );
+   BOOST_CHECK_EQUAL(storage_results[0].account.instance.value, 16 );
+   BOOST_CHECK_EQUAL(storage_results[0].key, "image_url");
+   BOOST_CHECK_EQUAL(storage_results[0].value->as_string(), "http://new.image.url/newimg.jpg");
+   BOOST_CHECK_EQUAL(storage_results[1].account.instance.value, 16 );
+   BOOST_CHECK_EQUAL(storage_results[1].key, "language");
+   BOOST_CHECK_EQUAL(storage_results[1].value->as_string(), "en");
+
+   account_storage_id_type storage_id = storage_results[1].id;
+
+   storage_results = custom_operations_api.get_storage_info({}, "settings", {}, 2, storage_id);
+   BOOST_REQUIRE_EQUAL(storage_results.size(), 2U );
+   BOOST_CHECK_EQUAL(storage_results[0].account.instance.value, 16 );
+   BOOST_CHECK_EQUAL(storage_results[0].key, "language");
+   BOOST_CHECK_EQUAL(storage_results[0].value->as_string(), "en");
+   BOOST_CHECK_EQUAL(storage_results[1].account.instance.value, 17 );
+   BOOST_CHECK_EQUAL(storage_results[1].key, "image_url");
+   BOOST_CHECK_EQUAL(storage_results[1].value->as_string(), "http://some.other.image.url/img.jpg");
+
+   // query by catalog and key
+   storage_results = custom_operations_api.get_storage_info({}, "settings", "test");
+   BOOST_REQUIRE_EQUAL(storage_results.size(), 0 );
+
+   storage_results = custom_operations_api.get_storage_info({}, "settings1", "image_url");
+   BOOST_REQUIRE_EQUAL(storage_results.size(), 0 );
+
+   storage_results = custom_operations_api.get_storage_info({}, "settings", "image_url");
+   BOOST_REQUIRE_EQUAL(storage_results.size(), 2U );
+   BOOST_CHECK_EQUAL(storage_results[0].account.instance.value, 16 );
+   BOOST_CHECK_EQUAL(storage_results[0].key, "image_url");
+   BOOST_CHECK_EQUAL(storage_results[0].value->as_string(), "http://new.image.url/newimg.jpg");
+   BOOST_CHECK_EQUAL(storage_results[1].account.instance.value, 17 );
+   BOOST_CHECK_EQUAL(storage_results[1].key, "image_url");
+   BOOST_CHECK_EQUAL(storage_results[1].value->as_string(), "http://some.other.image.url/img.jpg");
+
+   // query all
+   storage_results = custom_operations_api.get_storage_info();
+   BOOST_REQUIRE_EQUAL(storage_results.size(), 7U );
+   BOOST_CHECK_EQUAL(storage_results[0].account.instance.value, 16 );
+   BOOST_CHECK_EQUAL(storage_results[0].catalog, "settings");
+   BOOST_CHECK_EQUAL(storage_results[0].key, "image_url");
+   BOOST_CHECK_EQUAL(storage_results[0].value->as_string(), "http://new.image.url/newimg.jpg");
+   BOOST_CHECK_EQUAL(storage_results[1].account.instance.value, 16 );
+   BOOST_CHECK_EQUAL(storage_results[1].catalog, "settings");
+   BOOST_CHECK_EQUAL(storage_results[1].key, "language");
+   BOOST_CHECK_EQUAL(storage_results[1].value->as_string(), "en");
+   BOOST_CHECK_EQUAL(storage_results[2].account.instance.value, 17 );
+   BOOST_CHECK_EQUAL(storage_results[2].catalog, "random");
+   BOOST_CHECK_EQUAL(storage_results[2].key, "key1");
+   BOOST_CHECK_EQUAL(storage_results[2].value->as_string(), "value2");
+   BOOST_CHECK_EQUAL(storage_results[3].account.instance.value, 17 );
+   BOOST_CHECK_EQUAL(storage_results[3].catalog, "account_object");
+   BOOST_CHECK_EQUAL(storage_results[3].key, "nathan");
+   BOOST_CHECK_EQUAL(storage_results[3].value->as<account_object>(20).name, "nathan");
+   BOOST_CHECK_EQUAL(storage_results[4].account.instance.value, 17 );
+   BOOST_CHECK_EQUAL(storage_results[4].catalog, "account_object");
+   BOOST_CHECK_EQUAL(storage_results[4].key, "patty");
+   BOOST_CHECK_EQUAL(storage_results[4].value->as<account_object>(20).name, "patty");
+   BOOST_CHECK_EQUAL(storage_results[5].account.instance.value, 17 );
+   BOOST_CHECK_EQUAL(storage_results[5].catalog, "account_object");
+   BOOST_CHECK_EQUAL(storage_results[5].key, "robert");
+   BOOST_CHECK_EQUAL(storage_results[5].value->as<account_object>(20).name, "robert");
+   BOOST_CHECK_EQUAL(storage_results[6].account.instance.value, 17 );
+   BOOST_CHECK_EQUAL(storage_results[6].catalog, "settings");
+   BOOST_CHECK_EQUAL(storage_results[6].key, "image_url");
+   BOOST_CHECK_EQUAL(storage_results[6].value->as_string(), "http://some.other.image.url/img.jpg");
+
 }
 catch (fc::exception &e) {
    edump((e.to_detail_string()));
@@ -259,6 +407,9 @@ try {
    auto storage_results_nathan = custom_operations_api.get_storage_info("nathan", catalog);
    BOOST_CHECK_EQUAL(storage_results_nathan.size(), 0 );
 
+   // This throws due to API limit
+   BOOST_CHECK_THROW( custom_operations_api.get_storage_info("nathan", catalog, {}, 120), fc::exception );
+
    // keys are indexed so they cant be too big(greater than CUSTOM_OPERATIONS_MAX_KEY_SIZE(200) is not allowed)
    catalog = "whatever";
    std::string value(201, 'a');
@@ -280,7 +431,7 @@ try {
 
    // get the account list for nathan, check alice and robert are there
    storage_results_nathan = custom_operations_api.get_storage_info("nathan", "contact_list");
-   BOOST_CHECK_EQUAL(storage_results_nathan.size(), 2 );
+   BOOST_REQUIRE_EQUAL(storage_results_nathan.size(), 2U );
    BOOST_CHECK_EQUAL(storage_results_nathan[0].account.instance.value, 16 );
    BOOST_CHECK_EQUAL(storage_results_nathan[0].key, alice.name);
    BOOST_CHECK_EQUAL(storage_results_nathan[1].account.instance.value, 16 );
@@ -294,7 +445,7 @@ try {
 
    // nothing changes
    storage_results_nathan = custom_operations_api.get_storage_info("nathan", "contact_list");
-   BOOST_CHECK_EQUAL(storage_results_nathan.size(), 2 );
+   BOOST_REQUIRE_EQUAL(storage_results_nathan.size(), 2U );
    BOOST_CHECK_EQUAL(storage_results_nathan[0].account.instance.value, 16 );
    BOOST_CHECK_EQUAL(storage_results_nathan[0].key, alice.name);
    BOOST_CHECK_EQUAL(storage_results_nathan[1].account.instance.value, 16 );
@@ -308,7 +459,7 @@ try {
 
    // alice gone
    storage_results_nathan = custom_operations_api.get_storage_info("nathan", "contact_list");
-   BOOST_CHECK_EQUAL(storage_results_nathan.size(), 1 );
+   BOOST_CHECK_EQUAL(storage_results_nathan.size(), 1U );
    BOOST_CHECK_EQUAL(storage_results_nathan[0].account.instance.value, 16 );
    BOOST_CHECK_EQUAL(storage_results_nathan[0].key, robert.name);
 
@@ -320,7 +471,7 @@ try {
    generate_block();
 
    auto storage_results_alice = custom_operations_api.get_storage_info("alice", "contact_list");
-   BOOST_CHECK_EQUAL(storage_results_alice.size(), 1 );
+   BOOST_CHECK_EQUAL(storage_results_alice.size(), 1U );
    BOOST_CHECK_EQUAL(storage_results_alice[0].account.instance.value, 17 );
    BOOST_CHECK_EQUAL(storage_results_alice[0].key, robert.name);
 }


### PR DESCRIPTION
For issue #2139.

* Add `api-limit-get-storage-info` node startup option
* Extend `custom_operations_api::get_storage_info` API to accept 5 parameters:
  ```
  vector<account_storage_object> get_storage_info( account, catalog, key, limit, start_id );
  ```
  * All parameters are optional.
  * The account can be a name or an ID.
  * The default limit now is `101` (was unlimited).
  * The result is sorted by ID (was by key).
  ```
  *    By passing @a null to various optional parameters, or omitting where applicable,
  *    this API can be used to query stored objects by
  *    a) account, catalog and key, or
  *    b) account and catalog, or
  *    c) account, or
  *    d) catalog and key, or
  *    e) catalog, or
  *    f) unconditionally.
  ```
  Note: queries with keys without a catalog are not allowed.