### PR TITLE
Add `database_api::get_next_object_id` API

### DIFF
--- a/libraries/app/database_api_impl.hxx
+++ b/libraries/app/database_api_impl.hxx
@@ -62,6 +62,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
       fc::variant_object get_config()const;
       chain_id_type get_chain_id()const;
       dynamic_global_property_object get_dynamic_global_properties()const;
+      object_id_type get_next_object_id( uint8_t space_id, uint8_t type_id, bool with_pending_transactions )const;
 
       // Keys
       vector<flat_set<account_id_type>> get_key_references( vector<public_key_type> key )const;
@@ -430,6 +431,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
 
       const graphene::api_helper_indexes::amount_in_collateral_index* amount_in_collateral_index;
       const graphene::api_helper_indexes::asset_in_liquidity_pools_index* asset_in_liquidity_pools_index;
+      const graphene::api_helper_indexes::next_object_ids_index* next_object_ids_index;
 };
 
 } } // graphene::app

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -228,6 +228,17 @@ class database_api
        */
       dynamic_global_property_object get_dynamic_global_properties()const;
 
+      /**
+       * @brief Get the next object ID in an object space
+       * @param space_id The space ID
+       * @param type_id The type ID
+       * @param with_pending_transactions Whether to include pending transactions
+       * @return The next object ID to be assigned
+       * @throw fc::exception If the object space does not exist, or @p with_pending_transactions is @a false but
+       *                      the api_helper_indexes plugin is not enabled
+       */
+      object_id_type get_next_object_id( uint8_t space_id, uint8_t type_id, bool with_pending_transactions )const;
+
       //////////
       // Keys //
       //////////
