### PR TITLE
Extend get_block_header and get_block_header_batch APIs to return witness signatures

### DIFF
--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -240,13 +240,13 @@ optional<signed_block_header> database_api_impl::get_block_header(uint32_t block
    return {};
 }
 map<uint32_t, optional<signed_block_header>> database_api::get_block_header_batch(
-      const vector<uint32_t> block_nums) const
+      const vector<uint32_t>& block_nums) const
 {
    return my->get_block_header_batch( block_nums );
 }
 
 map<uint32_t, optional<signed_block_header>> database_api_impl::get_block_header_batch(
-      const vector<uint32_t> block_nums) const
+      const vector<uint32_t>& block_nums) const
 {
    map<uint32_t, optional<signed_block_header>> results;
    for (const uint32_t block_num : block_nums)

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -227,27 +227,28 @@ void database_api_impl::cancel_all_subscriptions( bool reset_callback, bool rese
 //                                                                  //
 //////////////////////////////////////////////////////////////////////
 
-optional<block_header> database_api::get_block_header(uint32_t block_num)const
+optional<signed_block_header> database_api::get_block_header(uint32_t block_num)const
 {
    return my->get_block_header( block_num );
 }
 
-optional<block_header> database_api_impl::get_block_header(uint32_t block_num) const
+optional<signed_block_header> database_api_impl::get_block_header(uint32_t block_num) const
 {
    auto result = _db.fetch_block_by_number(block_num);
    if(result)
       return *result;
    return {};
 }
-map<uint32_t, optional<block_header>> database_api::get_block_header_batch(const vector<uint32_t> block_nums)const
+map<uint32_t, optional<signed_block_header>> database_api::get_block_header_batch(
+      const vector<uint32_t> block_nums) const
 {
    return my->get_block_header_batch( block_nums );
 }
 
-map<uint32_t, optional<block_header>> database_api_impl::get_block_header_batch(
-                                         const vector<uint32_t> block_nums) const
+map<uint32_t, optional<signed_block_header>> database_api_impl::get_block_header_batch(
+      const vector<uint32_t> block_nums) const
 {
-   map<uint32_t, optional<block_header>> results;
+   map<uint32_t, optional<signed_block_header>> results;
    for (const uint32_t block_num : block_nums)
    {
       results[block_num] = get_block_header(block_num);

--- a/libraries/app/database_api_impl.hxx
+++ b/libraries/app/database_api_impl.hxx
@@ -51,7 +51,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
 
       // Blocks and transactions
       optional<signed_block_header> get_block_header(uint32_t block_num)const;
-      map<uint32_t, optional<signed_block_header>> get_block_header_batch(const vector<uint32_t> block_nums)const;
+      map<uint32_t, optional<signed_block_header>> get_block_header_batch(const vector<uint32_t>& block_nums)const;
       optional<signed_block> get_block(uint32_t block_num)const;
       processed_transaction get_transaction( uint32_t block_num, uint32_t trx_in_block )const;
 

--- a/libraries/app/database_api_impl.hxx
+++ b/libraries/app/database_api_impl.hxx
@@ -50,8 +50,8 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       void cancel_all_subscriptions(bool reset_callback, bool reset_market_subscriptions);
 
       // Blocks and transactions
-      optional<block_header> get_block_header(uint32_t block_num)const;
-      map<uint32_t, optional<block_header>> get_block_header_batch(const vector<uint32_t> block_nums)const;
+      optional<signed_block_header> get_block_header(uint32_t block_num)const;
+      map<uint32_t, optional<signed_block_header>> get_block_header_batch(const vector<uint32_t> block_nums)const;
       optional<signed_block> get_block(uint32_t block_num)const;
       processed_transaction get_transaction( uint32_t block_num, uint32_t trx_in_block )const;
 

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -153,18 +153,18 @@ class database_api
       /////////////////////////////
 
       /**
-       * @brief Retrieve a block header
+       * @brief Retrieve a signed block header
        * @param block_num Height of the block whose header should be returned
        * @return header of the referenced block, or null if no matching block was found
        */
-      optional<block_header> get_block_header(uint32_t block_num)const;
+      optional<signed_block_header> get_block_header(uint32_t block_num)const;
 
       /**
-      * @brief Retrieve multiple block header by block numbers
-      * @param block_nums vector containing heights of the block whose header should be returned
+      * @brief Retrieve multiple signed block headers by block numbers
+      * @param block_nums vector containing heights of the blocks whose headers should be returned
       * @return array of headers of the referenced blocks, or null if no matching block was found
       */
-      map<uint32_t, optional<block_header>> get_block_header_batch(const vector<uint32_t> block_nums)const;
+      map<uint32_t, optional<signed_block_header>> get_block_header_batch(const vector<uint32_t> block_nums)const;
 
       /**
        * @brief Retrieve a full, signed block

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -164,7 +164,7 @@ class database_api
       * @param block_nums vector containing heights of the blocks whose headers should be returned
       * @return array of headers of the referenced blocks, or null if no matching block was found
       */
-      map<uint32_t, optional<signed_block_header>> get_block_header_batch(const vector<uint32_t> block_nums)const;
+      map<uint32_t, optional<signed_block_header>> get_block_header_batch(const vector<uint32_t>& block_nums)const;
 
       /**
        * @brief Retrieve a full, signed block


### PR DESCRIPTION
PR for #2588.

Note: the `witness_signature` field is a bit long, so the return size has increased.

Before:
>`{"previous":"00000004659ea6a0ae8928db63338ca9b16e4a70","timestamp":"2015-05-15T14:27:20","witness":"1.6.6","transaction_merkle_root":"3d1a3de0a1de97f7b300846e1f2ec5b0c84179e2","extensions":[]}`

After:
>`{"previous":"00000004659ea6a0ae8928db63338ca9b16e4a70","timestamp":"2015-05-15T14:27:20","witness":"1.6.6","transaction_merkle_root":"3d1a3de0a1de97f7b300846e1f2ec5b0c84179e2","extensions":[],"witness_signature":"204e4172a77f89749e2a6a00eaf069c88dfb0ca2f985ba86c8f0b5a7e39d41b82953defea5805f510b83b40ef7f8ee11ad9f43a8a51ea72520a600bebd44a23534"}`