### PR TITLE
Use gcovr to process code coverage data

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -50,6 +50,7 @@ jobs:
           sudo apt-get install -y --allow-downgrades openssl=${openssl_ver} libssl-dev=${libssl_ver}
         sudo apt-get install -y \
                      ccache \
+                     gcovr \
                      parallel \
                      libboost-thread-dev \
                      libboost-iostreams-dev \
@@ -184,23 +185,11 @@ jobs:
         df -h
     - name: Prepare for scanning with SonarScanner
       run: |
-        find _build/libraries/[acdenptuw]*/CMakeFiles/*.dir \
-             _build/libraries/plugins/*/CMakeFiles/*.dir \
-             -type d -print \
-          | while read d; do \
-              tmpd="${d:7}"; \
-              srcd="${tmpd/CMakeFiles*.dir/.}"; \
-              gcov -o "$d" "${srcd}"/*.[ch][px][px] \
-                           "${srcd}"/include/graphene/*/*.[ch][px][px] ; \
-            done >/dev/null
-        find _build/programs/[cdgjsw]*/CMakeFiles/*.dir \
-             -type d -print \
-          | while read d; do \
-              tmpd="${d:7}"; \
-              srcd="${tmpd/CMakeFiles*.dir/.}"; \
-              gcov -o "$d" "${srcd}"/*.[ch][px][px] ; \
-            done >/dev/null
         programs/build_helpers/set_sonar_branch_for_github_actions sonar-project.properties
+        pushd _build
+        gcovr --version
+        gcovr --exclude-unreachable-branches --sonarqube ../coverage.xml -r ..
+        popd
     - name: Scan with SonarScanner
       env:
         # to get access to secrets.SONAR_TOKEN, provide GITHUB_TOKEN

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -20,7 +20,12 @@ sonar.tests=tests
 sonar.exclusions=programs/build_helper/**/*,libraries/fc/**/*,libraries/egenesis/egenesis_full.cpp
 sonar.sources=libraries,programs
 sonar.cfamily.build-wrapper-output=bw-output
-sonar.cfamily.gcov.reportsPath=.
+
+# Note:
+# It is hard to get the gcov sensor working, but gcovr works.
+# See https://community.sonarsource.com/t/code-coverage-incorrect-for-c-gcov-project/41837/5
+#sonar.cfamily.gcov.reportsPath=.
+sonar.coverageReportPaths=coverage.xml
 
 # Decide which tree the current build belongs to in SonarCloud.
 # Managed by the `set_sonar_branch*` script(s) when building with CI.


### PR DESCRIPTION
Use `gcovr` to process code coverage data for better coverage reporting, including branch coverage.