@@ -1475,6 +1486,7 @@ FC_API(graphene::app::database_api,
    (get_config)
    (get_chain_id)
    (get_dynamic_global_properties)
+   (get_next_object_id)
 
    // Keys
    (get_key_references)

--- a/libraries/plugins/account_history/account_history_plugin.cpp
+++ b/libraries/plugins/account_history/account_history_plugin.cpp
@@ -457,7 +457,8 @@ void account_history_plugin::plugin_initialize(const boost::program_options::var
 {
    my->init_program_options( options );
 
-   database().applied_block.connect( [&]( const signed_block& b){ my->update_account_histories(b); } );
+   // connect with group 0 to process before some special steps (e.g. snapshot or next_object_id)
+   database().applied_block.connect( 0, [this]( const signed_block& b){ my->update_account_histories(b); } );
    my->_oho_index = database().add_index< primary_index< operation_history_index > >();
    database().add_index< primary_index< account_history_index > >();
 

--- a/libraries/plugins/api_helper_indexes/api_helper_indexes.cpp
+++ b/libraries/plugins/api_helper_indexes/api_helper_indexes.cpp
@@ -26,6 +26,7 @@
 #include <graphene/chain/liquidity_pool_object.hpp>
 #include <graphene/chain/market_object.hpp>
 #include <graphene/chain/proposal_object.hpp>
+#include <graphene/chain/chain_property_object.hpp>
 
 namespace graphene { namespace api_helper_indexes {
 
@@ -198,6 +199,56 @@ void api_helper_indexes::plugin_startup()
    for( const auto& pool : database().get_index_type<liquidity_pool_index>().indices() )
       asset_in_liquidity_pools_idx->object_inserted( pool );
 
+   next_object_ids_idx = database().add_secondary_index< primary_index<simple_index<chain_property_object>>,
+                                                        next_object_ids_index >();
+   refresh_next_ids();
+   // connect with no group specified to process after the ones with a group specified
+   database().applied_block.connect( [this]( const chain::signed_block& )
+   {
+      refresh_next_ids();
+      _next_ids_map_initialized = true;
+   });
 }
+
+void api_helper_indexes::refresh_next_ids()
+{
+   const auto& db = database();
+   if( _next_ids_map_initialized )
+   {
+      for( auto& item : next_object_ids_idx->_next_ids )
+      {
+         item.second = db.get_index( item.first.first, item.first.second ).get_next_id();
+      }
+      return;
+   }
+
+   // Assuming that all indexes have been created when processing the first block,
+   // for better performance, only do this twice, one on plugin startup, the other on the first block.
+   constexpr uint8_t max = 255;
+   size_t count = 0;
+   size_t failed_count = 0;
+   for( uint8_t space = 0; space < max; ++space )
+   {
+      for( uint8_t type = 0; type < max; ++type )
+      {
+         try
+         {
+            const auto& idx = db.get_index( space, type );
+            next_object_ids_idx->_next_ids[ std::make_pair( space, type ) ] = idx.get_next_id();
+            ++count;
+         }
+         catch( const fc::exception& )
+         {
+            ++failed_count;
+         }
+      }
+   }
+   dlog( "${count} indexes detected, ${failed_count} not found", ("count",count)("failed_count",failed_count) );
+}
+
+object_id_type next_object_ids_index::get_next_id( uint8_t space_id, uint8_t type_id ) const
+{ try {
+   return _next_ids.at( std::make_pair( space_id, type_id ) );
+} FC_CAPTURE_AND_RETHROW( (space_id)(type_id) ) }
 
 } }

--- a/libraries/plugins/api_helper_indexes/include/graphene/api_helper_indexes/api_helper_indexes.hpp
+++ b/libraries/plugins/api_helper_indexes/include/graphene/api_helper_indexes/api_helper_indexes.hpp
@@ -71,6 +71,21 @@ class asset_in_liquidity_pools_index: public secondary_index
       flat_map<asset_id_type, flat_set<liquidity_pool_id_type>> asset_in_pools_map;
 };
 
+/**
+ *  @brief This secondary index tracks the next ID of all object types.
+ *  @note This is implemented with \c flat_map considering there aren't too many object types in the system thus
+ *        the performance would be acceptable.
+ */
+class next_object_ids_index : public secondary_index
+{
+   public:
+      object_id_type get_next_id( uint8_t space_id, uint8_t type_id ) const;
+
+   private:
+      friend class api_helper_indexes;
+      flat_map< std::pair<uint8_t,uint8_t>, object_id_type > _next_ids;
+};
+
 namespace detail
 {
     class api_helper_indexes_impl;
@@ -96,6 +111,10 @@ class api_helper_indexes : public graphene::app::plugin
       std::unique_ptr<detail::api_helper_indexes_impl> my;
       amount_in_collateral_index* amount_in_collateral_idx = nullptr;
       asset_in_liquidity_pools_index* asset_in_liquidity_pools_idx = nullptr;
+      next_object_ids_index* next_object_ids_idx = nullptr;
+
+      bool _next_ids_map_initialized = false;
+      void refresh_next_ids();
 };
 
 } } //graphene::template

--- a/libraries/plugins/custom_operations/custom_operations_plugin.cpp
+++ b/libraries/plugins/custom_operations/custom_operations_plugin.cpp
@@ -136,7 +136,8 @@ void custom_operations_plugin::plugin_initialize(const boost::program_options::v
       my->_start_block = options["custom-operations-start-block"].as<uint32_t>();
    }
 
