### PR TITLE
Fix race condition in P2P listen_to_p2p_network()

### DIFF
--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -1401,6 +1401,11 @@ net::node_ptr application::p2p_node()
    return my->_p2p_network;
 }
 
+std::shared_ptr<fc::http::websocket_server> application::websocket_server()
+{
+   return my->_websocket_server;
+}
+
 std::shared_ptr<chain::database> application::chain_database() const
 {
    return my->_chain_db;

--- a/libraries/app/include/graphene/app/application.hpp
+++ b/libraries/app/include/graphene/app/application.hpp
@@ -27,6 +27,8 @@
 #include <graphene/net/node.hpp>
 #include <graphene/chain/database.hpp>
 
+#include <fc/network/http/websocket.hpp>
+
 #include <boost/program_options.hpp>
 
 namespace graphene { namespace app {
@@ -140,6 +142,7 @@ namespace graphene { namespace app {
 
          net::node_ptr                    p2p_node();
          std::shared_ptr<chain::database> chain_database()const;
+         std::shared_ptr<fc::http::websocket_server> websocket_server();
          void set_api_limit();
          void set_block_production(bool producing_blocks);
          fc::optional< api_access_info > get_api_access_info( const string& username )const;

--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -4289,8 +4289,11 @@ namespace graphene { namespace net { namespace detail {
       assert(_node_public_key != fc::ecc::public_key_data());
 
       fc::ip::endpoint listen_endpoint = _node_configuration.listen_endpoint;
-      if( listen_endpoint.port() != 0 )
-      {
+
+      // We try to listen on the user-specified address and port first, if that fails,
+      // depending on the situation, we wait and retry, or try port 0, or stop.
+
+      // There was a comment here:
         // if the user specified a port, we only want to bind to it if it's not already
         // being used by another application.  During normal operation, we set the
         // SO_REUSEADDR/SO_REUSEPORT flags so that we can bind outbound sockets to the
@@ -4303,78 +4306,76 @@ namespace graphene { namespace net { namespace detail {
         //       before we try to listen with the real tcp server.
         //       This happens frequently when running multiple test cases at the same
         //       time, but less likely in production.
-        bool first = true;
-        for( ;; )
-        {
-          bool listen_failed = false;
-
-          try
-          {
-            fc::tcp_server temporary_server;
-            if( listen_endpoint.get_address() != fc::ip::address() )
-              temporary_server.listen( listen_endpoint );
-            else
-              temporary_server.listen( listen_endpoint.port() );
-            break;
-          }
-          catch ( const fc::exception&)
-          {
-            listen_failed = true;
-          }
-
-          if (listen_failed)
-          {
-            if( _node_configuration.wait_if_endpoint_is_busy )
-            {
-              std::ostringstream error_message_stream;
-              if( first )
-              {
-                error_message_stream << "Unable to listen for connections on port " << listen_endpoint.port()
-                                     << ", retrying in a few seconds\n";
-                error_message_stream << "You can wait for it to become available, or restart this program using\n";
-                error_message_stream << "the --p2p-endpoint option to specify another port\n";
-                first = false;
-              }
-              else
-              {
-                error_message_stream << "\nStill waiting for port " << listen_endpoint.port() << " to become available\n";
-              }
-              std::string error_message = error_message_stream.str();
-              wlog(error_message);
-              std::cout << "\033[31m" << error_message;  
-              _delegate->error_encountered( error_message, fc::oexception() );
-              fc::usleep( fc::seconds(5 ) );
-            }
-            else // don't wait, just find a random port
-            {
-              wlog( "unable to bind on the requested endpoint ${endpoint}, which probably means that endpoint is already in use",
-                   ( "endpoint", listen_endpoint ) );
-              listen_endpoint.set_port( 0 );
-            }
-          } // if (listen_failed)
-        } // for(;;)
-      } // if (listen_endpoint.port() != 0)
-      else // port is 0
-      {
-        // if they requested a random port, we'll just assume it's available
-        // (it may not be due to ip address, but we'll detect that in the next step)
-      }
+      // Now the new code set SO_REUSEADDR/SO_REUSEPORT flags directly, but not use a
+      // temporary tcp server to detect the availability of the user-specified port.
+      // This is to address the race condition mentioned above. This may cause problems
+      // on the "some platforms" mentioned above.
 
       _tcp_server.set_reuse_address();
-      try
+      bool first = true;
+      while( true )
       {
-        if( listen_endpoint.get_address() != fc::ip::address() )
-          _tcp_server.listen( listen_endpoint );
-        else
-          _tcp_server.listen( listen_endpoint.port() );
-        _actual_listening_endpoint = _tcp_server.get_local_endpoint();
-        ilog( "listening for connections on endpoint ${endpoint} (our first choice)",
-              ( "endpoint", _actual_listening_endpoint ) );
-      }
-      catch ( fc::exception& e )
-      {
-        FC_RETHROW_EXCEPTION( e, error, "unable to listen on ${endpoint}", ("endpoint",listen_endpoint ) );
-      }
+        try
+        {
+          ilog( "Trying to listen for connections on endpoint ${endpoint}",
+                ( "endpoint", listen_endpoint ) );
+          if( listen_endpoint.get_address() != fc::ip::address() )
+            _tcp_server.listen( listen_endpoint );
+          else
+            _tcp_server.listen( listen_endpoint.port() );
+          _actual_listening_endpoint = _tcp_server.get_local_endpoint();
+          ilog( "Listening for connections on endpoint ${endpoint}",
+                ( "endpoint", _actual_listening_endpoint ) );
+          return;
+        }
+        catch ( fc::exception& e )
+        {
+          wlog( "Failed to listen on endpoint ${endpoint}, error ${error}",
+                ( "endpoint", listen_endpoint ) ( "error", e ) );
+
+          if( !_node_configuration.wait_if_endpoint_is_busy ) // If configured to NOT wait when fails to listen,
+                                                              // regardless of the reason (not only "endpoint_is_busy")
+          {
+            // If port is 0, throw
+            if( 0 == listen_endpoint.port() )
+            {
+              FC_RETHROW_EXCEPTION( e, error, "Unable to listen on ${endpoint}", ("endpoint",listen_endpoint ) );
+            }
+
+            // If port is not 0, change port to 0 and retry
+            std::ostringstream error_message_stream;
+            error_message_stream << "Unable to listen for connections on endpoint " << std::string(listen_endpoint)
+                                 << ", which probably means the port is already in use, "
+                                 << " will try to listen on port 0 to let OS select a port";
+            std::string error_message = error_message_stream.str();
+            wlog(error_message); // logging to p2p.log
+            std::cerr << "\033[33m" << error_message; // message in yellow color
+            listen_endpoint.set_port( 0 );
+          }
+          else // Configured to wait when fails to listen, regardless of the reason (not only "endpoint_is_busy")
+          {
+            std::ostringstream error_message_stream;
+            if( first )
+            {
+              error_message_stream << "Unable to listen for connections on endpoint " << std::string(listen_endpoint)
+                                   << ", retrying in a few seconds\n";
+              error_message_stream << "You can wait for it to become available, or restart this program using\n";
+              error_message_stream << "the --p2p-endpoint option to specify another IP:port\n";
+              first = false;
+            }
+            else
+            {
+              error_message_stream << "\nStill waiting for endpoint " << std::string(listen_endpoint)
+                                   << " to become available\n";
+            }
+            std::string error_message = error_message_stream.str();
+            wlog(error_message); // logging to p2p.log
+            std::cerr << "\033[31m" << error_message; // message in red color
+            _delegate->error_encountered( error_message, fc::oexception() );
+            fc::usleep( fc::seconds(5) );
+          }
+        } // catch
+      } // while true
     }
 
     void node_impl::connect_to_p2p_network(node_impl_ptr self)

--- a/tests/app/main.cpp
+++ b/tests/app/main.cpp
@@ -225,18 +225,13 @@ BOOST_AUTO_TEST_CASE( three_node_network )
       // Start app1
       BOOST_TEST_MESSAGE( "Creating and initializing app1" );
 
-      auto port = fc::network::get_available_port();
-      auto app1_p2p_endpoint_str = string("127.0.0.1:") + std::to_string(port);
-      auto app2_seed_nodes_str = string("[\"") + app1_p2p_endpoint_str + "\"]";
-      auto app3_seed_nodes_str = string("[\"") + app1_p2p_endpoint_str + "\"]";
-
       fc::temp_directory app_dir( graphene::utilities::temp_directory_path() );
       auto genesis_file = create_genesis_file(app_dir);
 
       graphene::app::application app1;
       auto sharable_cfg = std::make_shared<boost::program_options::variables_map>();
       auto& cfg = *sharable_cfg;
-      fc::set_option( cfg, "p2p-endpoint", app1_p2p_endpoint_str );
+      fc::set_option( cfg, "p2p-endpoint", string("127.0.0.1:0") );
       fc::set_option( cfg, "genesis-json", genesis_file );
       fc::set_option( cfg, "seed-nodes", string("[]") );
       app1.initialize(app_dir.path(), sharable_cfg);
@@ -245,10 +240,16 @@ BOOST_AUTO_TEST_CASE( three_node_network )
 
       auto node_startup_wait_time = fc::seconds(15);
 
-      fc::wait_for( node_startup_wait_time, [&app1,port] () {
+      uint16_t port = 0;
+      fc::wait_for( node_startup_wait_time, [&app1,&port] () {
          const auto status = app1.p2p_node()->network_get_info();
-         return status["listening_on"].as<fc::ip::endpoint>( 5 ).port() == port;
+         port = status["listening_on"].as<fc::ip::endpoint>( 5 ).port();
+         return 0 != port;
       });
+
+      auto app1_p2p_endpoint_str = string("127.0.0.1:") + std::to_string(port);
+      auto app2_seed_nodes_str = string("[\"") + app1_p2p_endpoint_str + "\"]";
+      auto app3_seed_nodes_str = string("[\"") + app1_p2p_endpoint_str + "\"]";
 
       // Start app2
       BOOST_TEST_MESSAGE( "Creating and initializing app2" );

--- a/tests/cli/main.cpp
+++ b/tests/cli/main.cpp
@@ -95,8 +95,7 @@ std::shared_ptr<graphene::app::application> start_application(fc::temp_directory
 
    auto sharable_cfg = std::make_shared<boost::program_options::variables_map>();
    auto& cfg = *sharable_cfg;
-   server_port_number = fc::network::get_available_port();
-   fc::set_option( cfg, "rpc-endpoint", string("127.0.0.1:") + std::to_string(server_port_number) );
+   fc::set_option( cfg, "rpc-endpoint", string("127.0.0.1:0") );
    fc::set_option( cfg, "p2p-accept-incoming-connections", false );
    fc::set_option( cfg, "genesis-json", create_genesis_file(app_dir) );
    fc::set_option( cfg, "seed-nodes", string("[]") );
@@ -104,6 +103,8 @@ std::shared_ptr<graphene::app::application> start_application(fc::temp_directory
    app1->initialize(app_dir.path(), sharable_cfg);
 
    app1->startup();
+
+   server_port_number = app1->websocket_server()->get_listening_port();
 
    return app1;
 }

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -195,17 +195,8 @@ std::shared_ptr<boost::program_options::variables_map> database_fixture_base::in
       fc::set_option( options, "enable-p2p-network", false );
    else if( rand() % 100 >= 50 ) // Disable P2P network randomly for test cases
       fc::set_option( options, "enable-p2p-network", false );
-   else
-   {
-      if( rand() % 100 >= 50 ) // this should lead to no change
-      {
-         fc::set_option( options, "enable-p2p-network", true );
-      }
-      fc::ip::endpoint ep;
-      ep.set_port( rand() % 20000 + 5000 );
-      idump( (ep)(std::string(ep)) );
-      fc::set_option( options, "p2p-endpoint", std::string( ep ) );
-   }
+   else if( rand() % 100 >= 50 ) // this should lead to no change
+      fc::set_option( options, "enable-p2p-network", true );
 
    if (fixture.current_test_name == "min_blocks_to_keep_test")
    {

--- a/tests/common/init_unit_test_suite.hpp
+++ b/tests/common/init_unit_test_suite.hpp
@@ -26,8 +26,32 @@
 #include <cstdlib>
 #include <iostream>
 #include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test_monitor.hpp>
 #include <chrono>
 #include <string>
+
+#include <fc/exception/exception.hpp>
+
+/**
+ * Report escaped fc exceptions instead of swallowing them.
+ *
+ * Boost.Test recognises exceptions derived from std::exception and reports their what().
+ * fc::exception derives from nothing, so anything escaping a test case falls into Boost's
+ * catch-all, which reports the bare placeholder:
+ *
+ *     unknown location(0): fatal error: in "<some test>": unknown type
+ *
+ * No code, no message, no location -- and the exception's own text is never written
+ * anywhere, so it cannot be recovered from the log afterwards either. Two entirely
+ * different causes produce that identical line, which makes the report misleading rather
+ * than merely thin.
+ *
+ * The translator turns it into the detail string: code, message and throw site.
+ */
+inline void translate_fc_exception( const fc::exception& e )
+{
+   BOOST_FAIL( "fc::exception: " + e.to_detail_string() );
+}
 
 uint32_t    GRAPHENE_TESTING_GENESIS_TIMESTAMP = 1431700000;
 std::string GRAPHENE_TESTING_ES_URL            = "http://127.0.0.1:9200/";
@@ -50,5 +74,7 @@ boost::unit_test::test_suite* init_unit_test_suite(int argc, char* argv[]) {
          GRAPHENE_TESTING_ES_URL = tmp_es_url;
    }
    std::cout << "GRAPHENE_TESTING_ES_URL is " << GRAPHENE_TESTING_ES_URL << std::endl;
+   boost::unit_test::unit_test_monitor.register_exception_translator<fc::exception>(
+      &translate_fc_exception );
    return nullptr;
 }

--- a/tests/common/utils.hpp
+++ b/tests/common/utils.hpp
@@ -23,19 +23,6 @@
  */
 #pragma once
 
-#ifdef _WIN32
-   #ifndef _WIN32_WINNT
-      #define _WIN32_WINNT 0x0501
-   #endif
-   #include <winsock2.h>
-   #include <ws2tcpip.h>
-#else
-   #include <sys/types.h>
-   #include <sys/socket.h>
-   #include <netinet/in.h>
-   #include <netinet/ip.h>
-#endif
-
 namespace fc {
 
    /** Waits for F() to return true before max_duration has passed.
@@ -48,34 +35,5 @@ namespace fc {
          fc::usleep(fc::milliseconds(100));
       BOOST_REQUIRE( f() );
    }
-
-namespace network {
-   //////
-   /// @brief attempt to find an available port on localhost
-   /// @returns an available port number, or -1 on error
-   /////
-   int get_available_port()
-   {
-      struct sockaddr_in sin;
-      int socket_fd = socket(AF_INET, SOCK_STREAM, 0);
-      if (socket_fd == -1)
-         return -1;
-      sin.sin_family = AF_INET;
-      sin.sin_port = 0;
-      sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-      if (::bind(socket_fd, (struct sockaddr*)&sin, sizeof(struct sockaddr_in)) == -1)
-         return -1;
-      socklen_t len = sizeof(sin);
-      if (getsockname(socket_fd, (struct sockaddr *)&sin, &len) == -1)
-         return -1;
-   #ifdef _WIN32
-      closesocket(socket_fd);
-   #else
-      close(socket_fd);
-   #endif
-      return ntohs(sin.sin_port);
-   }
-
-} // namespace fc::network
 
 } // namespace fc

--- a/tests/tests/p2p_node_tests.cpp
+++ b/tests/tests/p2p_node_tests.cpp
@@ -251,7 +251,7 @@ class test_node : public graphene::net::node
 public:
    std::vector<std::shared_ptr<test_peer>> test_peers;
 
-   test_node( const std::string& name, const fc::path& config_dir, int port, int seed_port = -1 )
+   test_node( const std::string& name, const fc::path& config_dir )
          : node( name )
    {
       std::cout << "test_node::test_node(): current thread=" << uint64_t(&fc::thread::current()) << std::endl;
@@ -376,9 +376,8 @@ BOOST_FIXTURE_TEST_SUITE( p2p_node_tests, p2p_fixture )
 BOOST_AUTO_TEST_CASE( hello_test )
 { try {
    // create a node (node1)
-   int node1_port = fc::network::get_available_port();
    fc::temp_directory node1_dir( graphene::utilities::temp_directory_path() );
-   test_node node1( "Node1", node1_dir.path(), node1_port );
+   test_node node1( "Node1", node1_dir.path() );
    // simulate that node1 started to connect to the network and accepting connections
    fake_network_connect_guard guard( node1 );
 
@@ -434,9 +433,8 @@ BOOST_AUTO_TEST_CASE( hello_test )
 BOOST_AUTO_TEST_CASE( hello_firewalled_peer_test )
 { try {
    // create a node (node1)
-   int node1_port = fc::network::get_available_port();
    fc::temp_directory node1_dir( graphene::utilities::temp_directory_path() );
-   test_node node1( "Node1", node1_dir.path(), node1_port );
+   test_node node1( "Node1", node1_dir.path() );
    // simulate that node1 started to connect to the network and accepting connections
    fake_network_connect_guard guard( node1 );
 
@@ -504,9 +502,8 @@ BOOST_AUTO_TEST_CASE( hello_firewalled_peer_test )
 BOOST_AUTO_TEST_CASE( hello_not_accepting_connections )
 { try {
    // create a node (node1)
-   int node1_port = fc::network::get_available_port();
    fc::temp_directory node1_dir( graphene::utilities::temp_directory_path() );
-   test_node node1( "Node1", node1_dir.path(), node1_port );
+   test_node node1( "Node1", node1_dir.path() );
    // Note: no fake_network_connect_guard here, by default the node is not accepting connections
 
    // a new peer (peer3)
@@ -542,9 +539,8 @@ BOOST_AUTO_TEST_CASE( hello_not_accepting_connections )
 BOOST_AUTO_TEST_CASE( hello_unexpected )
 {
    // create a node (node1)
-   int node1_port = fc::network::get_available_port();
    fc::temp_directory node1_dir( graphene::utilities::temp_directory_path() );
-   test_node node1( "Node1", node1_dir.path(), node1_port );
+   test_node node1( "Node1", node1_dir.path() );
    // simulate that node1 started to connect to the network and accepting connections
    fake_network_connect_guard guard( node1 );
 
@@ -580,9 +576,8 @@ BOOST_AUTO_TEST_CASE( hello_unexpected )
 BOOST_AUTO_TEST_CASE( hello_from_different_chain )
 {
    // create a node (node1)
-   int node1_port = fc::network::get_available_port();
    fc::temp_directory node1_dir( graphene::utilities::temp_directory_path() );
-   test_node node1( "Node1", node1_dir.path(), node1_port );
+   test_node node1( "Node1", node1_dir.path() );
    // simulate that node1 started to connect to the network and accepting connections
    fake_network_connect_guard guard( node1 );
 
@@ -633,9 +628,8 @@ BOOST_AUTO_TEST_CASE( hello_from_different_chain )
 BOOST_AUTO_TEST_CASE( hello_invalid_signature )
 { try {
    // create a node (node1)
-   int node1_port = fc::network::get_available_port();
    fc::temp_directory node1_dir( graphene::utilities::temp_directory_path() );
-   test_node node1( "Node1", node1_dir.path(), node1_port );
+   test_node node1( "Node1", node1_dir.path() );
    // simulate that node1 started to connect to the network and accepting connections
    fake_network_connect_guard guard( node1 );
 
@@ -669,9 +663,8 @@ BOOST_AUTO_TEST_CASE( hello_invalid_signature )
 BOOST_AUTO_TEST_CASE( hello_null_node_id )
 { try {
    // create a node (node1)
-   int node1_port = fc::network::get_available_port();
    fc::temp_directory node1_dir( graphene::utilities::temp_directory_path() );
-   test_node node1( "Node1", node1_dir.path(), node1_port );
+   test_node node1( "Node1", node1_dir.path() );
    // simulate that node1 started to connect to the network and accepting connections
    fake_network_connect_guard guard( node1 );
 
@@ -705,9 +698,8 @@ BOOST_AUTO_TEST_CASE( hello_null_node_id )
 BOOST_AUTO_TEST_CASE( hello_from_self )
 { try {
    // create a node (node1)
-   int node1_port = fc::network::get_available_port();
    fc::temp_directory node1_dir( graphene::utilities::temp_directory_path() );
-   test_node node1( "Node1", node1_dir.path(), node1_port );
+   test_node node1( "Node1", node1_dir.path() );
    // simulate that node1 started to connect to the network and accepting connections
    fake_network_connect_guard guard( node1 );
 
@@ -761,9 +753,8 @@ BOOST_AUTO_TEST_CASE( hello_from_self )
 BOOST_AUTO_TEST_CASE( hello_already_connected )
 { try {
    // create a node (node1)
-   int node1_port = fc::network::get_available_port();
    fc::temp_directory node1_dir( graphene::utilities::temp_directory_path() );
-   test_node node1( "Node1", node1_dir.path(), node1_port );
+   test_node node1( "Node1", node1_dir.path() );
    // simulate that node1 started to connect to the network and accepting connections
    fake_network_connect_guard guard( node1 );
 
@@ -813,9 +804,8 @@ BOOST_AUTO_TEST_CASE( hello_already_connected )
 BOOST_AUTO_TEST_CASE( address_request_without_hello )
 {
    // create a node (node1)
-   int node1_port = fc::network::get_available_port();
    fc::temp_directory node1_dir( graphene::utilities::temp_directory_path() );
-   test_node node1( "Node1", node1_dir.path(), node1_port );
+   test_node node1( "Node1", node1_dir.path() );
    // simulate that node1 started to connect to the network and accepting connections
    fake_network_connect_guard guard( node1 );
 
@@ -849,9 +839,8 @@ BOOST_AUTO_TEST_CASE( address_request_without_hello )
 BOOST_AUTO_TEST_CASE( set_nothing_advertise_algorithm )
 {
    // create a node (node1)
-   int node1_port = fc::network::get_available_port();
    fc::temp_directory node1_dir( graphene::utilities::temp_directory_path() );
-   test_node node1( "Node1", node1_dir.path(), node1_port );
+   test_node node1( "Node1", node1_dir.path() );
    // simulate that node1 started to connect to the network and accepting connections
    fake_network_connect_guard guard( node1 );
 
@@ -883,9 +872,8 @@ BOOST_AUTO_TEST_CASE( set_nothing_advertise_algorithm )
 BOOST_AUTO_TEST_CASE( advertise_list_test )
 {
    // create a node (node1)
-   int node1_port = fc::network::get_available_port();
    fc::temp_directory node1_dir( graphene::utilities::temp_directory_path() );
-   test_node node1( "Node1", node1_dir.path(), node1_port );
+   test_node node1( "Node1", node1_dir.path() );
    // simulate that node1 started to connect to the network and accepting connections
    fake_network_connect_guard guard( node1 );
 
@@ -924,9 +912,8 @@ BOOST_AUTO_TEST_CASE( advertise_list_test )
 BOOST_AUTO_TEST_CASE( exclude_list )
 {
    // create a node (node1)
-   int node1_port = fc::network::get_available_port();
    fc::temp_directory node1_dir( graphene::utilities::temp_directory_path() );
-   test_node node1( "Node1", node1_dir.path(), node1_port );
+   test_node node1( "Node1", node1_dir.path() );
    // simulate that node1 started to connect to the network and accepting connections
    fake_network_connect_guard guard( node1 );
 
@@ -965,9 +952,8 @@ BOOST_AUTO_TEST_CASE( exclude_list )
 BOOST_AUTO_TEST_CASE( advertising_all_test )
 {
    // create a node (node1)
-   int node1_port = fc::network::get_available_port();
    fc::temp_directory node1_dir( graphene::utilities::temp_directory_path() );
-   test_node node1( "Node1", node1_dir.path(), node1_port );
+   test_node node1( "Node1", node1_dir.path() );
    // simulate that node1 started to connect to the network and accepting connections
    fake_network_connect_guard guard( node1 );
 


### PR DESCRIPTION
PR for #2834 (unstably reproduces with test cases in #2862).

Main changes:
* Updated `set_reuse_address()` functions in FC, do not set `SO_REUSEPORT` (see https://github.com/bitshares/bitshares-fc/pull/260).
* Updated `node_impl::listen_to_p2p_network()`, no longer use the "bind without SO_REUSEADDR to check port availability/close/set SO_REUSEADDR/bind for real" mode, instead use the "set SO_REUSEADDR/bind and retain" mode.
* Updated tests to avoid the "bind to port 0/get port/close/rebind to the port" mode, but use the "bind to port 0/get port/retain the socket" mode.
* Added tests.