### PR TITLE
Update README and add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,66 @@
+---
+name: Bug Report
+about: Create a detailed report about a deficiency in the BitShares Core implementation.
+
+---
+
+**Instructions**
+Please include a detailed Title above. Next, please complete the following sections below:
+* Bug Description
+* Impacts
+* Steps To Reproduce
+* Expected Behavior
+* Screenshots (optional)
+* Host Environment (optional)
+* Additional Context (optional)
+
+Finally, press the 'Submit new issue' button. The Core Team will evaluate and prioritize your Bug Report for future development. 
+
+**Bug Description**
+A clear and concise description of what the bug is.
+
+**Impacts**
+Describe which portion(s) of BitShares Core may be impacted by this bug. Please tick at least one box.
+- [ ] API (the application programming interface)
+- [ ] Build (the build process or something prior to compiled code)
+- [ ] CLI (the command line wallet)
+- [ ] Deployment (the deployment process after building such as Docker, Travis, etc.)
+- [ ] DEX (the Decentralized EXchange, market engine, etc.)
+- [ ] P2P (the peer-to-peer network for transaction/block propagation)
+- [ ] Performance (system or user efficiency, etc.)
+- [ ] Protocol (the blockchain logic, consensus, validation, etc.)
+- [ ] Security (the security of system or user data, etc.)
+- [ ] UX (the User Experience)
+- [ ] Other (please add below)
+
+**Steps To Reproduce**
+Steps to reproduce the behavior (example outlined below):
+1. Execute API call '...'
+2. Using JSON payload '...'
+3. Received response '...'
+4. See error in screenshot
+
+**Expected Behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots (optional)**
+If applicable, add screenshots to help explain process flow and behavior.
+
+**Host Environment**
+Please provide details about the host environment. Much of this information can be found running: `witness_node --version`. 
+ - Host OS:             [e.g. Ubuntu 18.04 LTS]
+ - Host Physical RAM    [e.g. 4GB]
+ - BitShares Version:   [e.g. 2.0.180425]
+ - OpenSSL Version:     [e.g. 1.1.0g]
+ - Boost Version:       [e.g. 1.65.1]
+ 
+**Additional Context (optional)**
+Add any other context about the problem here.
+
+## CORE TEAM TASK LIST
+- [ ] Evaluate / Prioritize Bug Report
+- [ ] Refine User Stories / Requirements
+- [ ] Define Test Cases
+- [ ] Design / Develop Solution
+- [ ] Perform QA/Testing
+- [ ] Update Documentation

--- a/.github/ISSUE_TEMPLATE/build_error.md
+++ b/.github/ISSUE_TEMPLATE/build_error.md
@@ -1,0 +1,41 @@
+---
+name: Build Error
+about: Create a detailed report about an error encountered during the BitShares Core build process.
+
+---
+
+**Instructions**
+Please include a detailed Title above. Next, please complete the following sections below:
+* Build Error
+* Build Environment
+* Steps To Reproduce
+* Console Logs (optional)
+
+Finally, press the 'Submit new issue' button. The Core Team will evaluate and prioritize your Bug Report for future development. 
+
+**Build Error Description**
+A clear and concise description of what the build error is.
+
+**Build Environment**
+Details about the build environment, including the relevant required libraries. Much of this information can be found in the `CMakeFiles/CMakeOutput.log`. 
+ - Host OS:             [e.g. Ubuntu 18.04 LTS]
+ - Host Physical RAM    [e.g. 4GB]
+ - Source Branch/Tag:   [e.g. master or 2.0.180425]
+ - OpenSSL Version:     [e.g. 1.1.0g]
+ - Boost Version:       [e.g. 1.65.1]
+ - C++ Compiler:        [e.g. gcc version 4.8.5]
+
+**Steps To Reproduce**
+Steps to reproduce the behavior (example outlined below):
+1. Using installation guide from this URL...
+2. This is my complete build script...
+3. It fails at this step with the following output...
+4. See the error in the console log below...
+
+**Console Logs (optional)**
+Please provide the full console log, including all commands entered and their output. This will allow detailed troubleshooting.
+
+## CORE TEAM TASK LIST
+- [ ] Evaluate `Build Error`
+- [ ] Provide build guidance
+- [ ] <OR> Create `Bug Report`

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,44 @@
+---
+name: Feature Request
+about: Suggest an idea for the BitShares Core Team to evaluate and prioritize for development.
+
+---
+
+**Instructions**
+Please include a detailed Title above. Next, please complete the following sections below:
+* User Story
+* Impacts
+* Additional Context (optional)
+
+Finally, press the 'Submit new issue' button. The Core Team will evaluate and prioritize your Feature Request for future development. 
+
+**User Story**
+Please tell us about your feature request using the User Story format:
+As a `<persona>` I want `<some functionality>` so that `<some benefit is realized>`.
+
+At minimum, please define the `<who>`, `<what>` and `<why>` for your feature request. The `<who>` may be the system software, a component thereof, the end user, etc.; please be specific describing the context. The `<what>` details the solution your feature will provide; please describe the process flow for the functionality. The `<why>` details the benefits the feature will deliver; consider referencing alternative implementations for context.
+
+**Impacts**
+Describe which portion(s) of BitShares Core may be impacted by your request. Please tick at least one box.
+- [ ] API (the application programming interface)
+- [ ] Build (the build process or something prior to compiled code)
+- [ ] CLI (the command line wallet)
+- [ ] Deployment (the deployment process after building such as Docker, Travis, etc.)
+- [ ] DEX (the Decentralized EXchange, market engine, etc.)
+- [ ] P2P (the peer-to-peer network for transaction/block propagation)
+- [ ] Performance (system or user efficiency, etc.)
+- [ ] Protocol (the blockchain logic, consensus, validation, etc.)
+- [ ] Security (the security of system or user data, etc.)
+- [ ] UX (the User Experience)
+- [ ] Other (please add below)
+
+**Additional Context (optional)**
+Add any other context about your request here.
+
+## CORE TEAM TASK LIST
+- [ ] Evaluate / Prioritize Feature Request
+- [ ] Refine User Stories / Requirements
+- [ ] Define Test Cases
+- [ ] Design / Develop Solution
+- [ ] Perform QA/Testing
+- [ ] Update Documentation

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ manually build your preferred version and use it with BitShares by specifying it
 
   Example: `cmake -DBOOST_ROOT=/path/to/boost ..`
 
