### PR TITLE
Set Mainnet 7.0 HF time to 2023-11-16 14:00:00 UTC

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -69,6 +69,7 @@ Jose Marcial Vieira Bisneto <marcial.vieirab@gmail.com>
 Jozef Knaperek <jknaperek@gmail.com>
 Ken Code <ken@BitShares-Munich.de>
 Krzysztof Szumny <krzysztof.szumny@stxnext.pl>
+Massimo Paladin <massimo.paladin@gmail.com>
 Paul Brossier <piem@piem.org>
 Roelandp <dnaleor@gmail.com>
 Semen Martynov <semen.martynov@gmail.com>
@@ -80,5 +81,6 @@ bitcube <root@seed.cubeconnex.com>
 hammadsherwani <83015346+hammadsherwani@users.noreply.github.com>
 lafona <lafona@protonmail.com>
 liondani <liondani@gmx.com>
+litepresence <finitestate@tutamail.com>
 lososeg <ya.lososeg@gmail.com>
 sinetek <pitwuu@gmail.com>

--- a/libraries/chain/hardfork.d/CORE_1604.hf
+++ b/libraries/chain/hardfork.d/CORE_1604.hf
@@ -1,5 +1,5 @@
 // bitshares-core issue #1604 Operation to modify existing limit order
 #ifndef HARDFORK_CORE_1604_TIME
-#define HARDFORK_CORE_1604_TIME (fc::time_point_sec(1893456000)) // Jan 1 00:00:00 2030 (Not yet scheduled)
+#define HARDFORK_CORE_1604_TIME (fc::time_point_sec( 1700143200 )) // Thursday, November 16, 2023 14:00:00 UTC
 #define HARDFORK_CORE_1604_PASSED(head_block_time) (head_block_time >= HARDFORK_CORE_1604_TIME)
 #endif

--- a/libraries/chain/hardfork.d/CORE_2535.hf
+++ b/libraries/chain/hardfork.d/CORE_2535.hf
@@ -1,6 +1,5 @@
 // bitshares-core issue #2535 Simple Order-Sends-Order (OSO)
 #ifndef HARDFORK_CORE_2535_TIME
-// Jan 1 2030, midnight; this is a dummy date until a hardfork date is scheduled
-#define HARDFORK_CORE_2535_TIME (fc::time_point_sec( 1893456000 ))
+#define HARDFORK_CORE_2535_TIME (fc::time_point_sec( 1700143200 )) // Thursday, November 16, 2023 14:00:00 UTC
 #define HARDFORK_CORE_2535_PASSED(head_block_time) (head_block_time >= HARDFORK_CORE_2535_TIME)
 #endif

--- a/libraries/chain/hardfork.d/CORE_2587.hf
+++ b/libraries/chain/hardfork.d/CORE_2587.hf
@@ -1,6 +1,5 @@
 // bitshares-core issue #2587 settle more than total debt in individual settlement fund when no sufficient price feeds
 #ifndef HARDFORK_CORE_2587_TIME
-// Jan 1 2030, midnight; this is a dummy date until a hardfork date is scheduled
-#define HARDFORK_CORE_2587_TIME (fc::time_point_sec( 1893456000 ))
+#define HARDFORK_CORE_2587_TIME (fc::time_point_sec( 1700143200 )) // Thursday, November 16, 2023 14:00:00 UTC
 #define HARDFORK_CORE_2587_PASSED(head_block_time) (head_block_time >= HARDFORK_CORE_2587_TIME)
 #endif

--- a/libraries/chain/hardfork.d/CORE_2591.hf
+++ b/libraries/chain/hardfork.d/CORE_2591.hf
@@ -1,6 +1,5 @@
 // bitshares-core issue #2591 Tighter peg when collateral price rises and settlement fund or settlement order exists
 #ifndef HARDFORK_CORE_2591_TIME
-// Jan 1 2030, midnight; this is a dummy date until a hardfork date is scheduled
-#define HARDFORK_CORE_2591_TIME (fc::time_point_sec( 1893456000 ))
+#define HARDFORK_CORE_2591_TIME (fc::time_point_sec( 1700143200 )) // Thursday, November 16, 2023 14:00:00 UTC
 #define HARDFORK_CORE_2591_PASSED(head_block_time) (head_block_time >= HARDFORK_CORE_2591_TIME)
 #endif

--- a/libraries/chain/hardfork.d/CORE_2595.hf
+++ b/libraries/chain/hardfork.d/CORE_2595.hf
@@ -1,6 +1,5 @@
 // bitshares-core issue #2595 Credit deal auto-repayment
 #ifndef HARDFORK_CORE_2595_TIME
-// Jan 1 2030, midnight; this is a dummy date until a hardfork date is scheduled
-#define HARDFORK_CORE_2595_TIME (fc::time_point_sec( 1893456000 ))
+#define HARDFORK_CORE_2595_TIME (fc::time_point_sec( 1700143200 )) // Thursday, November 16, 2023 14:00:00 UTC
 #define HARDFORK_CORE_2595_PASSED(head_block_time) (head_block_time >= HARDFORK_CORE_2595_TIME)
 #endif

--- a/libraries/chain/hardfork.d/CORE_2604.hf
+++ b/libraries/chain/hardfork.d/CORE_2604.hf
@@ -1,6 +1,5 @@
 // bitshares-core issue #2604 Allow updating liquidity pool fee rates with certain restrictions
 #ifndef HARDFORK_CORE_2604_TIME
-// Jan 1 2030, midnight; this is a dummy date until a hardfork date is scheduled
-#define HARDFORK_CORE_2604_TIME (fc::time_point_sec( 1893456000 ))
+#define HARDFORK_CORE_2604_TIME (fc::time_point_sec( 1700143200 )) // Thursday, November 16, 2023 14:00:00 UTC
 #define HARDFORK_CORE_2604_PASSED(head_block_time) (head_block_time >= HARDFORK_CORE_2604_TIME)
 #endif


### PR DESCRIPTION
Set BitShares Mainnet `7.0` protocol activation (hard fork) time to `Thursday, November 16, 2023 14:00:00 UTC` (`2023-11-16 14:00:00`).

Update docs and contributors.