### PR TITLE
Fix sonar project version

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=bitshares-on-github
 sonar.projectKey=bitshares_bitshares-core
 sonar.projectName=BitShares-Core
 sonar.projectDescription=BitShares Blockchain node and command-line wallet
-sonar.projectVersion=7.1.x
+sonar.projectVersion=7.0.x
 
 sonar.host.url=https://sonarcloud.io
 


### PR DESCRIPTION
The last commit https://github.com/bitshares/bitshares-core/commit/77ef234e91d498ff4f4c58335194b0ea4f497e87 in PR https://github.com/bitshares/bitshares-core/pull/2789 was OK, but now I think it was too early to merge it into the `release` branch in PR https://github.com/bitshares/bitshares-core/pull/2808, maybe at that time I planned to make a `7.1.0` release soon, but in the end I didn't do that.

This PR reverts the sonar project version change, but keeps other changes I merged from `develop` into `release` in PR https://github.com/bitshares/bitshares-core/pull/2808.