-Note: for older releases (Mainnet releases up to `7.0.2`, Testnet releases up to `test-7.0.4`), the supported boost version is `1.58` to `1.74`.
+  Note: for older releases (Mainnet releases up to `7.0.2`, Testnet releases up to `test-7.0.4`), the supported boost version is `1.58` to `1.74`.
 
 * BitShares requires [OpenSSL](https://www.openssl.org/) libraries to build, supports version `1.0.2` to `1.1.1` and version `3.0.x`.
 If your system came pre-installed with a version of OpenSSL libraries that you do not wish to use, you may
@@ -93,7 +93,7 @@ manually build your preferred version and use it with BitShares by specifying it
 
   Example: `cmake -DOPENSSL_ROOT_DIR=/path/to/openssl ..`
 
-Note: a) some earlier version of OpenSSL 3 are incompatible due to the lack of the `RIPEMD160` provider, and b) for older releases (Mainnet releases up to `7.0.2`, Testnet releases up to `test-7.0.4`), OpenSSL 3 is not supported.
+  Note: a) some earlier version of OpenSSL 3 are incompatible due to the lack of the `RIPEMD160` provider, and b) for older releases (Mainnet releases up to `7.0.2`, Testnet releases up to `test-7.0.4`), OpenSSL 3 is not supported.
 
 ### Running and Stopping Node Software
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ Prebuilt binaries can be found in the [releases page](https://github.com/bitshar
 
 ### Installing Node and Command-Line Wallet Software
 
-We recommend building on Ubuntu 20.04 LTS (64-bit)
+We recommend building on Ubuntu 24.04 LTS (64-bit).
+Note: for older releases (Mainnet releases up to `7.0.2`, Testnet releases up to `test-7.0.4`), we recommened Ubuntu 20.04 LTS.
 
 **Install Operating System Dependencies:**
 
     sudo apt-get update
-    sudo apt-get install autoconf cmake make automake libtool git libboost-all-dev libssl-dev g++ libcurl4-openssl-dev doxygen
+    sudo apt-get install autoconf cmake make automake libtool git libboost-all-dev libssl-dev g++ libz-dev libbz2-dev liblzma-dev libzstd-dev libcurl4-openssl-dev doxygen
 
 **Build Node And Command-Line Wallet:**
 
@@ -77,19 +78,22 @@ We recommend building on Ubuntu 20.04 LTS (64-bit)
   * Windows (various versions, Visual Studio and MinGW)
   * OpenBSD (various versions)
 
-* BitShares requires [Boost](https://www.boost.org/) libraries to build, supports version `1.58` to `1.74`.
+* BitShares requires [Boost](https://www.boost.org/) libraries to build, supports version `1.58` to `1.83`.
 Newer versions may work, but have not been tested.
 If your system came pre-installed with a version of Boost libraries that you do not wish to use, you may
 manually build your preferred version and use it with BitShares by specifying it on the CMake command line.
 
   Example: `cmake -DBOOST_ROOT=/path/to/boost ..`
 
-* BitShares requires [OpenSSL](https://www.openssl.org/) libraries to build, supports version `1.0.2` to `1.1.1`.
+Note: for older releases (Mainnet releases up to `7.0.2`, Testnet releases up to `test-7.0.4`), the supported boost version is `1.58` to `1.74`.
+
+* BitShares requires [OpenSSL](https://www.openssl.org/) libraries to build, supports version `1.0.2` to `1.1.1` and version `3.0.x`.
 If your system came pre-installed with a version of OpenSSL libraries that you do not wish to use, you may
 manually build your preferred version and use it with BitShares by specifying it on the CMake command line.
 
   Example: `cmake -DOPENSSL_ROOT_DIR=/path/to/openssl ..`
 
+Note: a) some earlier version of OpenSSL 3 are incompatible due to the lack of the `RIPEMD160` provider, and b) for older releases (Mainnet releases up to `7.0.2`, Testnet releases up to `test-7.0.4`), OpenSSL 3 is not supported.
 
 ### Running and Stopping Node Software
 


### PR DESCRIPTION
* Update Ubuntu / Boost / OpenSSL versions in README because we added Ubuntu 24.04 support.
* Since we updated the default branch of this repository on Github to the `develop` branch, issue templates are needed in the `develop` branch. This PR adds them.