### PR TITLE
Bump docker/build-push-action from 3 to 4

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
     - name: Build only
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v4
       with:
         context: .
         load: true


### PR DESCRIPTION
There is one change missing from https://github.com/bitshares/bitshares-core/pull/2722. This PR adds it.