### PR TITLE
Extend get_order_book API to return more info

### DIFF
--- a/libraries/app/api_objects.cpp
+++ b/libraries/app/api_objects.cpp
@@ -27,6 +27,30 @@
 
 namespace graphene { namespace app {
 
+order::order( const string& _price,
+              const string& _quote,
+              const string& _base,
+              const limit_order_id_type& _id,
+              const account_id_type& _oid,
+              const string& _oname,
+              const time_point_sec& _exp )
+: price( _price ),
+  quote( _quote ),
+  base( _base ),
+  id( _id ),
+  owner_id( _oid ),
+  owner_name( _oname ),
+  expiration( _exp )
+{
+   // Nothing to do
+}
+
+order_book::order_book( const string& _base, const string& _quote )
+: base( _base ), quote( _quote )
+{
+   // Do nothing else
+}
+
 market_ticker::market_ticker(const market_ticker_object& mto,
                              const fc::time_point_sec& now,
                              const asset_object& asset_base,

--- a/libraries/app/include/graphene/app/api_objects.hpp
+++ b/libraries/app/include/graphene/app/api_objects.hpp
@@ -84,6 +84,19 @@ namespace graphene { namespace app {
       string                     price;
       string                     quote;
       string                     base;
+      limit_order_id_type        id;
+      account_id_type            owner_id;
+      string                     owner_name;
+      time_point_sec             expiration;
+
+      order() = default;
+      order( const string& _price,
+             const string& _quote,
+             const string& _base,
+             const limit_order_id_type& _id,
+             const account_id_type& _oid,
+             const string& _oname,
+             const time_point_sec& _exp );
    };
 
    struct order_book
@@ -92,6 +105,8 @@ namespace graphene { namespace app {
      string                      quote;
      vector< order >             bids;
      vector< order >             asks;
+     order_book() = default;
+     order_book( const string& _base, const string& _quote );
    };
 
    struct market_ticker
@@ -191,7 +206,7 @@ FC_REFLECT( graphene::app::full_account,
             (more_data_available)
           )
 
-FC_REFLECT( graphene::app::order, (price)(quote)(base) )
+FC_REFLECT( graphene::app::order, (price)(quote)(base)(id)(owner_id)(owner_name)(expiration) )
 FC_REFLECT( graphene::app::order_book, (base)(quote)(bids)(asks) )
 FC_REFLECT( graphene::app::market_ticker,
             (time)(base)(quote)(latest)(lowest_ask)(lowest_ask_base_size)(lowest_ask_quote_size)


### PR DESCRIPTION
PR for #2637 and https://github.com/blocksights/blocksights-open-explorer/issues/9.

This PR adds 4 data fields into the `order` struct:
* `id` - ID of the limit order
* `owner_id` - owner account ID of the limit order
* `owner_name` - owner account name of the limit order
* `expiration` - expiration time of the limit order

The full `order` struct becomes:
```
   struct order
   {
      string                     price;
      string                     quote;
      string                     base;
      limit_order_id_type        id;
      account_id_type            owner_id;
      string                     owner_name;
      time_point_sec             expiration;
   };
```

The `order_book` struct itself is unchanged.
```
   struct order_book
   {
     string                      base;
     string                      quote;
     vector< order >             bids;
     vector< order >             asks;
   };
```
