### PR TITLE
Fix code smells

### DIFF
--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -182,7 +182,7 @@ namespace detail {
 
 } // graphene::chain::detail
 
-void_result asset_create_evaluator::do_evaluate( const asset_create_operation& op )
+void_result asset_create_evaluator::do_evaluate( const asset_create_operation& op ) const
 { try {
 
    const database& d = db();
@@ -235,11 +235,11 @@ void_result asset_create_evaluator::do_evaluate( const asset_create_operation& o
       if( dotpos != std::string::npos )
       {
          auto prefix = op.symbol.substr( 0, dotpos );
-         auto asset_symbol_itr = asset_indx.find( prefix );
-         FC_ASSERT( asset_symbol_itr != asset_indx.end(),
+         auto asset_prefix_itr = asset_indx.find( prefix );
+         FC_ASSERT( asset_prefix_itr != asset_indx.end(),
                     "Asset ${s} may only be created by issuer of asset ${p}, but asset ${p} has not been created",
                     ("s",op.symbol)("p",prefix) );
-         FC_ASSERT( asset_symbol_itr->issuer == op.issuer, "Asset ${s} may only be created by issuer of ${p}, ${i}",
+         FC_ASSERT( asset_prefix_itr->issuer == op.issuer, "Asset ${s} may only be created by issuer of ${p}, ${i}",
                     ("s",op.symbol)("p",prefix)("i", op.issuer(d).name) );
       }
    }
@@ -269,7 +269,7 @@ void_result asset_create_evaluator::do_evaluate( const asset_create_operation& o
    }
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 void asset_create_evaluator::pay_fee()
 {
@@ -279,7 +279,7 @@ void asset_create_evaluator::pay_fee()
    generic_evaluator::pay_fee();
 }
 
-object_id_type asset_create_evaluator::do_apply( const asset_create_operation& op )
+object_id_type asset_create_evaluator::do_apply( const asset_create_operation& op ) const
 { try {
    database& d = db();
 
@@ -294,7 +294,7 @@ object_id_type asset_create_evaluator::do_apply( const asset_create_operation& o
    if( fee_is_odd && !hf_429 )
    {
       d.modify( d.get_core_dynamic_data(), []( asset_dynamic_data_object& dd ) {
-         dd.current_supply++;
+         ++dd.current_supply;
       });
    }
 
@@ -315,7 +315,7 @@ object_id_type asset_create_evaluator::do_apply( const asset_create_operation& o
          a.symbol = op.symbol;
          a.precision = op.precision;
          a.options = op.common_options;
-         if( a.options.core_exchange_rate.base.asset_id.instance.value == 0 )
+         if( 0 == a.options.core_exchange_rate.base.asset_id.instance.value )
             a.options.core_exchange_rate.quote.asset_id = next_asset_id;
          else
             a.options.core_exchange_rate.base.asset_id = next_asset_id;
@@ -328,7 +328,7 @@ object_id_type asset_create_evaluator::do_apply( const asset_create_operation& o
    FC_ASSERT( new_asset.id == next_asset_id, "Unexpected object database error, object id mismatch" );
 
    return new_asset.id;
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 void_result asset_issue_evaluator::do_evaluate( const asset_issue_operation& o )
 { try {
@@ -349,9 +349,9 @@ void_result asset_issue_evaluator::do_evaluate( const asset_issue_operation& o )
    FC_ASSERT( (asset_dyn_data->current_supply + o.asset_to_issue.amount) <= a.options.max_supply );
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
-void_result asset_issue_evaluator::do_apply( const asset_issue_operation& o )
+void_result asset_issue_evaluator::do_apply( const asset_issue_operation& o ) const
 { try {
    db().adjust_balance( o.issue_to_account, o.asset_to_issue );
 
@@ -360,7 +360,7 @@ void_result asset_issue_evaluator::do_apply( const asset_issue_operation& o )
    });
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 void_result asset_reserve_evaluator::do_evaluate( const asset_reserve_operation& o )
 { try {
@@ -391,9 +391,9 @@ void_result asset_reserve_evaluator::do_evaluate( const asset_reserve_operation&
    }
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
-void_result asset_reserve_evaluator::do_apply( const asset_reserve_operation& o )
+void_result asset_reserve_evaluator::do_apply( const asset_reserve_operation& o ) const
 { try {
    db().adjust_balance( o.payer, -o.amount_to_reserve );
 
@@ -402,20 +402,20 @@ void_result asset_reserve_evaluator::do_apply( const asset_reserve_operation& o 
    });
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 void_result asset_fund_fee_pool_evaluator::do_evaluate(const asset_fund_fee_pool_operation& o)
 { try {
-   database& d = db();
+   const database& d = db();
 
    const asset_object& a = o.asset_id(d);
 
    asset_dyn_data = &a.dynamic_asset_data_id(d);
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
-void_result asset_fund_fee_pool_evaluator::do_apply(const asset_fund_fee_pool_operation& o)
+void_result asset_fund_fee_pool_evaluator::do_apply(const asset_fund_fee_pool_operation& o) const
 { try {
    db().adjust_balance(o.from_account, -o.amount);
 
@@ -424,7 +424,7 @@ void_result asset_fund_fee_pool_evaluator::do_apply(const asset_fund_fee_pool_op
    });
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 static void validate_new_issuer( const database& d, const asset_object& a, account_id_type new_issuer )
 { try {
@@ -441,7 +441,7 @@ static void validate_new_issuer( const database& d, const asset_object& a, accou
          FC_ASSERT( backing.get_id() == asset_id_type(),
                     "May not create a blockchain-controlled market asset which is not backed by CORE.");
    }
-} FC_CAPTURE_AND_RETHROW( (a)(new_issuer) ) }
+} FC_CAPTURE_AND_RETHROW( (a)(new_issuer) ) } // GCOVR_EXCL_LINE
 
 void_result asset_update_evaluator::do_evaluate(const asset_update_operation& o)
 { try {
@@ -593,7 +593,7 @@ void_result asset_update_evaluator::do_evaluate(const asset_update_operation& o)
       d.get(id);
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW((o)) }
+} FC_CAPTURE_AND_RETHROW((o)) } // GCOVR_EXCL_LINE
 
 void_result asset_update_evaluator::do_apply(const asset_update_operation& o)
 { try {
@@ -655,7 +655,7 @@ void_result asset_update_evaluator::do_apply(const asset_update_operation& o)
    });
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 void_result asset_update_issuer_evaluator::do_evaluate(const asset_update_issuer_operation& o)
 { try {
@@ -671,7 +671,7 @@ void_result asset_update_issuer_evaluator::do_evaluate(const asset_update_issuer
               ("o.issuer", o.issuer)("a.issuer", a.issuer) );
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW((o)) }
+} FC_CAPTURE_AND_RETHROW((o)) } // GCOVR_EXCL_LINE
 
 void_result asset_update_issuer_evaluator::do_apply(const asset_update_issuer_operation& o)
 { try {
@@ -681,7 +681,7 @@ void_result asset_update_issuer_evaluator::do_apply(const asset_update_issuer_op
    });
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 /****************
  * Loop through assets, looking for ones that are backed by the asset being changed. When found,
@@ -887,7 +887,7 @@ void_result asset_update_bitasset_evaluator::do_evaluate(const asset_update_bita
    asset_to_update = &asset_obj;
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 /*******
  * @brief Apply requested changes to bitasset options
@@ -1042,7 +1042,7 @@ void_result asset_update_bitasset_evaluator::do_apply(const asset_update_bitasse
 
       return void_result();
 
-   } FC_CAPTURE_AND_RETHROW( (op) )
+   } FC_CAPTURE_AND_RETHROW( (op) ) // GCOVR_EXCL_LINE
 }
 
 void_result asset_update_feed_producers_evaluator::do_evaluate(const asset_update_feed_producers_operation& o)
@@ -1067,7 +1067,7 @@ void_result asset_update_feed_producers_evaluator::do_evaluate(const asset_updat
       d.get(id);
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 void_result asset_update_feed_producers_evaluator::do_apply(const asset_update_feed_producers_operation& o) const
 { try {
@@ -1105,7 +1105,7 @@ void_result asset_update_feed_producers_evaluator::do_apply(const asset_update_f
    d.check_call_orders( *asset_to_update, true, false, &bitasset_to_update );
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 void_result asset_global_settle_evaluator::do_evaluate(const asset_global_settle_evaluator::operation_type& op)
 { try {
@@ -1133,14 +1133,14 @@ void_result asset_global_settle_evaluator::do_evaluate(const asset_global_settle
    }
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 void_result asset_global_settle_evaluator::do_apply(const asset_global_settle_evaluator::operation_type& op)
 { try {
    database& d = db();
    d.globally_settle_asset( *asset_to_settle, op.settle_price );
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 void_result asset_settle_evaluator::do_evaluate(const asset_settle_evaluator::operation_type& op)
 { try {
@@ -1191,7 +1191,7 @@ void_result asset_settle_evaluator::do_evaluate(const asset_settle_evaluator::op
    bitasset_ptr = &bitasset;
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 static optional<asset> pay_collateral_fees( database& d,
                                             const asset& pays,
@@ -1214,7 +1214,7 @@ static optional<asset> pay_collateral_fees( database& d,
             asset_to_settle.accumulate_fee( d, collateral_fees );
             return collateral_fees;
          }
-      } FC_CAPTURE_AND_LOG( (pays)(settled_amount)(fill_price) ) // Catch and log the exception
+      } FC_CAPTURE_AND_LOG( (pays)(settled_amount)(fill_price) ) // Catch and log the exception // GCOVR_EXCL_LINE
    }
    return optional<asset>();
 }
@@ -1409,7 +1409,7 @@ operation_result asset_settle_evaluator::do_apply(const asset_settle_evaluator::
 
    return result;
 
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 void_result asset_publish_feeds_evaluator::do_evaluate(const asset_publish_feed_operation& o)
 { try {
@@ -1471,7 +1471,7 @@ void_result asset_publish_feeds_evaluator::do_evaluate(const asset_publish_feed_
    bitasset_ptr = &bitasset;
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW((o)) }
+} FC_CAPTURE_AND_RETHROW((o)) } // GCOVR_EXCL_LINE
 
 void_result asset_publish_feeds_evaluator::do_apply(const asset_publish_feed_operation& o)
 { try {
@@ -1534,7 +1534,7 @@ void_result asset_publish_feeds_evaluator::do_apply(const asset_publish_feed_ope
    d.check_call_orders( base, true, false, bitasset_ptr );
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW((o)) }
+} FC_CAPTURE_AND_RETHROW((o)) } // GCOVR_EXCL_LINE
 
 
 /***
@@ -1579,7 +1579,7 @@ void_result asset_claim_fees_evaluator::do_evaluate( const asset_claim_fees_oper
    }
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 
 /***
@@ -1602,7 +1602,7 @@ void_result asset_claim_fees_evaluator::do_apply( const asset_claim_fees_operati
    d.adjust_balance( o.issuer, o.amount_to_claim );
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 
 void_result asset_claim_pool_evaluator::do_evaluate( const asset_claim_pool_operation& o )
@@ -1610,7 +1610,7 @@ void_result asset_claim_pool_evaluator::do_evaluate( const asset_claim_pool_oper
     FC_ASSERT( o.asset_id(db()).issuer == o.issuer, "Asset fee pool may only be claimed by the issuer" );
 
     return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 void_result asset_claim_pool_evaluator::do_apply( const asset_claim_pool_operation& o )
 { try {
@@ -1627,7 +1627,7 @@ void_result asset_claim_pool_evaluator::do_apply( const asset_claim_pool_operati
     d.adjust_balance( o.issuer, o.amount_to_claim );
 
     return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 
 } } // graphene::chain

--- a/libraries/chain/credit_offer_evaluator.cpp
+++ b/libraries/chain/credit_offer_evaluator.cpp
@@ -66,7 +66,7 @@ void_result credit_offer_create_evaluator::do_evaluate(const credit_offer_create
               "The account is unauthorized by the asset" );
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 object_id_type credit_offer_create_evaluator::do_apply(const credit_offer_create_operation& op) const
 { try {
@@ -88,7 +88,7 @@ object_id_type credit_offer_create_evaluator::do_apply(const credit_offer_create
       obj.acceptable_borrowers = op.acceptable_borrowers;
    });
    return new_credit_offer_object.id;
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 void_result credit_offer_delete_evaluator::do_evaluate(const credit_offer_delete_operation& op)
 { try {
@@ -104,7 +104,7 @@ void_result credit_offer_delete_evaluator::do_evaluate(const credit_offer_delete
    // Note: no asset authorization check here, allow funds to be moved to account balance
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 asset credit_offer_delete_evaluator::do_apply(const credit_offer_delete_operation& op) const
 { try {
@@ -120,7 +120,7 @@ asset credit_offer_delete_evaluator::do_apply(const credit_offer_delete_operatio
    d.remove( *_offer );
 
    return released;
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 void_result credit_offer_update_evaluator::do_evaluate(const credit_offer_update_operation& op)
 { try {
@@ -180,7 +180,7 @@ void_result credit_offer_update_evaluator::do_evaluate(const credit_offer_update
    }
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 void_result credit_offer_update_evaluator::do_apply( const credit_offer_update_operation& op) const
 { try {
@@ -224,7 +224,7 @@ void_result credit_offer_update_evaluator::do_apply( const credit_offer_update_o
    }
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 void_result credit_offer_accept_evaluator::do_evaluate(const credit_offer_accept_operation& op)
 { try {
@@ -304,7 +304,7 @@ void_result credit_offer_accept_evaluator::do_evaluate(const credit_offer_accept
    }
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 extendable_operation_result credit_offer_accept_evaluator::do_apply( const credit_offer_accept_operation& op) const
 { try {
@@ -368,7 +368,7 @@ extendable_operation_result credit_offer_accept_evaluator::do_apply( const credi
    result.value.impacted_accounts = flat_set<account_id_type>({ _offer->owner_account });
 
    return result;
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 void_result credit_deal_repay_evaluator::do_evaluate(const credit_deal_repay_operation& op)
 { try {
@@ -400,7 +400,7 @@ void_result credit_deal_repay_evaluator::do_evaluate(const credit_deal_repay_ope
               "The owner of the credit offer is unauthorized by the repaying asset" );
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 extendable_operation_result credit_deal_repay_evaluator::do_apply( const credit_deal_repay_operation& op) const
 { try {
@@ -470,10 +470,10 @@ extendable_operation_result credit_deal_repay_evaluator::do_apply( const credit_
    result.value.received = vector<asset>({ collateral_released });
 
    return result;
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 void_result credit_deal_update_evaluator::do_evaluate(const credit_deal_update_operation& op)
-{
+{ try {
    const database& d = db();
    const auto block_time = d.head_block_time();
 
@@ -486,10 +486,10 @@ void_result credit_deal_update_evaluator::do_evaluate(const credit_deal_update_o
    FC_ASSERT( _deal->auto_repay != op.auto_repay, "The automatic repayment type does not change" );
 
    return void_result();
-}
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 void_result credit_deal_update_evaluator::do_apply( const credit_deal_update_operation& op) const
-{
+{ try {
    database& d = db();
 
    d.modify( *_deal, [&op]( credit_deal_object& obj ){
@@ -497,6 +497,6 @@ void_result credit_deal_update_evaluator::do_apply( const credit_deal_update_ope
    });
 
    return void_result();
-}
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 } } // graphene::chain

--- a/libraries/chain/db_block.cpp
+++ b/libraries/chain/db_block.cpp
@@ -63,7 +63,7 @@ bool database::is_known_transaction( const transaction_id_type& id )const
 block_id_type  database::get_block_id_for_num( uint32_t block_num )const
 { try {
    return _block_id_to_block.fetch_block_id( block_num );
-} FC_CAPTURE_AND_RETHROW( (block_num) ) }
+} FC_CAPTURE_AND_RETHROW( (block_num) ) } // GCOVR_EXCL_LINE
 
 optional<signed_block> database::fetch_block_by_id( const block_id_type& id )const
 {
@@ -92,7 +92,8 @@ const signed_transaction& database::get_recent_transaction(const transaction_id_
 
 std::vector<block_id_type> database::get_block_ids_on_fork(block_id_type head_of_fork) const
 {
-  pair<fork_database::branch_type, fork_database::branch_type> branches = _fork_db.fetch_branch_from(head_block_id(), head_of_fork);
+  pair<fork_database::branch_type, fork_database::branch_type> branches
+        = _fork_db.fetch_branch_from(head_block_id(), head_of_fork);
   if( !((branches.first.back()->previous_id() == branches.second.back()->previous_id())) )
   {
      edump( (head_of_fork)
@@ -180,7 +181,8 @@ bool database::_push_block(const signed_block& new_block)
                   // remove the rest of branches.first from the fork_db, those blocks are invalid
                   while( ritr != branches.first.rend() )
                   {
-                     ilog( "removing block from fork_db #${n} ${id}", ("n",(*ritr)->data.block_num())("id",(*ritr)->id) );
+                     ilog( "removing block from fork_db #${n} ${id}",
+                           ("n",(*ritr)->data.block_num())("id",(*ritr)->id) );
                      _fork_db.remove( (*ritr)->id );
                      ++ritr;
                   }
@@ -225,7 +227,7 @@ bool database::_push_block(const signed_block& new_block)
    }
 
    return false;
-} FC_CAPTURE_AND_RETHROW( (new_block) ) }
+} FC_CAPTURE_AND_RETHROW( (new_block) ) } // GCOVR_EXCL_LINE
 
 void database::verify_signing_witness( const signed_block& new_block, const fork_item& fork_entry )const
 {
@@ -275,7 +277,7 @@ processed_transaction database::push_transaction( const precomputable_transactio
       result = _push_transaction( trx );
    } );
    return result;
-} FC_CAPTURE_AND_RETHROW( (trx) ) }
+} FC_CAPTURE_AND_RETHROW( (trx) ) } // GCOVR_EXCL_LINE
 
 processed_transaction database::_push_transaction( const precomputable_transaction& trx )
 {
@@ -313,7 +315,8 @@ public:
    push_proposal_nesting_guard( uint32_t& nesting_counter, const database& db )
       : orig_value(nesting_counter), counter(nesting_counter)
    {
-      FC_ASSERT( counter < db.get_global_properties().active_witnesses.size() * 2, "Max proposal nesting depth exceeded!" );
+      FC_ASSERT( counter < db.get_global_properties().active_witnesses.size() * 2,
+                 "Max proposal nesting depth exceeded!" );
       counter++;
    }
    ~push_proposal_nesting_guard()
@@ -370,7 +373,7 @@ processed_transaction database::push_proposal(const proposal_object& proposal)
 
    ptrx.operation_results = std::move(eval_state.operation_results);
    return ptrx;
-} FC_CAPTURE_AND_RETHROW( (proposal) ) }
+} FC_CAPTURE_AND_RETHROW( (proposal) ) } // GCOVR_EXCL_LINE
 
 signed_block database::generate_block(
    fc::time_point_sec when,
@@ -385,7 +388,7 @@ signed_block database::generate_block(
       result = _generate_block( when, witness_id, block_signing_private_key );
    } );
    return result;
-} FC_CAPTURE_AND_RETHROW() }
+} FC_CAPTURE_AND_RETHROW() } // GCOVR_EXCL_LINE
 
 signed_block database::_generate_block(
    fc::time_point_sec when,
@@ -426,9 +429,10 @@ signed_block database::_generate_block(
       FC_ASSERT( witness_id(*this).signing_key == block_signing_private_key.get_public_key() );
    }
 
-   static const size_t max_partial_block_header_size = fc::raw::pack_size( signed_block_header() )
-                                                       - fc::raw::pack_size( witness_id_type() ) // witness_id
-                                                       + 3; // max space to store size of transactions (out of block header),
+   static const size_t max_partial_block_header_size = ( fc::raw::pack_size( signed_block_header() )
+                                                       - fc::raw::pack_size( witness_id_type() ) ) // witness_id
+                                                       + 3; // max space to store size of transactions
+                                                            // (out of block header),
                                                             // +3 means 3*7=21 bits so it's practically safe
    const size_t max_block_header_size = max_partial_block_header_size + fc::raw::pack_size( witness_id );
    auto maximum_block_size = get_global_properties().parameters.maximum_block_size;
@@ -502,10 +506,11 @@ signed_block database::_generate_block(
    if( 0 == (skip & skip_witness_signature) )
       pending_block.sign( block_signing_private_key );
 
-   push_block( pending_block, skip | skip_transaction_signatures ); // skip authority check when pushing self-generated blocks
+   push_block( pending_block, skip | skip_transaction_signatures ); // skip authority check when pushing
+                                                                    // self-generated blocks
 
    return pending_block;
-} FC_CAPTURE_AND_RETHROW( (witness_id) ) }
+} FC_CAPTURE_AND_RETHROW( (witness_id) ) } // GCOVR_EXCL_LINE
 
 /**
  * Removes the most recent block from the database and
@@ -524,15 +529,17 @@ void database::pop_block()
       FC_ASSERT( fork_db_head, "Trying to pop() block that's not in fork database!?" );
    }
    pop_undo();
-   _popped_tx.insert( _popped_tx.begin(), fork_db_head->data.transactions.begin(), fork_db_head->data.transactions.end() );
-} FC_CAPTURE_AND_RETHROW() }
+   _popped_tx.insert( _popped_tx.begin(),
+                      fork_db_head->data.transactions.begin(),
+                      fork_db_head->data.transactions.end() );
+} FC_CAPTURE_AND_RETHROW() } // GCOVR_EXCL_LINE
 
 void database::clear_pending()
 { try {
    assert( (_pending_tx.size() == 0) || _pending_tx_session.valid() );
    _pending_tx.clear();
    _pending_tx_session.reset();
-} FC_CAPTURE_AND_RETHROW() }
+} FC_CAPTURE_AND_RETHROW() } // GCOVR_EXCL_LINE
 
 uint32_t database::push_applied_operation( const operation& op, bool is_virtual /* = true */ )
 {
@@ -667,7 +674,7 @@ void database::_apply_block( const signed_block& next_block )
    _applied_ops.clear();
 
    notify_changed_objects();
-} FC_CAPTURE_AND_RETHROW( (next_block.block_num()) )  }
+} FC_CAPTURE_AND_RETHROW( (next_block.block_num()) )  } // GCOVR_EXCL_LINE
 
 /**
  * @note if a @c processed_transaction is passed in, it is cast into @c signed_transaction here.
@@ -768,7 +775,7 @@ processed_transaction database::_apply_transaction(const signed_transaction& trx
               "Unpaid SameT Fund debt detected" );
 
    return ptrx;
-} FC_CAPTURE_AND_RETHROW( (trx) ) }
+} FC_CAPTURE_AND_RETHROW( (trx) ) } // GCOVR_EXCL_LINE
 
 operation_result database::apply_operation( transaction_evaluation_state& eval_state, const operation& op,
                                             bool is_virtual /* = true */ )
@@ -783,7 +790,7 @@ operation_result database::apply_operation( transaction_evaluation_state& eval_s
    auto result = eval->evaluate( eval_state, op, true );
    set_applied_operation_result( op_id, result );
    return result;
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 operation_result database::try_push_virtual_operation( transaction_evaluation_state& eval_state, const operation& op )
 {
@@ -886,7 +893,8 @@ fc::future<void> database::precompute_parallel( const signed_block& block, const
          for( size_t base = 0; base < block.transactions.size(); base += chunk_size )
             workers.push_back( fc::do_parallel( [this,&block,base,chunk_size,skip] () {
                _precompute_parallel( &block.transactions[base],
-                                     base + chunk_size < block.transactions.size() ? chunk_size : block.transactions.size() - base,
+                                     ( ( base + chunk_size ) < block.transactions.size() ) ? chunk_size
+                                                 : ( block.transactions.size() - base ),
                                      skip );
             }) );
       }

--- a/libraries/chain/db_maint.cpp
+++ b/libraries/chain/db_maint.cpp
@@ -305,7 +305,7 @@ void database::update_active_witnesses()
       });
    });
 
-} FC_CAPTURE_AND_RETHROW() }
+} FC_CAPTURE_AND_RETHROW() } // GCOVR_EXCL_LINE
 
 void database::update_active_committee_members()
 { try {
@@ -412,7 +412,7 @@ void database::update_active_committee_members()
                      std::inserter(gp.active_committee_members, gp.active_committee_members.begin()),
                      [](const committee_member_object& d) { return d.get_id(); });
    });
-} FC_CAPTURE_AND_RETHROW() }
+} FC_CAPTURE_AND_RETHROW() } // GCOVR_EXCL_LINE
 
 void database::initialize_budget_record( fc::time_point_sec now, budget_record& rec )const
 {
@@ -564,7 +564,7 @@ void database::process_budget()
       // available_funds is money we could spend, but don't want to.
       // we simply let it evaporate back into the reserve.
    }
