### PR TITLE
Fix issues related to global settlement introduced in PR #2721

### DIFF
--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -1201,7 +1201,8 @@ static optional<asset> pay_collateral_fees( database& d,
 {
    const auto& head_time = d.head_block_time();
    bool after_core_hardfork_2591 = HARDFORK_CORE_2591_PASSED( head_time ); // Tighter peg (fill settlement at MCOP)
-   if( after_core_hardfork_2591 && !bitasset.current_feed.settlement_price.is_null() )
+   if( after_core_hardfork_2591 && !bitasset.is_prediction_market
+         && !bitasset.current_feed.settlement_price.is_null() )
    {
       price fill_price = bitasset.get_margin_call_order_price();
       try

--- a/libraries/chain/db_market.cpp
+++ b/libraries/chain/db_market.cpp
@@ -319,7 +319,7 @@ void database::globally_settle_asset_impl( const asset_object& mia,
    const limit_order_object* limit_ptr = find_settled_debt_order( bitasset.asset_id );
    if( limit_ptr )
    {
-      collateral_gathered.amount += limit_ptr->for_sale;
+      collateral_gathered.amount += limit_ptr->settled_collateral_amount;
       remove( *limit_ptr );
    }
 


### PR DESCRIPTION
Follow-up of PR #2721 for issue #2591.

Fix issues:
* When force-settling a Predict Market (after globally settled), skip calculating collateral fees.
* When globally settling a Market Pegged Asset whose BSRM was `individual_settlement_to_order`, process collateral in the order correctly.