### PR TITLE
Remove SonarCloud cache and threads configuration as it is now by default

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -109,7 +109,6 @@ jobs:
       with:
         path: |
           ccache
-          sonar_cache
         key: sonar-${{ env.OS_VERSION }}-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
           sonar-${{ env.OS_VERSION }}-${{ github.ref }}-
@@ -185,7 +184,6 @@ jobs:
         df -h
     - name: Prepare for scanning with SonarScanner
       run: |
-        mkdir -p sonar_cache
         find _build/libraries/[acdenptuw]*/CMakeFiles/*.dir \
              _build/libraries/plugins/*/CMakeFiles/*.dir \
              -type d -print \

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,9 +17,6 @@ sonar.exclusions=programs/build_helper/**/*,libraries/fc/**/*,libraries/egenesis
 sonar.sources=libraries,programs
 sonar.cfamily.build-wrapper-output=bw-output
 sonar.cfamily.gcov.reportsPath=.
-sonar.cfamily.threads=2
-sonar.cfamily.cache.enabled=true
-sonar.cfamily.cache.path=sonar_cache
 
 # Decide which tree the current build belongs to in SonarCloud.
 # Managed by the `set_sonar_branch*` script(s) when building with CI.


### PR DESCRIPTION
No need to configure the cache and threads anymore,
SonarCloud now has automatic analysis caching. See:
https://docs.sonarcloud.io/advanced-setup/languages/c-c-objective-c/#analysis-cache.