-   FC_CAPTURE_AND_RETHROW()
+   FC_CAPTURE_AND_RETHROW() // GCOVR_EXCL_LINE
 }
 
 template< typename Visitor >

--- a/libraries/chain/db_market.cpp
+++ b/libraries/chain/db_market.cpp
@@ -335,7 +335,7 @@ void database::globally_settle_asset_impl( const asset_object& mia,
       obj.settlement_fund  = collateral_gathered.amount;
    });
 
-} FC_CAPTURE_AND_RETHROW( (mia)(settlement_price) ) }
+} FC_CAPTURE_AND_RETHROW( (mia)(settlement_price) ) } // GCOVR_EXCL_LINE
 
 void database::individually_settle( const asset_bitasset_data_object& bitasset, const call_order_object& order )
 {
@@ -448,7 +448,7 @@ void database::revive_bitasset( const asset_object& bitasset, const asset_bitass
       FC_ASSERT( bad.settlement_fund == 0 );
 
    _cancel_bids_and_revive_mpa( bitasset, bad );
-} FC_CAPTURE_AND_RETHROW( (bitasset) ) }
+} FC_CAPTURE_AND_RETHROW( (bitasset) ) } // GCOVR_EXCL_LINE
 
 void database::_cancel_bids_and_revive_mpa( const asset_object& bitasset, const asset_bitasset_data_object& bad )
 { try {
@@ -472,7 +472,7 @@ void database::_cancel_bids_and_revive_mpa( const asset_object& bitasset, const 
               obj.settlement_price = price();
               obj.settlement_fund = 0;
            });
-} FC_CAPTURE_AND_RETHROW( (bitasset) ) }
+} FC_CAPTURE_AND_RETHROW( (bitasset) ) } // GCOVR_EXCL_LINE
 
 void database::cancel_bid(const collateral_bid_object& bid, bool create_virtual_op)
 {
@@ -1619,7 +1619,8 @@ asset database::match_impl( const force_settlement_object& settle,
       cancel_settle_order( settle );
 
    return call_receives;
-} FC_CAPTURE_AND_RETHROW( (p_match_price)(max_settlement)(p_fill_price)(is_margin_call)(settle_is_taker) ) }
+} FC_CAPTURE_AND_RETHROW( (p_match_price)(max_settlement)(p_fill_price) // GCOVR_EXCL_LINE
+                          (is_margin_call)(settle_is_taker) ) } // GCOVR_EXCL_LINE
 
 bool database::fill_limit_order( const limit_order_object& order, const asset& pays, const asset& receives,
                                  bool cull_if_small, const price& fill_price, const bool is_maker)
