### PR TITLE
Extend get_block_header API and get_block_header_batch API to optionally return witness signatures

### DIFF
--- a/libraries/app/api_objects.cpp
+++ b/libraries/app/api_objects.cpp
@@ -131,7 +131,7 @@ market_ticker::market_ticker(const fc::time_point_sec& now,
 }
 
 maybe_signed_block_header::maybe_signed_block_header( const signed_block_header& bh, bool with_witness_signature )
-: block_header( bh ),
+: block_header( bh ), // Slice intentionally
   witness_signature( with_witness_signature ? bh.witness_signature : optional<signature_type>() )
 { // Nothing else to do
 }

--- a/libraries/app/api_objects.cpp
+++ b/libraries/app/api_objects.cpp
@@ -130,4 +130,10 @@ market_ticker::market_ticker(const fc::time_point_sec& now,
    quote_volume = "0";
 }
 
+maybe_signed_block_header::maybe_signed_block_header( const signed_block_header& bh, bool with_witness_signature )
+: block_header( bh ),
+  witness_signature( with_witness_signature ? bh.witness_signature : optional<signature_type>() )
+{ // Nothing else to do
+}
+
 } } // graphene::app

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -227,31 +227,36 @@ void database_api_impl::cancel_all_subscriptions( bool reset_callback, bool rese
 //                                                                  //
 //////////////////////////////////////////////////////////////////////
 
-optional<signed_block_header> database_api::get_block_header(uint32_t block_num)const
+optional<maybe_signed_block_header> database_api::get_block_header(
+            uint32_t block_num, const optional<bool>& with_witness_signature )const
 {
-   return my->get_block_header( block_num );
+   bool with_signature = ( with_witness_signature.valid() && *with_witness_signature );
+   return my->get_block_header( block_num, with_signature );
 }
 
-optional<signed_block_header> database_api_impl::get_block_header(uint32_t block_num) const
+optional<maybe_signed_block_header> database_api_impl::get_block_header(
+            uint32_t block_num, bool with_witness_signature )const
 {
    auto result = _db.fetch_block_by_number(block_num);
    if(result)
-      return *result;
+      return maybe_signed_block_header( *result, with_witness_signature );
    return {};
 }
-map<uint32_t, optional<signed_block_header>> database_api::get_block_header_batch(
-      const vector<uint32_t>& block_nums) const
+
+map<uint32_t, optional<maybe_signed_block_header>> database_api::get_block_header_batch(
+            const vector<uint32_t>& block_nums, const optional<bool>& with_witness_signatures )const
 {
-   return my->get_block_header_batch( block_nums );
+   bool with_signatures = ( with_witness_signatures.valid() && *with_witness_signatures );
+   return my->get_block_header_batch( block_nums, with_signatures );
 }
 
-map<uint32_t, optional<signed_block_header>> database_api_impl::get_block_header_batch(
-      const vector<uint32_t>& block_nums) const
+map<uint32_t, optional<maybe_signed_block_header>> database_api_impl::get_block_header_batch(
+            const vector<uint32_t>& block_nums, bool with_witness_signatures )const
 {
-   map<uint32_t, optional<signed_block_header>> results;
+   map<uint32_t, optional<maybe_signed_block_header>> results;
    for (const uint32_t block_num : block_nums)
    {
-      results[block_num] = get_block_header(block_num);
+      results[block_num] = get_block_header( block_num, with_witness_signatures );
    }
    return results;
 }

--- a/libraries/app/database_api_impl.hxx
+++ b/libraries/app/database_api_impl.hxx
@@ -50,8 +50,9 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       void cancel_all_subscriptions(bool reset_callback, bool reset_market_subscriptions);
 
       // Blocks and transactions
-      optional<signed_block_header> get_block_header(uint32_t block_num)const;
-      map<uint32_t, optional<signed_block_header>> get_block_header_batch(const vector<uint32_t>& block_nums)const;
+      optional<maybe_signed_block_header> get_block_header( uint32_t block_num, bool with_witness_signature )const;
+      map<uint32_t, optional<maybe_signed_block_header>> get_block_header_batch(
+            const vector<uint32_t>& block_nums, bool with_witness_signatures )const;
       optional<signed_block> get_block(uint32_t block_num)const;
       processed_transaction get_transaction( uint32_t block_num, uint32_t trx_in_block )const;
 

--- a/libraries/app/include/graphene/app/api_objects.hpp
+++ b/libraries/app/include/graphene/app/api_objects.hpp
@@ -177,6 +177,14 @@ namespace graphene { namespace app {
       optional<liquidity_pool_ticker_object> statistics;
    };
 
+   struct maybe_signed_block_header : block_header
+   {
+      maybe_signed_block_header() = default;
+      explicit maybe_signed_block_header( const signed_block_header& bh, bool with_witness_signature = true );
+
+      optional<signature_type> witness_signature;
+   };
+
 } }
 
 FC_REFLECT( graphene::app::more_data,
@@ -221,3 +229,5 @@ FC_REFLECT_DERIVED( graphene::app::extended_asset_object, (graphene::chain::asse
 FC_REFLECT_DERIVED( graphene::app::extended_liquidity_pool_object, (graphene::chain::liquidity_pool_object),
                     (statistics) )
 
+FC_REFLECT_DERIVED( graphene::app::maybe_signed_block_header, (graphene::protocol::block_header),
+                    (witness_signature) )

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -153,18 +153,26 @@ class database_api
       /////////////////////////////
 
       /**
-       * @brief Retrieve a signed block header
+       * @brief Retrieve a block header
        * @param block_num Height of the block whose header should be returned
+       * @param with_witness_signature Whether to return witness signature. Optional.
+       *                               If omitted or is @a false, will not return witness signature.
        * @return header of the referenced block, or null if no matching block was found
        */
-      optional<signed_block_header> get_block_header(uint32_t block_num)const;
+      optional<maybe_signed_block_header> get_block_header(
+            uint32_t block_num,
+            const optional<bool>& with_witness_signature = optional<bool>() )const;
 
       /**
-      * @brief Retrieve multiple signed block headers by block numbers
-      * @param block_nums vector containing heights of the blocks whose headers should be returned
-      * @return array of headers of the referenced blocks, or null if no matching block was found
-      */
-      map<uint32_t, optional<signed_block_header>> get_block_header_batch(const vector<uint32_t>& block_nums)const;
+       * @brief Retrieve multiple block headers by block numbers
+       * @param block_nums vector containing heights of the blocks whose headers should be returned
+       * @param with_witness_signatures Whether to return witness signatures. Optional.
+       *                                If omitted or is @a false, will not return witness signatures.
+       * @return array of headers of the referenced blocks, or null if no matching block was found
+       */
+      map<uint32_t, optional<maybe_signed_block_header>> get_block_header_batch(
+            const vector<uint32_t>& block_nums,
+            const optional<bool>& with_witness_signatures = optional<bool>() )const;
 
       /**
        * @brief Retrieve a full, signed block

--- a/libraries/protocol/include/graphene/protocol/block.hpp
+++ b/libraries/protocol/include/graphene/protocol/block.hpp
@@ -39,6 +39,8 @@ namespace graphene { namespace protocol {
       //       More info in https://github.com/bitshares/bitshares-core/issues/1136
       extensions_type               extensions;
 
+      virtual ~block_header() = default;
+
       static uint32_t num_from_id(const block_id_type& id);
    };
 
@@ -51,6 +53,9 @@ namespace graphene { namespace protocol {
       bool                       validate_signee( const fc::ecc::public_key& expected_signee )const;
 
       signature_type             witness_signature;
+
+      signed_block_header() = default;
+      explicit signed_block_header( const block_header& header ) : block_header( header ) {}
    protected:
       mutable fc::ecc::public_key _signee;
       mutable block_id_type       _block_id;


### PR DESCRIPTION
Follow-up of #2641, for issue #2588.

Instead of always returning witness signatures (as in #2641), this PR adds an optional `with_witness_signature` parameter to the `get_block_header` API, and add an optional `with_witness_signatures` parameter to the `get_block_header_batch` API, to indicate whether to return witness signatures.

This PR also updates the return types of these 2 APIs so that witness signature can optionally be returned. The new type `maybe_signed_block_header` is derived from `block_header` with an optional `witness_signature` field.
```
   struct maybe_signed_block_header : block_header
   {
      optional<signature_type> witness_signature;
   };
```

Updated APIs:
* `get_block_header( block_num, with_witness_signature )`
```
      /** 
       * @brief Retrieve a block header
       * @param block_num Height of the block whose header should be returned
       * @param with_witness_signature Whether to return witness signature. Optional.
       *                               If omitted or is @a false, will not return witness signature.
       * @return header of the referenced block, or null if no matching block was found
       */
      optional<maybe_signed_block_header> get_block_header(
            uint32_t block_num,
            const optional<bool>& with_witness_signature = optional<bool>() )const;
```
* `get_block_header_batch( block_nums, with_witness_signatures )`
```
      /** 
       * @brief Retrieve multiple block headers by block numbers
       * @param block_nums vector containing heights of the blocks whose headers should be returned
       * @param with_witness_signatures Whether to return witness signatures. Optional.
       *                                If omitted or is @a false, will not return witness signatures.
       * @return array of headers of the referenced blocks, or null if no matching block was found
       */
      map<uint32_t, optional<maybe_signed_block_header>> get_block_header_batch(
            const vector<uint32_t>& block_nums,
            const optional<bool>& with_witness_signatures = optional<bool>() )const;
```