### PR TITLE
Update Doxygen links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Use `gethelp <COMMAND>` to see more info about individual commands. E.G.
     >>> gethelp get_order_book
 
 The definition of all commands is available in the
-[wallet.hpp](https://github.com/bitshares/bitshares-core/blob/master/libraries/wallet/include/graphene/wallet/wallet.hpp) souce code file.
+[wallet.hpp](https://github.com/bitshares/bitshares-core/blob/master/libraries/wallet/include/graphene/wallet/wallet.hpp) source code file.
 Corresponding documentation can be found in the [Doxygen documentation](https://bitshares.github.io/doxygen/classgraphene_1_1wallet_1_1wallet__api.html).
 
 You can run the program with `--help` parameter to see more info:
@@ -304,7 +304,7 @@ Note: the `login` API set is always accessible.
 
 Passwords are stored in `base64` as salted `sha256` hashes.  A simple Python script,
 [`saltpass.py`](https://github.com/bitshares/bitshares-core/blob/master/programs/witness_node/saltpass.py)
-is avaliable to obtain hash and salt values from a password.
+is available to obtain hash and salt values from a password.
 A single asterisk `"*"` may be specified as username or password hash to accept any value.
 
 With the above configuration, here is an example of how to call the `add_node` API from the `network_node` API set:

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Use `gethelp <COMMAND>` to see more info about individual commands. E.G.
 
 The definition of all commands is available in the
 [wallet.hpp](https://github.com/bitshares/bitshares-core/blob/master/libraries/wallet/include/graphene/wallet/wallet.hpp) souce code file.
-Corresponding documentation can be found in the [Doxygen documentation](https://doxygen.bitshares.org/classgraphene_1_1wallet_1_1wallet__api.html).
+Corresponding documentation can be found in the [Doxygen documentation](https://bitshares.github.io/doxygen/classgraphene_1_1wallet_1_1wallet__api.html).
 
 You can run the program with `--help` parameter to see more info:
 
@@ -211,7 +211,7 @@ Questions can be posted in [Github Discussions](https://github.com/bitshares/bit
 
 BitShares UI bugs should be reported to the [UI issue tracker](https://github.com/bitshares/bitshares-ui/issues).
 
-Up to date online Doxygen documentation can be found at [Doxygen.BitShares.org](https://doxygen.bitshares.org/hierarchy.html).
+Up to date online Doxygen documentation can be found at [https://bitshares.github.io/doxygen](https://bitshares.github.io/doxygen/hierarchy.html).
 
 
 Using Built-In APIs
@@ -246,8 +246,8 @@ The definition of all node APIs is available in the source code files including
 [database_api.hpp](https://github.com/bitshares/bitshares-core/blob/master/libraries/app/include/graphene/app/database_api.hpp)
 and [api.hpp](https://github.com/bitshares/bitshares-core/blob/master/libraries/app/include/graphene/app/api.hpp).
 Corresponding documentation can be found in Doxygen:
-* [database API](https://doxygen.bitshares.org/classgraphene_1_1app_1_1database__api.html)
-* [other APIs](https://doxygen.bitshares.org/namespacegraphene_1_1app.html)
+* [database API](https://bitshares.github.io/doxygen/classgraphene_1_1app_1_1database__api.html)
+* [other APIs](https://bitshares.github.io/doxygen/namespacegraphene_1_1app.html)
 
 
 ### Wallet API
@@ -320,8 +320,8 @@ The restricted API sets are accessible via HTTP too using *basic access authenti
     $ curl --data '{"jsonrpc": "2.0", "method": "call", "params": ["network_node", "add_node", ["127.0.0.1:9090"]], "id": 1}' http://bytemaster:supersecret@127.0.0.1:8090/
 
 Our `doxygen` documentation contains the most up-to-date information
-about APIs for the [node](https://doxygen.bitshares.org/namespacegraphene_1_1app.html) and the
-[wallet](https://doxygen.bitshares.org/classgraphene_1_1wallet_1_1wallet__api.html).
+about APIs for the [node](https://bitshares.github.io/doxygen/namespacegraphene_1_1app.html) and the
+[wallet](https://bitshares.github.io/doxygen/classgraphene_1_1wallet_1_1wallet__api.html).
 
 
 FAQ

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -1,8 +1,8 @@
 # BitShares Libraries
 
-The libraries are the core of the project and defines everything where applications can build on top.
+The libraries are the core of the project and define everything where applications can build on top.
 
-A **graphene** blockchain software will use the `app` library to define what the application will do, what services it will offer. The blockchain is defined by the `chain` library and include all the objects, types, operations, protocols that builds current consensus blockchain. The lowest level in memory database of Bitshares is developed at the `db` library. The `fc` is a helper module broadly used in the libraries code, `egenesis` will help with the genesis file, `plugins` will be loaded optionally to the application. Wallet software like the cli_wallet will benefit from the `wallet` library.
+A **graphene** blockchain software will use the `app` library to define what the application will do, what services it will offer. The blockchain is defined by the `chain` library and includes all the objects, types, operations, protocols that build current consensus blockchain. The lowest level in memory database of Bitshares is developed at the `db` library. The `fc` is a helper module broadly used in the libraries code, `egenesis` will help with the genesis file, `plugins` will be loaded optionally to the application. Wallet software like the cli_wallet will benefit from the `wallet` library.
 
 Code in libraries is the most important part of **bitshares-core** project and it is maintained by the Bitshares Core Team and contributors.
 # Available Libraries

--- a/programs/README.md
+++ b/programs/README.md
@@ -2,7 +2,7 @@
 
 The bitshares programs are a collection of binaries to run the blockchain, interact with it or utilities.
 
-The main program is the `witness_node`, used to run a bitshares block producer, API or plugin node. The second in importance is the `cli_wallet`, used to interact with the blockchain. This 2 programs are the most used by the community and updated by the developers, rest of the programs are utilities.
+The main program is the `witness_node`, used to run a bitshares block producer, API or plugin node. The second in importance is the `cli_wallet`, used to interact with the blockchain. These 2 programs are the most used by the community and updated by the developers, rest of the programs are utilities.
 
 Programs in here are part of the **bitshares-core** project and are maintained by the bitshares core team and contributors.
 


### PR DESCRIPTION
* Update links: doxygen.bitshares.org -> bitshares.github.io/doxygen
* Fix typos (ported from https://github.com/bitshares/bitshares-core/pull/2784)