### PR TITLE
Update Docker base image to Ubuntu 24.04 (Noble)

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -30,30 +30,30 @@ jobs:
       if: env.DOCKER_PUSH_TAG != ''
       run: echo "${DOCKER_PUSH_TAG}"
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v4
     - name: Build only
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v7
       with:
         context: .
         load: true
     - name: Login to DockerHub
       if: env.DOCKER_PUSH_TAG != ''
-      uses: docker/login-action@v2
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Push to DockerHub (for branches)
       if: env.DOCKER_PUSH_TAG != '' && env.DOCKER_PUSH_TAG_SHORT == ''
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v7
       with:
         context: .
         push: true
         tags: ${{ secrets.DOCKERHUB_REPO_PATH }}:${{ env.DOCKER_PUSH_TAG }}
     - name: Push to DockerHub (for tags)
       if: env.DOCKER_PUSH_TAG != '' && env.DOCKER_PUSH_TAG_SHORT != ''
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v7
       with:
         context: .
         push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # The image for building
-FROM phusion/baseimage:focal-1.2.0 as build
+FROM phusion/baseimage:noble-1.0.2 as build
 ENV LANG=en_US.UTF-8
 
 # Install dependencies
@@ -13,6 +13,9 @@ RUN \
       cmake \
       git \
       libbz2-dev \
+      libzstd-dev \
+      liblzma-dev \
+      libz-dev \
       libcurl4-openssl-dev \
       libssl-dev \
       libncurses-dev \
@@ -64,7 +67,7 @@ RUN \
     rm -rf /bitshares-core
 
 # The final image
-FROM phusion/baseimage:focal-1.2.0
+FROM phusion/baseimage:noble-1.0.2
 LABEL maintainer="The bitshares decentralized organisation"
 ENV LANG=en_US.UTF-8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # The image for building
-FROM phusion/baseimage:noble-1.0.2 as build
+FROM phusion/baseimage:noble-1.0.2 AS build
 ENV LANG=en_US.UTF-8
 
 # Install dependencies
@@ -90,7 +90,7 @@ COPY --from=build /etc/bitshares/version /etc/bitshares/
 WORKDIR /
 RUN groupadd -g 10001 bitshares
 RUN useradd -u 10000 -g bitshares -s /bin/bash -m -d /var/lib/bitshares --no-log-init bitshares
-ENV HOME /var/lib/bitshares
+ENV HOME=/var/lib/bitshares
 RUN chown bitshares:bitshares -R /var/lib/bitshares
 
 # default exec/config files


### PR DESCRIPTION
Update Docker base image to Ubuntu 24.04 (Noble), and upgrade GitHub Actions and Docker actions in the Docker build workflow to latest versions.