### PR TITLE
Improve node networking stability and update dependency versions

### DIFF
--- a/.github/workflows/build-and-test.ubuntu-debug.yml
+++ b/.github/workflows/build-and-test.ubuntu-debug.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     services:
       elasticsearch8:
-        image: elastic/elasticsearch:8.10.2
+        image: elastic/elasticsearch:8.11.1
         options: >-
           --env ES_JAVA_OPTS="-Xms512m -Xmx512m"
           --env discovery.type=single-node
@@ -22,7 +22,7 @@ jobs:
           --env cluster.routing.allocation.disk.threshold_enabled=false
           --publish 9200:9200
       elasticsearch7:
-        image: elastic/elasticsearch:7.17.13
+        image: elastic/elasticsearch:7.17.15
         options: >-
           --env ES_JAVA_OPTS="-Xms512m -Xmx512m"
           --env discovery.type=single-node

--- a/.github/workflows/build-and-test.ubuntu-release.yml
+++ b/.github/workflows/build-and-test.ubuntu-release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     services:
       elasticsearch8:
-        image: elastic/elasticsearch:8.10.2
+        image: elastic/elasticsearch:8.11.1
         options: >-
           --env ES_JAVA_OPTS="-Xms512m -Xmx512m"
           --env discovery.type=single-node
@@ -22,7 +22,7 @@ jobs:
           --env cluster.routing.allocation.disk.threshold_enabled=false
           --publish 9200:9200
       elasticsearch7:
-        image: elastic/elasticsearch:7.17.13
+        image: elastic/elasticsearch:7.17.15
         options: >-
           --env ES_JAVA_OPTS="-Xms512m -Xmx512m"
           --env discovery.type=single-node

--- a/.github/workflows/build-and-test.win.yml
+++ b/.github/workflows/build-and-test.win.yml
@@ -6,7 +6,7 @@ env:
   # The following are for windows cross-build only:
   BOOST_VERSION: 1_69_0
   BOOST_DOTTED_VERSION: 1.69.0
-  CURL_VERSION: 8.3.0
+  CURL_VERSION: 8.4.0
   OPENSSL_VERSION: 1.1.1w
   ZLIB_VERSION: 1.3
 jobs:

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     services:
       elasticsearch8:
-        image: elastic/elasticsearch:8.10.2
+        image: elastic/elasticsearch:8.11.1
         options: >-
           --env ES_JAVA_OPTS="-Xms512m -Xmx512m"
           --env discovery.type=single-node


### PR DESCRIPTION
- Update FC again to include https://github.com/bitshares/bitshares-fc/pull/251 to improve node networking stability.
- Update dependency versions used in Github Actions
  - ElasticSearch 7: 7.17.13 -> 7.17.15
  - ElasticSearch 8: 8.10.2 -> 8.11.1
  - CURL: 8.3.0 -> 8.4.0