### PR TITLE
Add a workflow to keep Github Actions caches

### DIFF
--- a/.github/workflows/keep-cache.yml
+++ b/.github/workflows/keep-cache.yml
@@ -39,3 +39,10 @@ jobs:
         restore-keys: |
           ccache-docker-${{ steps.get_base_image.outputs.base-image }}-${{ github.ref }}-
           ccache-docker-${{ steps.get_base_image.outputs.base-image }}-
+
+  keepalive:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@7a9194bad497f0b993708eeaf10fc0a2d726eb71

--- a/.github/workflows/keep-cache.yml
+++ b/.github/workflows/keep-cache.yml
@@ -1,0 +1,41 @@
+name: Keep Cache
+
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: "26 4 * * 2,5"
+
+jobs:
+  keep-ubuntu-caches:
+    name: Keep Ubuntu Build Caches
+    strategy:
+      matrix:
+        os: [ ubuntu-24.04 ]
+        build-type: [ "release", "debug" ]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Load Ubuntu Build Caches
+      uses: actions/cache/restore@v6
+      with:
+        path: ccache-${{ matrix.build-type }}
+        key: ccache-${{ matrix.build-type }}-${{ matrix.os }}-${{ github.ref }}-${{ github.sha }}
+        restore-keys: |
+          ccache-release-${{ matrix.os }}-${{ github.ref }}-
+          ccache-release-${{ matrix.os }}-
+
+  keep-docker-cache:
+    name: Keep Docker Build Cache
+    runs-on: ubuntu-latest
+    steps:
+    - name: Extract base image from Dockerfile
+      id: get_base_image
+      shell: bash
+      run: echo "base-image=`grep -i 'FROM' Dockerfile | grep -i 'AS build' | awk '{print $2}' | sed s/:/-/g`" >> "$GITHUB_OUTPUT"
+    - name: Load Docker Build Cache
+      uses: actions/cache/restore@v6
+      with:
+        path: ccache-docker
+        key: ccache-docker-${{ steps.get_base_image.outputs.base-image }}-${{ github.ref }}-${{ github.sha }}
+        restore-keys: |
+          ccache-docker-${{ steps.get_base_image.outputs.base-image }}-${{ github.ref }}-
+          ccache-docker-${{ steps.get_base_image.outputs.base-image }}-


### PR DESCRIPTION
Note: the cache restore path need to be the same as the cache save path, otherwise the cache/restore action can not find the saved cache. See https://github.com/actions/cache/issues/1444.