### PR TITLE
Update code coverage report settings in sonar-scan overflow

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -188,7 +188,10 @@ jobs:
         programs/build_helpers/set_sonar_branch_for_github_actions sonar-project.properties
         pushd _build
         gcovr --version
-        gcovr --exclude-unreachable-branches --exclude-throw-branches --sonarqube ../coverage.xml -r ..
+        gcovr --exclude-unreachable-branches --exclude-throw-branches \
+              --exclude '\.\./programs/' \
+              --exclude '\.\./tests/' \
+              --sonarqube ../coverage.xml -r ..
         popd
     - name: Scan with SonarScanner
       env:

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -188,7 +188,7 @@ jobs:
         programs/build_helpers/set_sonar_branch_for_github_actions sonar-project.properties
         pushd _build
         gcovr --version
-        gcovr --exclude-unreachable-branches --sonarqube ../coverage.xml -r ..
+        gcovr --exclude-unreachable-branches --exclude-throw-branches --sonarqube ../coverage.xml -r ..
         popd
     - name: Scan with SonarScanner
       env:


### PR DESCRIPTION
Changs:
* Call `gcovr` with `--exclude-throw-branches` in CI. For branch coverage, exclude branches that the compiler generates for exception handling, to generate more "sensible" coverage reports.
* Exclude `programs` and `tests` from coverage reports.