### PR TITLE
Update default values of market history plugin options

### DIFF
--- a/docker/default_config.ini
+++ b/docker/default_config.ini
@@ -213,13 +213,10 @@ max-ops-per-account = 100
 # ==============================================================================
 
 # Track market history by grouping orders into buckets of equal size measured in seconds specified as a JSON array of numbers
-# bucket-size = [15,60,300,3600,86400]
-bucket-size = [60,300,900,1800,3600,14400,86400]
-# for 1 min, 5 mins, 30 mins, 1h, 4 hs and 1 day. i think this should be the default.
-# https://github.com/bitshares/bitshares-core/issues/465
+bucket-size = [60,300,900,3600,14400,86400,604800]
 
 # How far back in time to track history for each bucket size, measured in the number of buckets (default: 1000)
-history-per-size = 1000
+history-per-size = 1500
 
 # Will only store this amount of matched orders for each market in order history for querying, or those meet the other option, which has more data (default: 1000)
 max-order-his-records-per-market = 1000

--- a/libraries/plugins/market_history/market_history_plugin.cpp
+++ b/libraries/plugins/market_history/market_history_plugin.cpp
@@ -744,12 +744,14 @@ void market_history_plugin::plugin_set_program_options(
    )
 {
    cli.add_options()
-         ("bucket-size", boost::program_options::value<string>()->default_value("[60,300,900,1800,3600,14400,86400]"),
+         ("bucket-size",
+           // 1m, 5m, 15m, 1h, 4h, 1d, 1w
+           boost::program_options::value<string>()->default_value("[60,300,900,3600,14400,86400,604800]"),
            "Track market history by grouping orders into buckets of equal size measured "
            "in seconds specified as a JSON array of numbers")
-         ("history-per-size", boost::program_options::value<uint32_t>()->default_value(1000),
+         ("history-per-size", boost::program_options::value<uint32_t>()->default_value(1500),
            "How far back in time to track history for each bucket size, "
-           "measured in the number of buckets (default: 1000)")
+           "measured in the number of buckets (default: 1500)")
          ("max-order-his-records-per-market", boost::program_options::value<uint32_t>()->default_value(1000),
            "Will only store this amount of matched orders for each market in order history for querying, "
            "or those meet the other option, which has more data (default: 1000). "


### PR DESCRIPTION
Changes:
* Update the default `bucket-size` list to `1m, 5m, 15m, 1h, 4h, 1d, 1w` (remove `30m` and add `1w`).
* Update the default `history-per-size` to `1500`, so that in trading chart we can see
  * data of a full day if looking at the `1m` chart, and
  * data of 4 years if looking at the `1d` chart, and
  * all data if looking at the `1w` chart.

Note:
* Config of old nodes won't update itself if upgraded.