@@ -1725,7 +1726,7 @@ bool database::fill_limit_order( const limit_order_object& order, const asset& p
          return maybe_cull_small_order( *this, order );
       return false;
    }
-} FC_CAPTURE_AND_RETHROW( (pays)(receives) ) }
+} FC_CAPTURE_AND_RETHROW( (pays)(receives) ) } // GCOVR_EXCL_LINE
 
 /***
  * @brief fill a call order in the specified amounts
@@ -1808,7 +1809,7 @@ bool database::fill_call_order( const call_order_object& order, const asset& pay
       remove( order );
 
    return collateral_freed.valid();
-} FC_CAPTURE_AND_RETHROW( (pays)(receives) ) }
+} FC_CAPTURE_AND_RETHROW( (pays)(receives) ) } // GCOVR_EXCL_LINE
 
 /***
  * @brief fullfill a settle order in the specified amounts
@@ -1881,7 +1882,7 @@ bool database::fill_settle_order( const force_settlement_object& settle, const a
 
    return filled;
 
-} FC_CAPTURE_AND_RETHROW( (pays)(receives) ) }
+} FC_CAPTURE_AND_RETHROW( (pays)(receives) ) } // GCOVR_EXCL_LINE
 
 /**
  *  Starting with the least collateralized orders, fill them if their
@@ -2254,7 +2255,7 @@ bool database::check_call_orders( const asset_object& mia, bool enable_black_swa
    } // while there exists a call order
    check_settled_debt_order( bitasset );
    return margin_called;
-} FC_CAPTURE_AND_RETHROW() }
+} FC_CAPTURE_AND_RETHROW() } // GCOVR_EXCL_LINE
 
 bool database::match_force_settlements( const asset_bitasset_data_object& bitasset )
 {

--- a/libraries/chain/db_notify.cpp
+++ b/libraries/chain/db_notify.cpp
@@ -656,6 +656,6 @@ void database::notify_changed_objects()
 } catch( const graphene::chain::plugin_exception& e ) {
    elog( "Caught plugin exception: ${e}", ("e", e.to_detail_string() ) );
    throw;
-} FC_CAPTURE_AND_LOG( (0) ) }
+} FC_CAPTURE_AND_LOG( (0) ) } // GCOVR_EXCL_LINE
 
 } } // namespace graphene::chain

--- a/libraries/chain/db_update.cpp
+++ b/libraries/chain/db_update.cpp
@@ -150,7 +150,7 @@ void database::clear_expired_transactions()
    const auto& dedupe_index = transaction_idx.indices().get<by_expiration>();
    while( (!dedupe_index.empty()) && (head_block_time() > dedupe_index.begin()->trx.expiration) )
       transaction_idx.remove(*dedupe_index.begin());
-} FC_CAPTURE_AND_RETHROW() }
+} FC_CAPTURE_AND_RETHROW() } // GCOVR_EXCL_LINE
 
 void database::clear_expired_proposals()
 {
@@ -344,7 +344,7 @@ void database::clear_expired_orders()
                check_call_orders( quote_asset( *this ) );
             }
          }
-} FC_CAPTURE_AND_RETHROW() }
+} FC_CAPTURE_AND_RETHROW() } // GCOVR_EXCL_LINE
 
 void database::clear_expired_force_settlements()
 { try {
@@ -526,7 +526,7 @@ void database::clear_expired_force_settlements()
          });
       }
    }
-} FC_CAPTURE_AND_RETHROW() }
+} FC_CAPTURE_AND_RETHROW() } // GCOVR_EXCL_LINE
 
 void database::update_expired_feeds()
 {

--- a/libraries/chain/include/graphene/chain/asset_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/asset_evaluator.hpp
@@ -36,13 +36,13 @@ namespace graphene { namespace chain {
       public:
          using operation_type = asset_create_operation;
 
-         void_result do_evaluate( const asset_create_operation& o );
-         object_id_type do_apply( const asset_create_operation& o );
+         void_result do_evaluate( const asset_create_operation& o ) const;
+         object_id_type do_apply( const asset_create_operation& o ) const;
 
          /** override the default behavior defined by generic_evalautor which is to
           * post the fee to fee_paying_account_stats.pending_fees
           */
