### PR TITLE
Update Dockerfile and build-docker workflow

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -17,6 +17,15 @@ jobs:
         fi
         echo "DOCKER_PUSH_TAG=${DOCKER_PUSH_TAG}"
         echo "DOCKER_PUSH_TAG=${DOCKER_PUSH_TAG}" >> $GITHUB_ENV
+        VERSION_MAJOR=`echo "${DOCKER_PUSH_TAG}" | cut -f1 -d'.'`
+        if [ "${VERSION_MAJOR}" != "${DOCKER_PUSH_TAG}" ]; then
+          VERSION_MINOR=`echo "${DOCKER_PUSH_TAG}" | cut -f2 -d'.'`
+          DOCKER_PUSH_TAG_SHORT=${VERSION_MAJOR}.${VERSION_MINOR}
+          if [ "${DOCKER_PUSH_TAG_SHORT}" != "${DOCKER_PUSH_TAG}" ]; then
+            echo "DOCKER_PUSH_TAG_SHORT=${DOCKER_PUSH_TAG_SHORT}"
+            echo "DOCKER_PUSH_TAG_SHORT=${DOCKER_PUSH_TAG_SHORT}" >> $GITHUB_ENV
+          fi
+        fi
     - name: Test tag
       if: env.DOCKER_PUSH_TAG != ''
       run: echo "${DOCKER_PUSH_TAG}"
@@ -35,10 +44,19 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Push to DockerHub
-      if: env.DOCKER_PUSH_TAG != ''
+    - name: Push to DockerHub (for branches)
+      if: env.DOCKER_PUSH_TAG != '' && env.DOCKER_PUSH_TAG_SHORT == ''
       uses: docker/build-push-action@v3
       with:
         context: .
         push: true
         tags: ${{ secrets.DOCKERHUB_REPO_PATH }}:${{ env.DOCKER_PUSH_TAG }}
+    - name: Push to DockerHub (for tags)
+      if: env.DOCKER_PUSH_TAG != '' && env.DOCKER_PUSH_TAG_SHORT != ''
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        push: true
+        tags: |
+          ${{ secrets.DOCKERHUB_REPO_PATH }}:${{ env.DOCKER_PUSH_TAG }}
+          ${{ secrets.DOCKERHUB_REPO_PATH }}:${{ env.DOCKER_PUSH_TAG_SHORT }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -41,4 +41,4 @@ jobs:
       with:
         context: .
         push: true
-        tags: bitshares/bitshares-core:${{ env.DOCKER_PUSH_TAG }}
+        tags: ${{ secrets.DOCKERHUB_REPO_PATH }}:${{ env.DOCKER_PUSH_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,6 @@ RUN \
       libtool \
       doxygen \
       ca-certificates \
-      fish \
     && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ EXPOSE 1776
 # Make Docker send SIGINT instead of SIGTERM to the daemon
 STOPSIGNAL SIGINT
 
-# Temporarily commented out due to permission issues cuased by older versions, to be restored in a future version
+# Temporarily commented out due to permission issues caused by older versions, to be restored in a future version
 #USER bitshares:bitshares
 
 # default execute entry

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,10 @@ RUN \
 	-DGRAPHENE_DISABLE_UNITY_BUILD=ON \
         . && \
     make witness_node cli_wallet get_dev_key && \
-    install -s programs/witness_node/witness_node programs/genesis_util/get_dev_key programs/cli_wallet/cli_wallet /usr/local/bin && \
+    install -s programs/witness_node/witness_node \
+               programs/genesis_util/get_dev_key \
+               programs/cli_wallet/cli_wallet \
+            /usr/local/bin && \
     #
     # Obtain version
     mkdir -p /etc/bitshares && \
@@ -62,7 +65,8 @@ RUN \
 
 # Home directory $HOME
 WORKDIR /
-RUN useradd -s /bin/bash -m -d /var/lib/bitshares bitshares
+RUN groupadd -g 10001 bitshares
+RUN useradd -u 10000 -g bitshares -s /bin/bash -m -d /var/lib/bitshares --no-log-init bitshares
 ENV HOME /var/lib/bitshares
 RUN chown bitshares:bitshares -R /var/lib/bitshares
 
@@ -82,6 +86,8 @@ RUN chmod a+x /usr/local/bin/bitsharesentry.sh
 
 # Make Docker send SIGINT instead of SIGTERM to the daemon
 STOPSIGNAL SIGINT
+
+USER bitshares:bitshares
 
 # default execute entry
 CMD ["/usr/local/bin/bitsharesentry.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ RUN chmod a+x /usr/local/bin/bitsharesentry.sh
 # Make Docker send SIGINT instead of SIGTERM to the daemon
 STOPSIGNAL SIGINT
 
-USER bitshares:bitshares
+#USER bitshares:bitshares
 
 # default execute entry
 CMD ["/usr/local/bin/bitsharesentry.sh"]

--- a/docker/bitsharesentry.sh
+++ b/docker/bitsharesentry.sh
@@ -86,6 +86,9 @@ ln -f -s /etc/bitshares/logging.ini /var/lib/bitshares
 
 chown -R bitshares:bitshares /var/lib/bitshares
 
+# Get the latest security updates
+apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confold"
+
 # Plugins need to be provided in a space-separated list, which
 # makes it necessary to write it like this
 if [[ ! -z "$BITSHARESD_PLUGINS" ]]; then

--- a/docker/bitsharesentry.sh
+++ b/docker/bitsharesentry.sh
@@ -84,10 +84,14 @@ fi
 ln -f -s /etc/bitshares/config.ini /var/lib/bitshares
 ln -f -s /etc/bitshares/logging.ini /var/lib/bitshares
 
+chown -R bitshares:bitshares /var/lib/bitshares
+
 # Plugins need to be provided in a space-separated list, which
 # makes it necessary to write it like this
 if [[ ! -z "$BITSHARESD_PLUGINS" ]]; then
-   exec "$BITSHARESD" --data-dir "${HOME}" ${ARGS} ${BITSHARESD_ARGS} --plugins "${BITSHARESD_PLUGINS}"
+   exec /usr/bin/setpriv --reuid=bitshares --regid=bitshares --clear-groups \
+     "$BITSHARESD" --data-dir "${HOME}" ${ARGS} ${BITSHARESD_ARGS} --plugins "${BITSHARESD_PLUGINS}"
 else
-   exec "$BITSHARESD" --data-dir "${HOME}" ${ARGS} ${BITSHARESD_ARGS}
+   exec /usr/bin/setpriv --reuid=bitshares --regid=bitshares --clear-groups \
+     "$BITSHARESD" --data-dir "${HOME}" ${ARGS} ${BITSHARESD_ARGS}
 fi


### PR DESCRIPTION
PR for #2011.

Changes:
* Use Docker Multistage Builds to produce smaller images (398M -> 177M).
* Run the container with the `bitshares` user whose UID is statically set to `10000` and GID to `10001`, to follow best practices https://github.com/hexops/dockerfile#use-a-static-uid-and-gid.
* Upgrade libraries in the entry script. Although this will bloat the container size (not the image size) and slow down the startup process, it ensures security when https://github.com/bitshares/bitshares-core/issues/2667 is not done.
* Push the `major.minor` version tag to Docker Hub too, to follow best practices https://github.com/hexops/dockerfile#do-not-use-latest-pin-your-image-tags
* Update the Docker Hub repository path in the `build-docker` workflow to a variable instead of hardcoding it.