-   database().applied_block.connect( [this]( const signed_block& b) {
+   // connect with group 0 to process before some special steps (e.g. snapshot or next_object_id)
+   database().applied_block.connect( 0, [this]( const signed_block& b) {
       if( b.block_num() >= my->_start_block )
          my->onBlock();
    } );

--- a/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
+++ b/libraries/plugins/elasticsearch/elasticsearch_plugin.cpp
@@ -575,7 +575,8 @@ void elasticsearch_plugin::plugin_initialize(const boost::program_options::varia
 
    if( my->_options.elasticsearch_mode != mode::only_query )
    {
-      database().applied_block.connect([this](const signed_block &b) {
+      // connect with group 0 to process before some special steps (e.g. snapshot or next_object_id)
+      database().applied_block.connect( 0, [this](const signed_block &b) {
          my->update_account_histories(b);
       });
    }

--- a/libraries/plugins/market_history/market_history_plugin.cpp
+++ b/libraries/plugins/market_history/market_history_plugin.cpp
@@ -766,7 +766,8 @@ void market_history_plugin::plugin_set_program_options(
 
 void market_history_plugin::plugin_initialize(const boost::program_options::variables_map& options)
 { try {
-   database().applied_block.connect( [this]( const signed_block& b){ my->update_market_histories(b); } );
+   // connect with group 0 to process before some special steps (e.g. snapshot or next_object_id)
+   database().applied_block.connect( 0, [this]( const signed_block& b){ my->update_market_histories(b); } );
 
    database().add_index< primary_index< bucket_index  > >();
    database().add_index< primary_index< history_index  > >();

--- a/libraries/plugins/snapshot/snapshot.cpp
+++ b/libraries/plugins/snapshot/snapshot.cpp
@@ -72,6 +72,7 @@ void snapshot_plugin::plugin_initialize(const boost::program_options::variables_
          snapshot_block = options[OPT_BLOCK_NUM].as<uint32_t>();
       if( options.count(OPT_BLOCK_TIME) > 0 )
          snapshot_time = fc::time_point_sec::from_iso_string( options[OPT_BLOCK_TIME].as<std::string>() );
+      // connect with no group specified to process after the ones with a group specified
       database().applied_block.connect( [&]( const graphene::chain::signed_block& b ) {
          check_snapshot( b );
       });

--- a/libraries/plugins/template_plugin/template_plugin.cpp
+++ b/libraries/plugins/template_plugin/template_plugin.cpp
@@ -103,7 +103,8 @@ void template_plugin::plugin_set_program_options(
 
 void template_plugin::plugin_initialize(const boost::program_options::variables_map& options)
 {
-   database().applied_block.connect( [&]( const signed_block& b) {
+   // connect with group 0 by default to process before some special steps (e.g. snapshot or next_object_id)
+   database().applied_block.connect( 0, [this]( const signed_block& b) {
       my->on_block(b);
    } );
 

--- a/tests/tests/database_api_tests.cpp
+++ b/tests/tests/database_api_tests.cpp
@@ -1985,10 +1985,22 @@ BOOST_AUTO_TEST_CASE( get_trade_history )
    opt.has_market_history_plugin = true;
    graphene::app::database_api db_api( db, &opt);
 
+   // check get_next_object_id
+   auto next_id = db_api.get_next_object_id( MARKET_HISTORY_SPACE_ID,
+                                             graphene::market_history::order_history_object_type,
+                                             false );
+   BOOST_CHECK( std::string(next_id) == "5.0.0" );
+   next_id = db_api.get_next_object_id( MARKET_HISTORY_SPACE_ID,
+                                        graphene::market_history::order_history_object_type,
+                                        true );
+   BOOST_CHECK( std::string(next_id) == "5.0.0" );
+
    ACTORS((bob)(alice));
 
    const auto& eur = create_user_issued_asset("EUR");
+   asset_id_type eur_id = eur.id;
    const auto& usd = create_user_issued_asset("USD");
+   asset_id_type usd_id = usd.id;
 
    issue_uia( bob_id, usd.amount(1000000) );
    issue_uia( alice_id, eur.amount(1000000) );
@@ -1996,8 +2008,28 @@ BOOST_AUTO_TEST_CASE( get_trade_history )
    // maker create an order
    create_sell_order(bob, usd.amount(200), eur.amount(210));
 
+   // btw check get_next_object_id
+   next_id = db_api.get_next_object_id( protocol_ids,
+                                        limit_order_object_type,
+                                        false );
+   BOOST_CHECK( std::string(next_id) == "1.7.0" );
+   next_id = db_api.get_next_object_id( protocol_ids,
+                                        limit_order_object_type,
+                                        true );
+   BOOST_CHECK( std::string(next_id) == "1.7.1" );
+
    // taker match it
    create_sell_order(alice, eur.amount(210), usd.amount(200));
+
+   // btw check get_next_object_id
+   next_id = db_api.get_next_object_id( protocol_ids,
+                                        limit_order_object_type,
+                                        false );
+   BOOST_CHECK( std::string(next_id) == "1.7.0" );
+   next_id = db_api.get_next_object_id( protocol_ids,
+                                        limit_order_object_type,
+                                        true );
+   BOOST_CHECK( std::string(next_id) == "1.7.2" );
 
    generate_block();
 
@@ -2039,6 +2071,56 @@ BOOST_AUTO_TEST_CASE( get_trade_history )
    BOOST_CHECK_EQUAL( "buy", history[0].type );
    BOOST_CHECK_EQUAL( bob_id.instance.value, history[0].side1_account_id.instance.value );
    BOOST_CHECK_EQUAL( alice_id.instance.value, history[0].side2_account_id.instance.value );
+
+   // check get_next_object_id
+   next_id = db_api.get_next_object_id( MARKET_HISTORY_SPACE_ID,
+                                        graphene::market_history::order_history_object_type,
+                                        false );
+   BOOST_CHECK( std::string(next_id) == "5.0.2" );
+   next_id = db_api.get_next_object_id( MARKET_HISTORY_SPACE_ID,
+                                        graphene::market_history::order_history_object_type,
+                                        true );
+   BOOST_CHECK( std::string(next_id) == "5.0.2" );
+   next_id = db_api.get_next_object_id( protocol_ids,
+                                        limit_order_object_type,
+                                        false );
+   BOOST_CHECK( std::string(next_id) == "1.7.2" );
+   next_id = db_api.get_next_object_id( protocol_ids,
+                                        limit_order_object_type,
+                                        true );
+   BOOST_CHECK( std::string(next_id) == "1.7.2" );
+   // maker create an order
+   create_sell_order(bob, asset(200,usd_id), asset(210,eur_id));
+   // check get_next_object_id
+   next_id = db_api.get_next_object_id( protocol_ids,
+                                        limit_order_object_type,
+                                        false );
+   BOOST_CHECK( std::string(next_id) == "1.7.2" );
+   next_id = db_api.get_next_object_id( protocol_ids,
+                                        limit_order_object_type,
+                                        true );
+   BOOST_CHECK( std::string(next_id) == "1.7.3" );
+   BOOST_CHECK_THROW( db_api.get_next_object_id( 1,100,true ), fc::exception );
+   BOOST_CHECK_THROW( db_api.get_next_object_id( 10,0,false ), fc::exception );
+
+   generate_block();
+   // check get_next_object_id
+   next_id = db_api.get_next_object_id( MARKET_HISTORY_SPACE_ID,
+                                        graphene::market_history::order_history_object_type,
+                                        false );
+   BOOST_CHECK( std::string(next_id) == "5.0.2" );
+   next_id = db_api.get_next_object_id( MARKET_HISTORY_SPACE_ID,
+                                        graphene::market_history::order_history_object_type,
+                                        true );
+   BOOST_CHECK( std::string(next_id) == "5.0.2" );
+   next_id = db_api.get_next_object_id( protocol_ids,
+                                        limit_order_object_type,
+                                        false );
+   BOOST_CHECK( std::string(next_id) == "1.7.3" );
+   next_id = db_api.get_next_object_id( protocol_ids,
+                                        limit_order_object_type,
+                                        true );
+   BOOST_CHECK( std::string(next_id) == "1.7.3" );
 
 } FC_LOG_AND_RETHROW() }
 


### PR DESCRIPTION
PR for #2649.

This PR adds a database API which partially depends on the `api_helper_indexes` plugin.
* `get_next_object_id( space_id, type_id, whether_with_pending_transactions )` 

```
/**
 * @brief Get the next object ID in an object space
 * @param space_id The space ID
 * @param type_id The type ID
 * @param with_pending_transactions Whether to include pending transactions
 * @return The next object ID to be assigned
 * @throw fc::exception If the object space does not exist, or @p with_pending_transactions
 *                      is @a false but the api_helper_indexes plugin is not enabled
 */
object_id_type get_next_object_id( uint8_t space_id, uint8_t type_id,
                                   bool with_pending_transactions )const;
```