-         virtual void pay_fee() override;
+         void pay_fee() override;
       private:
          bool fee_is_odd;
    };
@@ -52,8 +52,9 @@ namespace graphene { namespace chain {
       public:
          using operation_type = asset_issue_operation;
          void_result do_evaluate( const asset_issue_operation& o );
-         void_result do_apply( const asset_issue_operation& o );
+         void_result do_apply( const asset_issue_operation& o ) const;
 
+      private:
          const asset_dynamic_data_object* asset_dyn_data = nullptr;
          const account_object*            to_account = nullptr;
    };
@@ -63,8 +64,9 @@ namespace graphene { namespace chain {
       public:
          using operation_type = asset_reserve_operation;
          void_result do_evaluate( const asset_reserve_operation& o );
-         void_result do_apply( const asset_reserve_operation& o );
+         void_result do_apply( const asset_reserve_operation& o ) const;
 
+      private:
          const asset_dynamic_data_object* asset_dyn_data = nullptr;
          const account_object*            from_account = nullptr;
    };
@@ -78,6 +80,7 @@ namespace graphene { namespace chain {
          void_result do_evaluate( const asset_update_operation& o );
          void_result do_apply( const asset_update_operation& o );
 
+      private:
          const asset_object* asset_to_update = nullptr;
          const asset_bitasset_data_object* bitasset_data = nullptr;
    };
@@ -90,6 +93,7 @@ namespace graphene { namespace chain {
          void_result do_evaluate( const asset_update_issuer_operation& o );
          void_result do_apply( const asset_update_issuer_operation& o );
 
+      private:
          const asset_object* asset_to_update = nullptr;
    };
 
@@ -116,6 +120,7 @@ namespace graphene { namespace chain {
          void_result do_evaluate( const operation_type& o );
          void_result do_apply( const operation_type& o ) const;
 
+      private:
          const asset_object* asset_to_update = nullptr;
    };
 
@@ -125,8 +130,9 @@ namespace graphene { namespace chain {
          using operation_type = asset_fund_fee_pool_operation;
 
          void_result do_evaluate(const asset_fund_fee_pool_operation& op);
-         void_result do_apply(const asset_fund_fee_pool_operation& op);
+         void_result do_apply(const asset_fund_fee_pool_operation& op) const;
 
+      private:
          const asset_dynamic_data_object* asset_dyn_data = nullptr;
    };
 
@@ -138,6 +144,7 @@ namespace graphene { namespace chain {
          void_result do_evaluate(const operation_type& op);
          void_result do_apply(const operation_type& op);
 
+      private:
          const asset_object* asset_to_settle = nullptr;
    };
    class asset_settle_evaluator : public evaluator<asset_settle_evaluator>
@@ -174,6 +181,7 @@ namespace graphene { namespace chain {
          void_result do_evaluate( const asset_claim_fees_operation& o );
          void_result do_apply( const asset_claim_fees_operation& o );
 
+      private:
          const asset_object* container_asset = nullptr;
          const asset_dynamic_data_object* container_ddo = nullptr;
    };

--- a/libraries/chain/include/graphene/chain/liquidity_pool_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/liquidity_pool_evaluator.hpp
@@ -35,22 +35,24 @@ namespace graphene { namespace chain {
    class liquidity_pool_create_evaluator : public evaluator<liquidity_pool_create_evaluator>
    {
       public:
-         typedef liquidity_pool_create_operation operation_type;
+         using operation_type = liquidity_pool_create_operation;
 
          void_result do_evaluate( const liquidity_pool_create_operation& op );
          generic_operation_result do_apply( const liquidity_pool_create_operation& op );
 
+      private:
          const asset_object* _share_asset = nullptr;
    };
 
    class liquidity_pool_delete_evaluator : public evaluator<liquidity_pool_delete_evaluator>
    {
       public:
-         typedef liquidity_pool_delete_operation operation_type;
+         using operation_type = liquidity_pool_delete_operation;
 
          void_result do_evaluate( const liquidity_pool_delete_operation& op );
-         generic_operation_result do_apply( const liquidity_pool_delete_operation& op );
+         generic_operation_result do_apply( const liquidity_pool_delete_operation& op ) const;
 
+      private:
          const liquidity_pool_object* _pool = nullptr;
          const asset_object* _share_asset = nullptr;
    };
@@ -63,17 +65,19 @@ namespace graphene { namespace chain {
          void_result do_evaluate( const liquidity_pool_update_operation& op );
          void_result do_apply( const liquidity_pool_update_operation& op ) const;
 
+      private:
          const liquidity_pool_object* _pool = nullptr;
    };
 
    class liquidity_pool_deposit_evaluator : public evaluator<liquidity_pool_deposit_evaluator>
    {
       public:
-         typedef liquidity_pool_deposit_operation operation_type;
+         using operation_type = liquidity_pool_deposit_operation;
 
          void_result do_evaluate( const liquidity_pool_deposit_operation& op );
          generic_exchange_operation_result do_apply( const liquidity_pool_deposit_operation& op );
 
+      private:
          const liquidity_pool_object* _pool = nullptr;
          const asset_dynamic_data_object* _share_asset_dyn_data = nullptr;
          asset _account_receives;
@@ -84,11 +88,12 @@ namespace graphene { namespace chain {
    class liquidity_pool_withdraw_evaluator : public evaluator<liquidity_pool_withdraw_evaluator>
    {
       public:
-         typedef liquidity_pool_withdraw_operation operation_type;
+         using operation_type = liquidity_pool_withdraw_operation;
 
          void_result do_evaluate( const liquidity_pool_withdraw_operation& op );
          generic_exchange_operation_result do_apply( const liquidity_pool_withdraw_operation& op );
 
+      private:
          const liquidity_pool_object* _pool = nullptr;
          const asset_dynamic_data_object* _share_asset_dyn_data = nullptr;
          asset _pool_pays_a;
@@ -100,11 +105,12 @@ namespace graphene { namespace chain {
    class liquidity_pool_exchange_evaluator : public evaluator<liquidity_pool_exchange_evaluator>
    {
       public:
-         typedef liquidity_pool_exchange_operation operation_type;
+         using operation_type = liquidity_pool_exchange_operation;
 
          void_result do_evaluate( const liquidity_pool_exchange_operation& op );
          generic_exchange_operation_result do_apply( const liquidity_pool_exchange_operation& op );
 
+      private:
          const liquidity_pool_object* _pool = nullptr;
          const asset_object* _pool_pays_asset = nullptr;
          const asset_object* _pool_receives_asset = nullptr;

--- a/libraries/chain/liquidity_pool_evaluator.cpp
+++ b/libraries/chain/liquidity_pool_evaluator.cpp
@@ -59,7 +59,7 @@ void_result liquidity_pool_create_evaluator::do_evaluate(const liquidity_pool_cr
               "Current supply of the share asset needs to be zero" );
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 generic_operation_result liquidity_pool_create_evaluator::do_apply(const liquidity_pool_create_operation& op)
 { try {
@@ -81,7 +81,7 @@ generic_operation_result liquidity_pool_create_evaluator::do_apply(const liquidi
    });
 
    return result;
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 void_result liquidity_pool_delete_evaluator::do_evaluate(const liquidity_pool_delete_operation& op)
 { try {
@@ -96,9 +96,9 @@ void_result liquidity_pool_delete_evaluator::do_evaluate(const liquidity_pool_de
    FC_ASSERT( _share_asset->issuer == op.account, "The account is not the owner of the liquidity pool" );
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
-generic_operation_result liquidity_pool_delete_evaluator::do_apply(const liquidity_pool_delete_operation& op)
+generic_operation_result liquidity_pool_delete_evaluator::do_apply(const liquidity_pool_delete_operation& op) const
 { try {
    database& d = db();
    generic_operation_result result;
@@ -112,7 +112,7 @@ generic_operation_result liquidity_pool_delete_evaluator::do_apply(const liquidi
    d.remove( *_pool );
 
    return result;
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 void_result liquidity_pool_update_evaluator::do_evaluate(const liquidity_pool_update_operation& op)
 { try {
@@ -136,7 +136,7 @@ void_result liquidity_pool_update_evaluator::do_evaluate(const liquidity_pool_up
    }
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 void_result liquidity_pool_update_evaluator::do_apply(const liquidity_pool_update_operation& op) const
 { try {
@@ -150,7 +150,7 @@ void_result liquidity_pool_update_evaluator::do_apply(const liquidity_pool_updat
    });
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 void_result liquidity_pool_deposit_evaluator::do_evaluate(const liquidity_pool_deposit_operation& op)
 { try {
@@ -219,7 +219,7 @@ void_result liquidity_pool_deposit_evaluator::do_evaluate(const liquidity_pool_d
    }
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 generic_exchange_operation_result liquidity_pool_deposit_evaluator::do_apply(
       const liquidity_pool_deposit_operation& op)
@@ -249,7 +249,7 @@ generic_exchange_operation_result liquidity_pool_deposit_evaluator::do_apply(
    result.received.emplace_back( _account_receives );
 
    return result;
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 void_result liquidity_pool_withdraw_evaluator::do_evaluate(const liquidity_pool_withdraw_operation& op)
 { try {
@@ -303,7 +303,7 @@ void_result liquidity_pool_withdraw_evaluator::do_evaluate(const liquidity_pool_
    }
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 generic_exchange_operation_result liquidity_pool_withdraw_evaluator::do_apply(
       const liquidity_pool_withdraw_operation& op)
@@ -338,7 +338,7 @@ generic_exchange_operation_result liquidity_pool_withdraw_evaluator::do_apply(
    result.fees.emplace_back( _fee_b );
 
    return result;
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 void_result liquidity_pool_exchange_evaluator::do_evaluate(const liquidity_pool_exchange_operation& op)
 { try {
@@ -436,7 +436,7 @@ void_result liquidity_pool_exchange_evaluator::do_evaluate(const liquidity_pool_
    _pool_taker_fee = asset( static_cast<int64_t>( pool_taker_fee ), op.min_to_receive.asset_id );
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 generic_exchange_operation_result liquidity_pool_exchange_evaluator::do_apply(
       const liquidity_pool_exchange_operation& op)
@@ -483,6 +483,6 @@ generic_exchange_operation_result liquidity_pool_exchange_evaluator::do_apply(
    result.fees.emplace_back( _pool_taker_fee );
 
    return result;
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 } } // graphene::chain

--- a/libraries/chain/market_evaluator.cpp
+++ b/libraries/chain/market_evaluator.cpp
@@ -75,7 +75,7 @@ void_result limit_order_create_evaluator::do_evaluate(const limit_order_create_o
                     ("balance",d.get_balance(*_seller,*_sell_asset))("amount_to_sell",op.amount_to_sell) );
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 void limit_order_create_evaluator::convert_fee()
 {
@@ -133,7 +133,7 @@ object_id_type limit_order_create_evaluator::do_apply(const limit_order_create_o
                     ("op",op) );
 
    return order_id;
-} FC_CAPTURE_AND_RETHROW( (op) ) }
+} FC_CAPTURE_AND_RETHROW( (op) ) } // GCOVR_EXCL_LINE
 
 void limit_order_update_evaluator::convert_fee()
 {
@@ -153,7 +153,7 @@ void limit_order_update_evaluator::pay_fee()
 }
 
 void_result limit_order_update_evaluator::do_evaluate(const limit_order_update_operation& o)
-{
+{ try {
    const database& d = db();
    FC_ASSERT( HARDFORK_CORE_1604_PASSED( d.head_block_time() ) , "Operation has not activated yet");
 
@@ -241,7 +241,7 @@ void_result limit_order_update_evaluator::do_evaluate(const limit_order_update_o
               "The account is not allowed to transact the receiving asset" );
 
    return {};
-}
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 void limit_order_update_evaluator::process_deferred_fee()
 {
@@ -328,7 +328,7 @@ void limit_order_update_evaluator::process_deferred_fee()
 }
 
 void_result limit_order_update_evaluator::do_apply(const limit_order_update_operation& o)
-{
+{ try {
    database& d = db();
 
    // Adjust account balance
@@ -363,7 +363,7 @@ void_result limit_order_update_evaluator::do_apply(const limit_order_update_oper
    d.apply_order(*_order);
 
    return {};
-}
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 void_result limit_order_cancel_evaluator::do_evaluate(const limit_order_cancel_operation& o)
 { try {
@@ -382,7 +382,7 @@ void_result limit_order_cancel_evaluator::do_evaluate(const limit_order_cancel_o
                     ("oid", o.order) );
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 asset limit_order_cancel_evaluator::do_apply(const limit_order_cancel_operation& o) const
 { try {
@@ -404,7 +404,7 @@ asset limit_order_cancel_evaluator::do_apply(const limit_order_cancel_operation&
    }
 
    return refunded;
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 void_result call_order_update_evaluator::do_evaluate(const call_order_update_operation& o)
 { try {
@@ -488,7 +488,7 @@ void_result call_order_update_evaluator::do_evaluate(const call_order_update_ope
    //       which is now removed since the check is implicitly done later by `adjust_balance()` in `do_apply()`.
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 
 object_id_type call_order_update_evaluator::do_apply(const call_order_update_operation& o)
@@ -696,7 +696,7 @@ object_id_type call_order_update_evaluator::do_apply(const call_order_update_ope
    }
 
    return call_order_id;
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 void_result bid_collateral_evaluator::do_evaluate(const bid_collateral_operation& o)
 { try {
@@ -758,7 +758,7 @@ void_result bid_collateral_evaluator::do_evaluate(const bid_collateral_operation
    }
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 
 void_result bid_collateral_evaluator::do_apply(const bid_collateral_operation& o) const
@@ -780,6 +780,6 @@ void_result bid_collateral_evaluator::do_apply(const bid_collateral_operation& o
    // Note: CORE asset in collateral_bid_object is not counted in account_stats.total_core_in_orders
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 } } // graphene::chain

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -431,7 +431,7 @@ void_result proposal_create_evaluator::do_evaluate( const proposal_create_operat
    _proposed_trx.validate();
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 object_id_type proposal_create_evaluator::do_apply( const proposal_create_operation& o )
 { try {
@@ -466,7 +466,7 @@ object_id_type proposal_create_evaluator::do_apply( const proposal_create_operat
    });
 
    return proposal.id;
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 void_result proposal_update_evaluator::do_evaluate( const proposal_update_operation& o )
 { try {
@@ -490,7 +490,7 @@ void_result proposal_update_evaluator::do_evaluate( const proposal_update_operat
    }
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 void_result proposal_update_evaluator::do_apply(const proposal_update_operation& o)
 { try {
@@ -527,14 +527,15 @@ void_result proposal_update_evaluator::do_apply(const proposal_update_operation&
          d.modify(*_proposal, [&e](proposal_object& p) {
             p.fail_reason = e.to_string(fc::log_level(fc::log_level::all));
          });
-         wlog("Proposed transaction ${id} failed to apply once approved with exception:\n----\n${reason}\n----\nWill try again when it expires.",
+         wlog("Proposed transaction ${id} failed to apply once approved with exception:\n"
+              "----\n${reason}\n----\nWill try again when it expires.",
               ("id", o.proposal)("reason", e.to_detail_string()));
          _proposal_failed = true;
       }
    }
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 void_result proposal_delete_evaluator::do_evaluate(const proposal_delete_operation& o)
 { try {
@@ -549,14 +550,14 @@ void_result proposal_delete_evaluator::do_evaluate(const proposal_delete_operati
               ("provided", o.fee_paying_account)("required", *required_approvals));
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 void_result proposal_delete_evaluator::do_apply(const proposal_delete_operation& o)
 { try {
    db().remove(*_proposal);
 
    return void_result();
-} FC_CAPTURE_AND_RETHROW( (o) ) }
+} FC_CAPTURE_AND_RETHROW( (o) ) } // GCOVR_EXCL_LINE
 
 
 } } // graphene::chain

--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -451,7 +451,7 @@ namespace graphene { namespace net { namespace detail {
           ilog( "p2p_network_connect_loop canceled" );
           throw;
         }
-        FC_CAPTURE_AND_LOG( (0) )
+        FC_CAPTURE_AND_LOG( (0) ) // GCOVR_EXCL_LINE
       }// while !canceled
     }
 
@@ -482,7 +482,7 @@ namespace graphene { namespace net { namespace detail {
          ilog( "update_seed_nodes_task canceled" );
          throw;
       }
-      FC_CAPTURE_AND_LOG( (_seed_nodes) )
+      FC_CAPTURE_AND_LOG( (_seed_nodes) ) // GCOVR_EXCL_LINE
 
       schedule_next_update_seed_nodes_task();
    }
@@ -4047,7 +4047,7 @@ namespace graphene { namespace net { namespace detail {
 
           // limit the rate at which we accept connections to mitigate DOS attacks
           fc::usleep( fc::milliseconds(10) );
-        } FC_CAPTURE_AND_LOG( (0) )
+        } FC_CAPTURE_AND_LOG( (0) ) // GCOVR_EXCL_LINE
       }
     } // accept_loop()
 
@@ -4476,7 +4476,7 @@ namespace graphene { namespace net { namespace detail {
             FC_THROW("Bad port: ${port}", ("port", port_string));
          }
       }
-      FC_CAPTURE_AND_RETHROW((in))
+      FC_CAPTURE_AND_RETHROW((in)) // GCOVR_EXCL_LINE
    }
 
    void node_impl::resolve_seed_node_and_add(const std::string& endpoint_string)

--- a/libraries/protocol/include/graphene/protocol/market.hpp
+++ b/libraries/protocol/include/graphene/protocol/market.hpp
@@ -190,7 +190,7 @@ namespace graphene { namespace protocol {
       void            validate()const { FC_ASSERT( !"virtual operation" ); }
 
       /// This is a virtual operation; there is no fee
-      share_type      calculate_fee(const fee_params_t& k)const { return 0; }
+      share_type      calculate_fee(const fee_params_t&)const { return 0; }
    };
 
    /**
@@ -237,7 +237,7 @@ namespace graphene { namespace protocol {
       void            validate()const { FC_ASSERT( !"virtual operation" ); }
 
       /// This is a virtual operation; there is no fee
-      share_type      calculate_fee(const fee_params_t& k)const { return 0; }
+      share_type      calculate_fee(const fee_params_t&)const { return 0; }
    };
 } } // graphene::protocol
 

--- a/libraries/protocol/market.cpp
+++ b/libraries/protocol/market.cpp
@@ -36,7 +36,7 @@ void limit_order_create_operation::validate()const
 }
 
 void limit_order_update_operation::validate() const
-{
+{ try {
    FC_ASSERT(fee.amount >= 0, "Fee must not be negative");
    FC_ASSERT(new_price || delta_amount_to_sell || new_expiration,
              "Cannot update limit order if nothing is specified to update");
@@ -44,7 +44,7 @@ void limit_order_update_operation::validate() const
       new_price->validate();
    if (delta_amount_to_sell)
       FC_ASSERT(delta_amount_to_sell->amount != 0, "Cannot change limit order amount by zero");
-}
+} FC_CAPTURE_AND_RETHROW((*this)) } // GCOVR_EXCL_LINE
 
 void limit_order_cancel_operation::validate()const
 {
@@ -59,13 +59,13 @@ void call_order_update_operation::validate()const
 
    // note: no validation is needed for extensions so far: the only attribute inside is target_collateral_ratio
 
-} FC_CAPTURE_AND_RETHROW((*this)) }
+} FC_CAPTURE_AND_RETHROW((*this)) } // GCOVR_EXCL_LINE
 
 void bid_collateral_operation::validate()const
 { try {
    FC_ASSERT( fee.amount >= 0 );
    FC_ASSERT( debt_covered.amount == 0 || (debt_covered.amount > 0 && additional_collateral.amount > 0) );
-} FC_CAPTURE_AND_RETHROW((*this)) }
+} FC_CAPTURE_AND_RETHROW((*this)) } // GCOVR_EXCL_LINE
 
 } } // graphene::protocol
 

--- a/libraries/utilities/elasticsearch.cpp
+++ b/libraries/utilities/elasticsearch.cpp
@@ -211,7 +211,7 @@ std::string es_client::get_version() const
 
    fc::variant content = fc::json::from_string( response.content );
    return content["version"]["number"].as_string();
-} FC_CAPTURE_LOG_AND_RETHROW( (base_url) ) }
+} FC_CAPTURE_LOG_AND_RETHROW( (base_url) ) } // GCOVR_EXCL_LINE
 
 void es_client::check_version_7_or_above( bool& result ) const noexcept
 {

--- a/tests/tests/fee_tests.cpp
+++ b/tests/tests/fee_tests.cpp
@@ -3928,6 +3928,14 @@ BOOST_AUTO_TEST_CASE( defaults_test )
     asset fee = schedule.calculate_fee( limit_order_create_operation() );
     BOOST_CHECK_EQUAL( (int64_t)default_order_fee.fee, fee.amount.value );
 
+    // fill_order fee is zero
+    fee = schedule.calculate_fee( fill_order_operation() );
+    BOOST_CHECK_EQUAL( (int64_t)0, fee.amount.value );
+
+    // execute_bid fee is zero
+    fee = schedule.calculate_fee( execute_bid_operation() );
+    BOOST_CHECK_EQUAL( (int64_t)0, fee.amount.value );
+
     limit_order_create_operation::fee_params_t new_order_fee; new_order_fee.fee = 123;
     // set fee + check
     schedule.parameters.insert( new_order_fee );
@@ -3951,6 +3959,15 @@ BOOST_AUTO_TEST_CASE( defaults_test )
     schedule.parameters.insert( new_bid_fee );
     fee = schedule.calculate_fee( bid_collateral_operation() );
     BOOST_CHECK_EQUAL( (int64_t)new_bid_fee.fee, fee.amount.value );
+
+    // fill_order fee is still zero
+    fee = schedule.calculate_fee( fill_order_operation() );
+    BOOST_CHECK_EQUAL( (int64_t)0, fee.amount.value );
+
+    // execute_bid fee is still zero
+    fee = schedule.calculate_fee( execute_bid_operation() );
+    BOOST_CHECK_EQUAL( (int64_t)0, fee.amount.value );
+
   }
   catch( const fc::exception& e )
   {


### PR DESCRIPTION
* Add `GCOVR_EXCL_LINE` markers to some `FC_CAPTURE_*` lines so that the code coverage reports make more sense.
  Note: the `GCOVR_EXCL_BR_LINE` marker would make even more sense for us, but it's added in `gcovr` version `6.0`, in our main CI environment (Ubuntu 20.04 LTS) the version of `gcovr` is `4.2` (see https://gcovr.com/en/6.0/guide/exclusion-markers.html and https://gcovr.com/en/5.2/guide/exclusion-markers.html).
* Make some unused function parameters unnamed, and add tests.
* Fix other code smells