### PR TITLE
Improve node networking stability and update dependency versions

### DIFF
--- a/.github/workflows/build-and-test.ubuntu-debug.yml
+++ b/.github/workflows/build-and-test.ubuntu-debug.yml
@@ -66,14 +66,14 @@ jobs:
         df -h .
         free
         mkdir -p _build
-        sudo mkdir -p /_build/libraries /_build/programs /_build/tests /mnt/_build
-        sudo chmod a+rwx /_build/libraries /_build/programs /_build/tests
+        sudo mkdir -p /_build/libraries /_build/programs /mnt/_build/tests
+        sudo chmod a+rwx /_build/libraries /_build/programs /mnt/_build/tests
         ln -s /_build/libraries _build/libraries
         ln -s /_build/programs _build/programs
-        ln -s /_build/tests _build/tests
+        ln -s /mnt/_build/tests _build/tests
         sudo ln -s /_build/libraries /mnt/_build/libraries
         sudo ln -s /_build/programs /mnt/_build/programs
-        sudo ln -s /_build/tests /mnt/_build/tests
+        sudo ln -s /mnt/_build/tests /_build/tests
         ls -al _build
         pushd _build
         export -n BOOST_ROOT BOOST_INCLUDEDIR BOOST_LIBRARYDIR

--- a/.github/workflows/build-and-test.ubuntu-debug.yml
+++ b/.github/workflows/build-and-test.ubuntu-debug.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     services:
       elasticsearch8:
-        image: elastic/elasticsearch:8.8.1
+        image: elastic/elasticsearch:8.9.1
         options: >-
           --env ES_JAVA_OPTS="-Xms512m -Xmx512m"
           --env discovery.type=single-node
@@ -22,7 +22,7 @@ jobs:
           --env cluster.routing.allocation.disk.threshold_enabled=false
           --publish 9200:9200
       elasticsearch7:
-        image: elastic/elasticsearch:7.17.10
+        image: elastic/elasticsearch:7.17.12
         options: >-
           --env ES_JAVA_OPTS="-Xms512m -Xmx512m"
           --env discovery.type=single-node

--- a/.github/workflows/build-and-test.ubuntu-release.yml
+++ b/.github/workflows/build-and-test.ubuntu-release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     services:
       elasticsearch8:
-        image: elastic/elasticsearch:8.8.1
+        image: elastic/elasticsearch:8.9.1
         options: >-
           --env ES_JAVA_OPTS="-Xms512m -Xmx512m"
           --env discovery.type=single-node
@@ -22,7 +22,7 @@ jobs:
           --env cluster.routing.allocation.disk.threshold_enabled=false
           --publish 9200:9200
       elasticsearch7:
-        image: elastic/elasticsearch:7.17.10
+        image: elastic/elasticsearch:7.17.12
         options: >-
           --env ES_JAVA_OPTS="-Xms512m -Xmx512m"
           --env discovery.type=single-node

--- a/.github/workflows/build-and-test.win.yml
+++ b/.github/workflows/build-and-test.win.yml
@@ -6,9 +6,9 @@ env:
   # The following are for windows cross-build only:
   BOOST_VERSION: 1_69_0
   BOOST_DOTTED_VERSION: 1.69.0
-  CURL_VERSION: 8.1.2
-  OPENSSL_VERSION: 1.1.1u
-  ZLIB_VERSION: 1.2.13
+  CURL_VERSION: 8.2.1
+  OPENSSL_VERSION: 1.1.1v
+  ZLIB_VERSION: 1.3
 jobs:
   prepare-mingw64-libs:
     name: Build required 3rd-party libraries

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     services:
       elasticsearch8:
-        image: elastic/elasticsearch:8.8.1
+        image: elastic/elasticsearch:8.9.1
         options: >-
           --env ES_JAVA_OPTS="-Xms512m -Xmx512m"
           --env discovery.type=single-node


### PR DESCRIPTION
* Update FC to include https://github.com/bitshares/bitshares-fc/pull/249 to improve node networking stability.
* Update dependency versions used in Github Actions
    - ElasticSearch 7: 7.17.10 -> 7.17.12
    - ElasticSearch 8: 8.8.1 -> 8.9.1
    - OpenSSL: 1.1.1u -> 1.1.1v
    - CURL: 8.1.2 -> 8.2.1
    - zlib: 1.2.13 -> 1.3