### PR TITLE
Fix Github Actions Ubuntu release build (Follow-up of PR #2707)

### DIFF
--- a/.github/workflows/build-and-test.mac.yml
+++ b/.github/workflows/build-and-test.mac.yml
@@ -42,7 +42,7 @@ jobs:
       run: |
         export CCACHE_DIR="$GITHUB_WORKSPACE/ccache"
         mkdir -p "$CCACHE_DIR"
-        make -j 2 -C _build witness_node cli_wallet app_test cli_test chain_test
+        make -j 3 -C _build witness_node cli_wallet app_test cli_test chain_test
         df -h
     - name: Unit-Tests
       run: |

--- a/.github/workflows/build-and-test.ubuntu-debug.yml
+++ b/.github/workflows/build-and-test.ubuntu-debug.yml
@@ -98,13 +98,13 @@ jobs:
         export CCACHE_DIR="$GITHUB_WORKSPACE/ccache"
         mkdir -p "$CCACHE_DIR"
         df -h
-        make -j 1 -C _build chain_test
-        make -j 1 -C _build cli_test
-        make -j 1 -C _build app_test
-        make -j 1 -C _build es_test
-        make -j 1 -C _build cli_wallet
-        make -j 1 -C _build witness_node
-        make -j 1 -C _build
+        make -j 2 -C _build chain_test
+        make -j 2 -C _build cli_test
+        make -j 2 -C _build app_test
+        make -j 2 -C _build es_test
+        make -j 2 -C _build cli_wallet
+        make -j 2 -C _build witness_node
+        make -j 2 -C _build
         df -h
         du -hs _build/libraries/* _build/programs/* _build/tests/*
         du -hs _build/*

--- a/.github/workflows/build-and-test.ubuntu-debug.yml
+++ b/.github/workflows/build-and-test.ubuntu-debug.yml
@@ -14,6 +14,7 @@ jobs:
       elasticsearch8:
         image: elastic/elasticsearch:8.5.3
         options: >-
+          --env ES_JAVA_OPTS="-Xms512m -Xmx512m"
           --env discovery.type=single-node
           --env xpack.security.enabled=false
           --env xpack.security.http.ssl.enabled=false
@@ -23,6 +24,7 @@ jobs:
       elasticsearch7:
         image: elastic/elasticsearch:7.17.8
         options: >-
+          --env ES_JAVA_OPTS="-Xms512m -Xmx512m"
           --env discovery.type=single-node
           --env cluster.routing.allocation.disk.threshold_enabled=false
           --publish 9201:9200
@@ -62,11 +64,6 @@ jobs:
       run: |
         pwd
         df -h .
-        free
-        sudo dd if=/dev/zero of=/swapfile bs=1024 count=4M
-        sudo chmod 600 /swapfile
-        sudo mkswap /swapfile
-        sudo swapon /swapfile
         free
         mkdir -p _build
         sudo mkdir -p /_build/libraries /_build/programs /_build/tests /mnt/_build

--- a/.github/workflows/build-and-test.ubuntu-release.yml
+++ b/.github/workflows/build-and-test.ubuntu-release.yml
@@ -84,7 +84,7 @@ jobs:
       run: |
         export CCACHE_DIR="$GITHUB_WORKSPACE/ccache"
         mkdir -p "$CCACHE_DIR"
-        make -j 1 -C _build
+        make -j 2 -C _build
         df -h
     - name: Unit-Tests
       run: |

--- a/.github/workflows/build-and-test.ubuntu-release.yml
+++ b/.github/workflows/build-and-test.ubuntu-release.yml
@@ -14,6 +14,7 @@ jobs:
       elasticsearch8:
         image: elastic/elasticsearch:8.5.3
         options: >-
+          --env ES_JAVA_OPTS="-Xms512m -Xmx512m"
           --env discovery.type=single-node
           --env xpack.security.enabled=false
           --env xpack.security.http.ssl.enabled=false
@@ -23,6 +24,7 @@ jobs:
       elasticsearch7:
         image: elastic/elasticsearch:7.17.8
         options: >-
+          --env ES_JAVA_OPTS="-Xms512m -Xmx512m"
           --env discovery.type=single-node
           --env cluster.routing.allocation.disk.threshold_enabled=false
           --publish 9201:9200
@@ -57,6 +59,8 @@ jobs:
         submodules: recursive
     - name: Configure
       run: |
+        df -h
+        free
         mkdir -p _build
         pushd _build
         export -n BOOST_ROOT BOOST_INCLUDEDIR BOOST_LIBRARYDIR

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -14,6 +14,7 @@ jobs:
       elasticsearch8:
         image: elastic/elasticsearch:8.5.3
         options: >-
+          --env ES_JAVA_OPTS="-Xms512m -Xmx512m"
           --env discovery.type=single-node
           --env xpack.security.enabled=false
           --env xpack.security.http.ssl.enabled=false
@@ -75,11 +76,6 @@ jobs:
       run: |
         pwd
         df -h .
-        free
-        sudo dd if=/dev/zero of=/swapfile bs=1024 count=4M
-        sudo chmod 600 /swapfile
-        sudo mkswap /swapfile
-        sudo swapon /swapfile
         free
         mkdir -p _build
         sudo mkdir -p /_build/libraries /_build/programs /mnt/_build/tests

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -119,7 +119,7 @@ jobs:
         export CCACHE_DIR="$GITHUB_WORKSPACE/ccache"
         mkdir -p "$CCACHE_DIR"
         df -h
-        programs/build_helpers/make_with_sonar bw-output -j 1 -C _build \
+        programs/build_helpers/make_with_sonar bw-output -j 2 -C _build \
           witness_node cli_wallet js_operation_serializer get_dev_key network_mapper \
           app_test chain_test cli_test es_test
         df -h


### PR DESCRIPTION
Follow-up of #2707.

After merging #2707, the Ubuntu Release workflow in Github Actions fails to build the `develop` branch (at commit https://github.com/bitshares/bitshares-core/commit/6e0e232d84724705c5401a9d3f033f8fc7c71949) due to OOM. This PR fixes it.

See https://github.com/bitshares/bitshares-core/actions/runs/3873850229/jobs/6609080483:
> [ 50%] Building CXX object libraries/chain/CMakeFiles/graphene_chain.dir/database.o
g++: fatal error: Killed signal terminated program cc1plus
compilation terminated.

Cause: Introduced in #2707, we start 2 ES services in the workflow, so more memory is needed.