### PR TITLE
Add `history_api::get_account_history_by_time` API

### DIFF
--- a/libraries/app/include/graphene/app/api.hpp
+++ b/libraries/app/include/graphene/app/api.hpp
@@ -78,13 +78,13 @@ namespace graphene { namespace app {
          };
 
          /**
-          * @brief Get operations relevant to the specificed account
+          * @brief Get the history of operations related to the specified account
           * @param account_name_or_id The account name or ID whose history should be queried
           * @param stop ID of the earliest operation to retrieve
           * @param limit Maximum number of operations to retrieve, must not exceed the configured value of
           *              @a api_limit_get_account_history
           * @param start ID of the most recent operation to retrieve
-          * @return A list of operations performed by account, ordered from most recent to oldest.
+          * @return A list of operations related to the specified account, ordered from most recent to oldest.
           */
          vector<operation_history_object> get_account_history(
             const std::string& account_name_or_id,
@@ -94,11 +94,33 @@ namespace graphene { namespace app {
          )const;
 
          /**
-          * @brief Get operations relevant to the specified account filtering by operation type
+          * @brief Get the history of operations related to the specified account no later than the specified time
+          * @param account_name_or_id The account name or ID whose history should be queried
+          * @param limit Maximum number of operations to retrieve, must not exceed the configured value of
+          *              @a api_limit_get_account_history
+          * @param start the time point to start looping back through history
+          * @return A list of operations related to the specified account, ordered from most recent to oldest.
+          *
+          * @note
+          * 1. If @p account_name_or_id cannot be tied to an account, an empty list will be returned
+          * 2. @p limit can be omitted or be @a null, if so the configured value of
+          *       @a api_limit_get_account_history will be used
+          * 3. @p start can be omitted or be @a null, if so the api will return the "first page" of the history
+          * 4. One or more optional parameters can be omitted from the end of the parameter list, and the optional
+          *    parameters in the middle cannot be omitted (but can be @a null).
+          */
+         vector<operation_history_object> get_account_history_by_time(
+            const std::string& account_name_or_id,
+            const optional<uint32_t>& limit = optional<uint32_t>(),
+            const optional<fc::time_point_sec>& start = optional<fc::time_point_sec>()
+         )const;
+
+         /**
+          * @brief Get the history of operations related to the specified account filtering by operation types
           * @param account_name_or_id The account name or ID whose history should be queried
           * @param operation_types The IDs of the operation we want to get operations in the account
-          * ( 0 = transfer , 1 = limit order create, ...)
-          * @param start the sequence number where to start looping back throw the history
+          *                        ( 0 = transfer , 1 = limit order create, ...)
+          * @param start the sequence number where to start looping back through the history
           * @param limit the max number of entries to return (from start number), must not exceed the configured
           *              value of @a api_limit_get_account_history_by_operations
           * @return history_operation_detail
@@ -111,15 +133,15 @@ namespace graphene { namespace app {
          )const;
 
          /**
-          * @brief Get only asked operations relevant to the specified account
+          * @brief Get the history of operations related to the specified account filtering by operation type
           * @param account_name_or_id The account name or ID whose history should be queried
           * @param operation_type The type of the operation we want to get operations in the account
-          * ( 0 = transfer , 1 = limit order create, ...)
+          *                       ( 0 = transfer , 1 = limit order create, ...)
           * @param stop ID of the earliest operation to retrieve
           * @param limit Maximum number of operations to retrieve, must not exceed the configured value of
           *              @a api_limit_get_account_history_operations
           * @param start ID of the most recent operation to retrieve
-          * @return A list of operations performed by account, ordered from most recent to oldest.
+          * @return A list of operations related to the specified account, ordered from most recent to oldest.
           */
          vector<operation_history_object> get_account_history_operations(
             const std::string& account_name_or_id,
@@ -130,9 +152,9 @@ namespace graphene { namespace app {
          )const;
 
          /**
-          * @brief Get operations relevant to the specified account referenced
-          * by an event numbering specific to the account. The current number of operations
-          * for the account can be found in the account statistics (or use 0 for start).
+          * @brief Get the history of operations related to the specified account referenced
+          *        by an event numbering specific to the account. The current number of operations
+          *        for the account can be found in the account statistics (or use 0 for start).
           * @param account_name_or_id The account name or ID whose history should be queried
           * @param stop Sequence number of earliest operation. 0 is default and will
           *             query 'limit' number of operations.
@@ -140,7 +162,7 @@ namespace graphene { namespace app {
           *              @a api_limit_get_relative_account_history
           * @param start Sequence number of the most recent operation to retrieve.
           *              0 is default, which will start querying from the most recent operation.
-          * @return A list of operations performed by account, ordered from most recent to oldest.
+          * @return A list of operations related to the specified account, ordered from most recent to oldest.
           */
          vector<operation_history_object> get_relative_account_history(
                const std::string& account_name_or_id,
@@ -787,6 +809,7 @@ FC_REFLECT( graphene::app::asset_api::asset_holders, (asset_id)(count) )
 
 FC_API(graphene::app::history_api,
        (get_account_history)
+       (get_account_history_by_time)
        (get_account_history_by_operations)
        (get_account_history_operations)
        (get_relative_account_history)

--- a/libraries/chain/include/graphene/chain/operation_history_object.hpp
+++ b/libraries/chain/include/graphene/chain/operation_history_object.hpp
@@ -106,6 +106,7 @@ namespace graphene { namespace chain {
    };
 
    struct by_block;
+   struct by_time;
 
    using operation_history_mlti_idx_type = multi_index_container<
       operation_history_object,
@@ -117,6 +118,16 @@ namespace graphene { namespace chain {
                member< operation_history_object, uint16_t, &operation_history_object::trx_in_block>,
                member< operation_history_object, uint16_t, &operation_history_object::op_in_trx>,
                member< operation_history_object, uint32_t, &operation_history_object::virtual_op>
+            >
+         >,
+         ordered_unique< tag<by_time>,
+            composite_key< operation_history_object,
+               member< operation_history_object, time_point_sec, &operation_history_object::block_time>,
+               member< object, object_id_type, &object::id >
+            >,
+            composite_key_compare<
+               std::greater< time_point_sec >,
+               std::greater< object_id_type >
             >
          >
       >
@@ -142,6 +153,10 @@ namespace graphene { namespace chain {
             composite_key< account_history_object,
                member< account_history_object, account_id_type, &account_history_object::account>,
                member< account_history_object, operation_history_id_type, &account_history_object::operation_id>
+            >,
+            composite_key_compare<
+               std::less< account_id_type >,
+               std::greater< operation_history_id_type >
             >
          >,
          ordered_non_unique< tag<by_opid>,

--- a/libraries/protocol/include/graphene/protocol/object_id.hpp
+++ b/libraries/protocol/include/graphene/protocol/object_id.hpp
@@ -108,6 +108,11 @@ namespace graphene { namespace db {
 
       static constexpr uint16_t space_type = uint16_t(uint16_t(space_id) << 8) | uint16_t(type_id);
 
+      static constexpr object_id max()
+      {
+         return object_id( 0xffffffffffff );
+      }
+
       object_id() = default;
       object_id( unsigned_int i ):instance(i){}
       explicit object_id( uint64_t i ):instance(i)

--- a/tests/tests/history_api_tests.cpp
+++ b/tests/tests/history_api_tests.cpp
@@ -222,6 +222,7 @@ BOOST_AUTO_TEST_CASE(get_account_history_additional) {
       create_bitasset("OIL", dan.id); // create op 6
 
       generate_block();
+      fc::usleep(fc::milliseconds(100));
 
       // f(A, 0, 4, 9) = { 5, 3, 1, 0 }
       histories = hist_api.get_account_history("1.2.0", operation_history_id_type(), 4, operation_history_id_type(9));

--- a/tests/tests/history_api_tests.cpp
+++ b/tests/tests/history_api_tests.cpp
@@ -526,6 +526,141 @@ BOOST_AUTO_TEST_CASE(get_account_history_additional) {
    }
 }
 
+BOOST_AUTO_TEST_CASE(get_account_history_by_time) {
+   try {
+      graphene::app::history_api hist_api(app);
+
+      auto time1 = db.head_block_time();
+
+      // A = account_id_type() with records { 5, 3, 1, 0 }, and
+      // B = dan with records { 6, 4, 2, 1 }
+      // account_id_type() and dan share operation id 1(account create) - share can be also in id 0
+
+      // no history at all in the chain
+      vector<operation_history_object> histories = hist_api.get_account_history_by_time("1.2.0");
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
+
+      create_bitasset("USD", account_id_type()); // create op 0
+      generate_block();
+      fc::usleep(fc::milliseconds(100));
+
+      auto time2 = db.head_block_time();
+
+      // what if the account only has one history entry and it is 0?
+      histories = hist_api.get_account_history_by_time("1.2.0");
+      BOOST_REQUIRE_EQUAL(histories.size(), 1u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 0u);
+
+      histories = hist_api.get_account_history_by_time("1.2.0", 0);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
+
+      histories = hist_api.get_account_history_by_time("1.2.0", 2, time1);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
+
+      histories = hist_api.get_account_history_by_time("1.2.0", 10, time2);
+      BOOST_REQUIRE_EQUAL(histories.size(), 1u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 0u);
+
+      histories = hist_api.get_account_history_by_time("1.2.0", {}, time2);
+      BOOST_REQUIRE_EQUAL(histories.size(), 1u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 0u);
+
+      BOOST_CHECK_THROW( hist_api.get_account_history_by_time( "1.2.0", 102 ), fc::exception );
+
+      const account_object& dan = create_account("dan"); // create op 1
+
+      create_bitasset("CNY", dan.id); // create op 2
+      create_bitasset("BTC", account_id_type()); // create op 3
+      create_bitasset("XMR", dan.id); // create op 4
+      create_bitasset("EUR", account_id_type()); // create op 5
+      create_bitasset("OIL", dan.id); // create op 6
+
+      generate_block();
+      fc::usleep(fc::milliseconds(100));
+
+      auto time3 = db.head_block_time();
+
+      histories = hist_api.get_account_history_by_time("1.2.0", {}, time2);
+      BOOST_REQUIRE_EQUAL(histories.size(), 1u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 0u);
+
+      histories = hist_api.get_account_history_by_time("1.2.0", {}, time2 + fc::seconds(1));
+      BOOST_REQUIRE_EQUAL(histories.size(), 1u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 0u);
+
+      histories = hist_api.get_account_history_by_time("1.2.0", {}, time3);
+      BOOST_REQUIRE_EQUAL(histories.size(), 4u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1u);
+      BOOST_CHECK_EQUAL(histories[3].id.instance(), 0u);
+
+      histories = hist_api.get_account_history_by_time("1.2.0", 2, time3);
+      BOOST_REQUIRE_EQUAL(histories.size(), 2u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3u);
+
+      histories = hist_api.get_account_history_by_time("1.2.0", 2);
+      BOOST_REQUIRE_EQUAL(histories.size(), 2u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3u);
+
+      histories = hist_api.get_account_history_by_time("1.2.0");
+      BOOST_REQUIRE_EQUAL(histories.size(), 4u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 5u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 3u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 1u);
+      BOOST_CHECK_EQUAL(histories[3].id.instance(), 0u);
+
+      histories = hist_api.get_account_history_by_time("dan", {}, time3);
+      BOOST_REQUIRE_EQUAL(histories.size(), 4u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 2u);
+      BOOST_CHECK_EQUAL(histories[3].id.instance(), 1u);
+
+      histories = hist_api.get_account_history_by_time("dan", 5, time3);
+      BOOST_REQUIRE_EQUAL(histories.size(), 4u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 2u);
+      BOOST_CHECK_EQUAL(histories[3].id.instance(), 1u);
+
+      histories = hist_api.get_account_history_by_time("dan", 5);
+      BOOST_REQUIRE_EQUAL(histories.size(), 4u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 2u);
+      BOOST_CHECK_EQUAL(histories[3].id.instance(), 1u);
+
+      histories = hist_api.get_account_history_by_time("dan");
+      BOOST_REQUIRE_EQUAL(histories.size(), 4u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4u);
+      BOOST_CHECK_EQUAL(histories[2].id.instance(), 2u);
+      BOOST_CHECK_EQUAL(histories[3].id.instance(), 1u);
+
+      histories = hist_api.get_account_history_by_time("dan", 2, time3);
+      BOOST_REQUIRE_EQUAL(histories.size(), 2u);
+      BOOST_CHECK_EQUAL(histories[0].id.instance(), 6u);
+      BOOST_CHECK_EQUAL(histories[1].id.instance(), 4u);
+
+      histories = hist_api.get_account_history_by_time("dan", 2, time2);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
+
+      histories = hist_api.get_account_history_by_time("dan", {}, time1);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
+
+      histories = hist_api.get_account_history_by_time("nathan", 2);
+      BOOST_CHECK_EQUAL(histories.size(), 0u);
+
+   }
+   catch (fc::exception &e) {
+      edump((e.to_detail_string()));
+      throw;
+   }
+}
+
 BOOST_AUTO_TEST_CASE(track_account) {
    try {
       graphene::app::history_api hist_api(app);


### PR DESCRIPTION
PR for #2647.

Add `history_api::get_account_history_by_time` API,
```
/**
 * @brief Get the history of operations related to the specified account no later than the specified time
 * @param account_name_or_id The account name or ID whose history should be queried
 * @param limit Maximum number of operations to retrieve, must not exceed the configured value of
 *              @a api_limit_get_account_history
 * @param start the time point to start looping back through history
 * @return A list of operations related to the specified account, ordered from most recent to oldest.
 *
 * @note
 * 1. If @p account_name_or_id cannot be tied to an account, an empty list will be returned
 * 2. @p limit can be omitted or be @a null, if so the configured value of
 *       @a api_limit_get_account_history will be used
 * 3. @p start can be omitted or be @a null, if so the api will return the "first page" of the history
 * 4. One or more optional parameters can be omitted from the end of the parameter list, and the optional
 *    parameters in the middle cannot be omitted (but can be @a null).
 */
vector<operation_history_object> get_account_history_by_time(
   const std::string& account_name_or_id,
   const optional<uint32_t>& limit = optional<uint32_t>(),
   const optional<fc::time_point_sec>& start = optional<fc::time_point_sec>()
)const;
```

and refactor `history_api::get_account_history` by the way.